### PR TITLE
Readme Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ Alternatively, the same solutions could be imported via SCSS!
 For more advanced setups, you can use our highly customisable Sass mixins that can modify many of the existing @font-face variables.
 
 ```scss
+@use "@fontsource/open-sans/scss/mixins" as OpenSans;
+@use "@fontsource/roboto/scss/mixins" as Roboto;
+
+// Uses a unicode-range map to automatically generate multiple @font-face rules.
+@include OpenSans.fontFace(
+  $weight: 500,
+  $display: fallback,
+  $fontDir: "~@fontsource/open-sans/files"
+);
+
+// Fully customisable single @font-face mixin.
+@include Roboto.fontFaceCustom(
+  $weight: 600,
+  $display: optional,
+  $woff2Path: "#{$fontDir}/custom-file.woff2",
+  $unicodeRange: false
+);
+```
+
+For those not using Dart Sass, you can still use @import although it can be highly problematic as variables are placed in the global scope which can conflict with existing Sass setups. It's highly recommended to migrate to Dart Sass as all other versions have been deprecated.
+
+```scss
 @import "~@fontsource/open-sans/scss/mixins";
 
 // Uses a unicode-range map to automatically generate multiple @font-face rules.
@@ -66,19 +88,6 @@ For more advanced setups, you can use our highly customisable Sass mixins that c
   $woff2Path: "#{$fontDir}/custom-file.woff2",
   $unicodeRange: false
 );
-```
-
-We also have default variables that you can use!
-
-```scss
-@import "~@fontsource/open-sans/scss/mixins";
-
-$style: italic;
-
-@include fontFace($weight: 500);
-@include fontFace($weight: 600);
-
-// Applies italic to both @includes.
 ```
 
 You can see all of the existing inputtable mixin variables [here](https://github.com/fontsource/fontsource/tree/master/packages/open-sans/scss/mixins.scss).

--- a/scripts/generic/generic-packager.js
+++ b/scripts/generic/generic-packager.js
@@ -92,6 +92,7 @@ module.exports = function (font, rebuildFlag) {
   const packageReadme = readme({
     fontId,
     fontName,
+    fontNameNoSpace: fontName.replace(" ", ""),
     subsets,
     weights,
     styles,

--- a/scripts/google/run.js
+++ b/scripts/google/run.js
@@ -110,6 +110,7 @@ if (changed || force === "force") {
   const packageReadme = readme({
     fontId: font.id,
     fontName: font.family,
+    fontNameNoSpace: font.family.replace(" ", ""),
     subsets: font.subsets,
     weights: font.weights,
     styles: font.styles,

--- a/scripts/templates/readme.js
+++ b/scripts/templates/readme.js
@@ -45,9 +45,9 @@ For more advanced setups, you can use our highly customisable Sass mixins that c
   $weight: 500,
   $display: fallback,
   $fontDir: "~@fontsource/<%= fontId %>/files"
-);<% } %>
+);
 
-// Fully customisable single @font-face mixin.
+<% } %>// Fully customisable single @font-face mixin.
 @include <%= fontNameNoSpace %>.fontFaceCustom(
   $weight: 600,
   $display: optional,
@@ -66,9 +66,9 @@ For those not using Dart Sass, you can still use @import although it can be high
   $weight: 500,
   $display: fallback,
   $fontDir: "~@fontsource/<%= fontId %>/files"
-);<% } %>
+);
 
-// Fully customisable single @font-face mixin.
+<% } %>// Fully customisable single @font-face mixin.
 @include fontFaceCustom(
   $weight: 600,
   $display: optional,

--- a/scripts/templates/readme.js
+++ b/scripts/templates/readme.js
@@ -38,6 +38,27 @@ Alternatively, the same solutions could be imported via SCSS!
 For more advanced setups, you can use our highly customisable Sass mixins that can modify many of the existing @font-face variables.
 
 \`\`\`scss
+@use "@fontsource/<%= fontId %>/scss/mixins" as <%= fontNameNoSpace %>;
+
+<% if (type == "google") { %>// Uses a unicode-range map to automatically generate multiple @font-face rules.
+@include <%= fontNameNoSpace %>.fontFace(
+  $weight: 500,
+  $display: fallback,
+  $fontDir: "~@fontsource/<%= fontId %>/files"
+);<% } %>
+
+// Fully customisable single @font-face mixin.
+@include <%= fontNameNoSpace %>.fontFaceCustom(
+  $weight: 600,
+  $display: optional,
+  $woff2Path: "#{$fontDir}/custom-file.woff2",
+  $unicodeRange: false
+);
+\`\`\`
+
+For those not using Dart Sass, you can still use @import although it can be highly problematic as variables are placed in the global scope which can conflict with existing Sass setups. It's highly recommended to migrate to Dart Sass as all other versions have been deprecated.
+
+\`\`\`scss
 @import "~@fontsource/<%= fontId %>/scss/mixins";
 
 <% if (type == "google") { %>// Uses a unicode-range map to automatically generate multiple @font-face rules.
@@ -45,7 +66,7 @@ For more advanced setups, you can use our highly customisable Sass mixins that c
   $weight: 500,
   $display: fallback,
   $fontDir: "~@fontsource/<%= fontId %>/files"
-);
+);<% } %>
 
 // Fully customisable single @font-face mixin.
 @include fontFaceCustom(
@@ -53,27 +74,7 @@ For more advanced setups, you can use our highly customisable Sass mixins that c
   $display: optional,
   $woff2Path: "#{$fontDir}/custom-file.woff2",
   $unicodeRange: false
-);<% } else { %>// Fully customisable single @font-face mixin.
-@include fontFaceCustom(
-  $weight: 600,
-  $display: optional,
-  $woff2Path: "#{$fontDir}/custom-file.woff2",
-  $unicodeRange: false
-);<% } %>
-// More options available in link below.
-\`\`\`
-
-We also have default variables that you can use!
-
-\`\`\`scss
-@import "~@fontsource/<%= fontId %>/scss/mixins";
-
-$style: italic;
-
-@include fontFace($weight: 500);
-@include fontFace($weight: 600);
-
-// Applies italic to both @includes.
+);
 \`\`\`
 
 You can see all of the existing inputtable mixin variables [here](https://github.com/fontsource/fontsource/tree/master/packages/<%= fontId %>/scss/mixins.scss).


### PR DESCRIPTION
Updates the README templates and main repo to endorse the usage of `@use` for Sass imports.

Resolves #130. Although I will not be force rebuilding the entire repo and publishing NPM updates with this minor documentation update.