### PR TITLE
Remove TTF/OTF Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "util:generic-renamer": "node scripts/generic/renamer.js",
     "util:package-json-rebuild": "node scripts/utils/package-json-rebuild.js",
     "deploy": "lerna publish patch --no-git-tag-version --no-push --force-publish",
-    "deploy:ci": "lerna version 3.0.2 --yes --force-publish --no-push && lerna publish from-git --yes && git push --follow-tags --no-verify origin master"
+    "deploy:ci": "lerna version 3.0.3 --yes --force-publish --no-push && lerna publish from-git --yes && git push --follow-tags --no-verify origin master"
   },
   "resolutions": {
     "npm-packlist": "1.1.12"

--- a/scripts/google/google-font-packager-v1.js
+++ b/scripts/google/google-font-packager-v1.js
@@ -66,14 +66,17 @@ if (changed || force == "force") {
   // Filter out local font links and only leave URLs for each pair
   const links = downloadURLPairs
     .filter(pair => isAbsoluteUrl(pair[1].toString()))
+    .filter(file => {
+      const extension = file[0].split(".")[4]
+      if (extension == "truetype" || extension == "opentype") {
+        return false
+      } else {
+        return true
+      }
+    })
     .map(file => {
       const types = file[0].split(".")
-      const dest = makeFontDownloadPath(
-        types[2],
-        types[0],
-        types[1],
-        types[4].replace("truetype", "ttf").replace("opentype", "otf")
-      )
+      const dest = makeFontDownloadPath(types[2], types[0], types[1], types[4])
       const url = file[1]
       return {
         url,
@@ -93,15 +96,6 @@ if (changed || force == "force") {
   })
 
   // Generate CSS
-  const ttforotf = (subset, weight, style) => {
-    if (
-      Object.keys(font.variants[weight][style][subset].url).includes("opentype")
-    ) {
-      return "otf"
-    }
-    return "ttf"
-  }
-
   font.subsets.forEach(subset => {
     cssSubset = []
     font.weights.forEach(weight => {
@@ -118,15 +112,6 @@ if (changed || force == "force") {
             weight,
             woff2Path: makeFontFilePath(subset, weight, style, "woff2"),
             woffPath: makeFontFilePath(subset, weight, style, "woff"),
-            ttforotf: ttforotf(subset, weight, style)
-              .replace("otf", "opentype")
-              .replace("ttf", "truetype"),
-            ttforotfPath: makeFontFilePath(
-              subset,
-              weight,
-              style,
-              ttforotf(subset, weight, style)
-            ),
           })
           cssWeight.push(css)
           cssSubset.push(css)

--- a/scripts/google/google-font-packager-v2.js
+++ b/scripts/google/google-font-packager-v2.js
@@ -72,24 +72,15 @@ if (changed || force == "force") {
   let oldLinks = downloadURLPairs
     .filter(pair => isAbsoluteUrl(pair[1].toString()))
     .filter(file => {
-      const types = file[0].split(".")
-      if (
-        types[4] === "woff" ||
-        types[4] === "truetype" ||
-        types[4] === "opentype"
-      ) {
+      const extension = file[0].split(".")[4]
+      if (extension === "woff") {
         return true
       }
       return false
     })
     .map(file => {
       const types = file[0].split(".")
-      const dest = makeFontDownloadPath(
-        "all",
-        types[0],
-        types[1],
-        types[4].replace("truetype", "ttf").replace("opentype", "otf")
-      )
+      const dest = makeFontDownloadPath("all", types[0], types[1], types[4])
       const url = file[1]
       return {
         url,
@@ -117,15 +108,6 @@ if (changed || force == "force") {
   })
 
   // Generate CSS
-  const ttforotf = (subset, weight, style) => {
-    if (
-      Object.keys(font.variants[weight][style][subset].url).includes("opentype")
-    ) {
-      return "otf"
-    }
-    return "ttf"
-  }
-
   const unicodeKeys = Object.keys(font.unicodeRange)
 
   font.weights.forEach(weight => {
@@ -149,15 +131,6 @@ if (changed || force == "force") {
               "woff2"
             ),
             woffPath: makeFontFilePath("all", weight, style, "woff"),
-            ttforotf: ttforotf(subset, weight, style)
-              .replace("otf", "opentype")
-              .replace("ttf", "truetype"),
-            ttforotfPath: makeFontFilePath(
-              "all",
-              weight,
-              style,
-              ttforotf(subset, weight, style)
-            ),
             unicodeRange: font.unicodeRange[subset],
           })
           cssStyle.push(css)

--- a/scripts/google/templates.js
+++ b/scripts/google/templates.js
@@ -40,8 +40,7 @@ exports.fontFace = _.template(
     local('<%= localName %>'),<% });
     %> 
     url('<%= woff2Path %>') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-    url('<%= woffPath %>') format('woff'), /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-    url('<%= ttforotfPath %>') format('<%= ttforotf %>');
+    url('<%= woffPath %>') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 `
 )
@@ -53,7 +52,7 @@ exports.fontFaceUnicode = _.template(
   font-style: <%= style %>;
   font-display: swap;
   font-weight: <%= weight %>;
-  src: url('<%= woff2Path %>') format('woff2'), url('<%= woffPath %>') format('woff'), url('<%= ttforotfPath %>') format('<%= ttforotf %>');
+  src: url('<%= woff2Path %>') format('woff2'), url('<%= woffPath %>') format('woff');
   unicode-range: <%= unicodeRange %>;
 }
 `


### PR DESCRIPTION
With packages exceeding 200MB for select fonts such as Noto Serif SC, publishing to NPM became increasingly failure-prone. This update removes the backwards compatibility for extremely old browsers and it is arguably reasonable to remove support for this. 

The supported extensions are now woff and woff2. Support extends to these browsers: [caniuse](https://caniuse.com/#feat=woff)