### PR TITLE
Generic Packager Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ These occur when an automatic update is pushed from a source, such as Google, or
 ### Fixes
 
 - Adjusted templates.js to add more relevant fields to package.json [#37](https://github.com/fontsource/fontsource/pull/37)
+- Resolved subsets not correctly being identified when packaging files through the generic packager. [#45](https://github.com/fontsource/fontsource/pull/45)
 
 # 2.x Release
 

--- a/scripts/generic/generic-font-packager.js
+++ b/scripts/generic/generic-font-packager.js
@@ -30,8 +30,8 @@ glob(fontFileDir + "/**/*.woff2", {}, (err, files) => {
   let styles = []
 
   files.forEach(file => {
-    // Remove file path and extension
-    name = file.slice(23 + Object.keys(config.fontId).length, -6).split("-")
+    // Remove file path and extension. 34 characters to account for scripts/generic/... filepath
+    name = file.slice(34 + fontId.length, -6).split("-")
     styles.push(name.slice(-1)[0])
     name.pop()
     weights.push(name.slice(-1)[0])


### PR DESCRIPTION
Resolve subsets not correctly being identified when packaging files through the generic packager. This probably was the result of a file structure refactor in the past.