### PR TITLE
Use async/await for main run function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,8 @@
     // Airbnb prefers forEach
     "unicorn/no-array-for-each": "off",
     // It's not accurate in the monorepo style
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    // Fontsource doesn't need to worry about heavyweight libraries
+    "no-restricted-syntax": "off"
   }
 }

--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Format files
         run: yarn format
-        
+
       - name: Stage, commit and push files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: "fontsource-bot"
           commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
-          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>" 
-          commit_message: "chore(build): update packages [Force Rebuild $GITHUB_RUN_NUMBER]"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): update packages [Force Rebuild]"
         continue-on-error: true

--- a/scripts/google/download-google.ts
+++ b/scripts/google/download-google.ts
@@ -12,16 +12,17 @@ fs.ensureDirSync("packages");
 fs.ensureDirSync("scripts/temp_packages");
 
 // Create an async queue object
-const processQueue = (fontId: string, cb: () => void) => {
+const processQueue = async (fontId: string, cb: () => void) => {
   console.log(`Downloading ${fontId}`);
-  run(fontId, force);
+  await run(fontId, force);
+  console.log(`Finished processing ${fontId}`);
   cb();
 };
 
 // EventEmitter listener is usually set at a default limit of 10, below chosen 12 concurrent workers
 EventEmitter.defaultMaxListeners = 0;
 
-const queue = async.queue(processQueue, 12);
+const queue = async.queue(processQueue, 3);
 
 queue.drain(() => {
   console.log(

--- a/scripts/templates/readme.ts
+++ b/scripts/templates/readme.ts
@@ -18,7 +18,7 @@ yarn add @fontsource/<%= fontId %> // npm install @fontsource/<%= fontId %>
 Within your app entry file or site component, import it in.
 
 \`\`\`javascript
-import "@fontsource/<%= fontId %>" // Defaults to weight 400.
+import "@fontsource/<%= fontId %>"; // Defaults to weight 400.
 \`\`\`
 
 Supported variables:


### PR DESCRIPTION
The queuing system went completely whack when I removed ShellJS in #229 which led to downloads failing due to the sheer number of threads. This refactors a lot of the functions to use async/await which fixes the build issues and plays around with concurrency due to the new structure.