### PR TITLE
Add a fallback for the font preview

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "@next/mdx": "^11.0.0",
     "@types/css-font-loading-module": "^0.0.5",
     "algoliasearch": "^4.9.3",
+    "fallback-font": "^1.0.0",
     "framer-motion": "4.1.17",
     "gray-matter": "^4.0.3",
     "next": "^11.0.0",

--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -157,7 +157,12 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
           onChange={(event) => setPreviewText(event.target.value)}
           variant="flushed"
           style={{
-            fontFamily: `"${metadata.fontName}", "Fallback Outline"`,
+            // if the font is a material icons variant, then use the Chakra default font as a fallback
+            fontFamily: `"${metadata.fontName}", ${
+              metadata.fontId.startsWith("material-icons")
+                ? `var(--chakra-fonts-body), `
+                : ""
+            }"Fallback Outline"`,
             fontSize: `${fontSize}px`,
             fontWeight: weight,
           }}

--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -165,6 +165,7 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
             }"Fallback Outline"`,
             fontSize: `${fontSize}px`,
             fontWeight: weight,
+            fontStyle: style,
           }}
           height={`${fontSize + 12}px`}
         />

--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -60,7 +60,7 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
     });
   }, [events, defPreviewText, defStyle, defWeight]);
 
-  const downloadLink = fontsourceDownload.fontDownload(
+  const downloadLink = fontsourceDownload.cssDownload(
     metadata.fontId,
     weight,
     style

--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -62,7 +62,6 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
 
   const downloadLink = fontsourceDownload.fontDownload(
     metadata.fontId,
-    metadata.defSubset,
     weight,
     style
   );
@@ -158,7 +157,7 @@ export const FontPreview = ({ defPreviewText, metadata }: FontPreviewProps) => {
           onChange={(event) => setPreviewText(event.target.value)}
           variant="flushed"
           style={{
-            fontFamily: metadata.fontName,
+            fontFamily: `"${metadata.fontName}", "Fallback Outline"`,
             fontSize: `${fontSize}px`,
             fontWeight: weight,
           }}

--- a/website/src/hooks/useFontDownload.tsx
+++ b/website/src/hooks/useFontDownload.tsx
@@ -12,11 +12,12 @@ const useFontDownload = (metadata: MetadataProps, downloadLink: string) => {
     fetch(downloadLink)
       .then((res) => res.text())
       .then((cssFile) => {
-        document.getElementById("font-preview-css").innerText =
-          cssFile.replaceAll(
-            /url\('\.\/(files\/.*?)'\)/g,
-            `url('${fontsourceDownload.fontDownload(metadata.fontId)}/$1')`
-          );
+        // fetch font's css, fix file sources' base url, and add updated css to the head
+        document.getElementById("font-preview-css").innerText = cssFile.replace(
+          /url\('\.\/(files\/.*?)'\)/g,
+          // match "url('./files/${woffFileName}')", then replace with "url('${baseURL}/files/${woffFileName}')"
+          `url('${fontsourceDownload.fontDownload(metadata.fontId)}/$1')`
+        );
 
         document.fonts.ready.then(() => setFontLoaded(true));
       });

--- a/website/src/hooks/useFontDownload.tsx
+++ b/website/src/hooks/useFontDownload.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { MetadataProps } from "../@types/[font]";
+import { fontsourceDownload } from "../utils/fontsourceUtils";
 
 const useFontDownload = (metadata: MetadataProps, downloadLink: string) => {
   const [fontLoaded, setFontLoaded] = useState(false);
@@ -8,15 +9,18 @@ const useFontDownload = (metadata: MetadataProps, downloadLink: string) => {
   useEffect(() => {
     setFontLoaded(false);
 
-    // Fetch font file
-    new FontFace(metadata.fontName, `url(${downloadLink})`)
-      .load()
-      .then((result) => {
-        document.fonts.add(result);
-        setFontLoaded(true);
-      })
-      .catch((error) => console.log(error));
-  }, [metadata.fontId, metadata.fontName, downloadLink]);
+    fetch(downloadLink)
+      .then((res) => res.text())
+      .then((cssFile) => {
+        document.getElementById("font-preview-css").innerText =
+          cssFile.replaceAll(
+            /url\('\.\/(files\/.*?)'\)/g,
+            `url('${fontsourceDownload.fontDownload(metadata.fontId)}/$1')`
+          );
+
+        document.fonts.ready.then(() => setFontLoaded(true));
+      });
+  }, [metadata.fontId, downloadLink]);
 
   return fontLoaded;
 };

--- a/website/src/pages/_document.tsx
+++ b/website/src/pages/_document.tsx
@@ -72,6 +72,7 @@ export default class Document extends NextDocument {
             property="og:image"
             content="https://fontsource.org/icons/apple-touch-icon.png"
           />
+          <style id="font-preview-css" />
         </Head>
         <body>
           {/* Make Color mode to persists when you refresh the page. */}

--- a/website/src/pages/fonts/[font].tsx
+++ b/website/src/pages/fonts/[font].tsx
@@ -1,3 +1,5 @@
+import "fallback-font/fallback-outline.css";
+
 import { Skeleton } from "@chakra-ui/react";
 import { promises as fs } from "fs";
 import { GetStaticPaths, GetStaticProps } from "next";

--- a/website/src/utils/fontsourceUtils.ts
+++ b/website/src/utils/fontsourceUtils.ts
@@ -13,10 +13,14 @@ const fontsourceDownload = {
     };
   },
 
-  fontDownload(fontId: string, weight: number, style: string) {
+  cssDownload(fontId: string, weight: number, style: string) {
     const dir = `${baseUrlDownload}/@fontsource/${fontId}`;
 
-    return `${dir}/files/${fontId}-all-${weight}-${style}.woff`;
+    return `${dir}/${weight}${style === "normal" ? "" : `-${style}`}.css`;
+  },
+
+  fontDownload(fontId: string) {
+    return `${baseUrlDownload}/@fontsource/${fontId}`;
   },
 };
 

--- a/website/src/utils/fontsourceUtils.ts
+++ b/website/src/utils/fontsourceUtils.ts
@@ -16,6 +16,7 @@ const fontsourceDownload = {
   cssDownload(fontId: string, weight: number, style: string) {
     const dir = `${baseUrlDownload}/@fontsource/${fontId}`;
 
+    // If style is normal, only search for the "weight.css" file. e.g. "400.css" instead of "400-italic.css"
     return `${dir}/${weight}${style === "normal" ? "" : `-${style}`}.css`;
   },
 

--- a/website/src/utils/fontsourceUtils.ts
+++ b/website/src/utils/fontsourceUtils.ts
@@ -13,15 +13,10 @@ const fontsourceDownload = {
     };
   },
 
-  fontDownload(
-    fontId: string,
-    defSubset: string,
-    weight: number,
-    style: string
-  ) {
+  fontDownload(fontId: string, weight: number, style: string) {
     const dir = `${baseUrlDownload}/@fontsource/${fontId}`;
 
-    return `${dir}/files/${fontId}-${defSubset}-${weight}-${style}.woff2`;
+    return `${dir}/files/${fontId}-all-${weight}-${style}.woff`;
   },
 };
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2726,6 +2726,11 @@ extend@^3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+fallback-font@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fallback-font/-/fallback-font-1.0.0.tgz#3e2a00bd8542de7dcde4f57ea45b9d95471f3774"
+  integrity sha512-t5QCHJUXVYnJAgRays9Vgpl2hoc1o8ZVuYerRK0VZ00Yqp+HgPas0dhnDS41JHnF8KGHQEoobxeNmxt1T371FQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
I added the "Fallback Outline" font that I have been working on as the fallback for the font preview. I set the preview to load the WOFF file with "all" in the subset field. The only problem is that there are not any WOFF2 files with "all" subsets. I was also wondering if there were actually WOFF files with an "all" subset in every single font. If this works, we can close https://github.com/fontsource/fontsource/issues/208.