### PR TITLE
feat: add NPM links to each FontPreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ These will always contain changes from Fontsource's end.
 - Update READMEs with new information. [#199](https://github.com/fontsource/fontsource/pull/199)
 - GitHub Actions Git configs changed to 'fontsource-bot'. [#200](https://github.com/fontsource/fontsource/pull/200)
 - Update dependencies. [#207](https://github.com/fontsource/fontsource/pull/207) [#209](https://github.com/fontsource/fontsource/pull/209)
+- Add NPM and GitHub links to each Font Preview page. [#210](https://github.com/fontsource/fontsource/pull/210)
 
 ## 4.2.x
 

--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -5,6 +5,8 @@ import {
   Code,
   Divider,
   Heading,
+  HStack,
+  IconButton,
   Input,
   Link,
   Select,
@@ -19,7 +21,8 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { AiOutlineFontSize } from "react-icons/ai";
+import { AiFillGithub, AiOutlineFontSize } from "react-icons/ai";
+import { ImNpm } from "react-icons/im";
 
 import { MetadataProps } from "../@types/[font]";
 import useFontDownload from "../hooks/useFontDownload";
@@ -72,7 +75,31 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
   return (
     <>
       <Box>
-        <Heading size="2xl">{metadata.fontName}</Heading>
+        <SimpleGrid columns={{ base: 1, sm: 2 }}>
+          <Heading size="2xl">{metadata.fontName}</Heading>
+          <HStack display={{ base: "none", sm: "flex" }} ml="auto">
+            <Link
+              isExternal
+              href={`https://www.npmjs.com/package/@fontsource/${metadata.fontId}`}
+            >
+              <IconButton
+                aria-label="Link to NPM"
+                variant="ghost"
+                icon={<ImNpm />}
+              />
+            </Link>
+            <Link
+              isExternal
+              href={`https://github.com/fontsource/fontsource/tree/main/packages/${metadata.fontId}#readme`}
+            >
+              <IconButton
+                aria-label="Link to Github"
+                variant="ghost"
+                icon={<AiFillGithub />}
+              />
+            </Link>
+          </HStack>
+        </SimpleGrid>
         <Divider mt={1} />
       </Box>
 
@@ -213,7 +240,7 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
         Some fonts use the Apache 2 license. The Ubuntu fonts use the Ubuntu
         Font License v1.0.
       </Text>
-      <SimpleGrid columns={{ md: 1, lg: 2 }}>
+      <SimpleGrid columns={{ base: 1, sm: 2 }}>
         <Link href={metadata.source} isExternal mr="auto" fontWeight="700">
           <Button variant="ghost" rightIcon={<ExternalLinkIcon />}>
             Source


### PR DESCRIPTION
Adds small buttons on each font preview page to link to NPM and their respective GitHub directory.