### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/_bug_report.md
@@ -1,8 +1,8 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: "🐛 Bug report"
+about: "Create a report to help us improve."
 title: ""
-labels: bug
+labels: "bug"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/_feature_request.md
@@ -1,8 +1,8 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: "✨ Feature request"
+about: "Suggest an idea for this project."
 title: ""
-labels: enhancement
+labels: "enhancement"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/_font_request.md
+++ b/.github/ISSUE_TEMPLATE/_font_request.md
@@ -1,8 +1,8 @@
 ---
-name: Font request
-about: Request a new Open Source font
-title: ""
-labels: font request
+name: "➕ Font request"
+about: "Request a new Open Source font."
+title: "Font Request: "
+labels: "font request"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -2,7 +2,7 @@
 name: "Blank issue"
 about: "Don’t see your issue here? Open a blank issue."
 title: ""
-labels: "triage label"
+labels: "needs triage"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,9 @@
+---
+name: "Blank issue"
+about: "Don’t see your issue here? Open a blank issue."
+title: ""
+labels: "triage label"
+assignees: ""
+---
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,7 +1,0 @@
----
-name: Custom issue template
-about: Describe this issue template's purpose here.
-title: ""
-labels: ""
-assignees: ""
----


### PR DESCRIPTION
- Standardized formatting
- Added emojis
- Changed "Custom issue template" to "Blank issue", and fixed the corresponding description
- Added initial title to the "Font request" template
- I also made the "Blank issue" template assign the "triage label" label to say that a label needs to be added (you will need to create a new label with that name and a description of, I suggest, "Relevant labels need to be added")

Note: The underscores at the beginning of the file names were purposefully added to keep the template order correct. (They are sorted alphebeticaly)