### PR TITLE
Add fallback family to the code sample

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -37,7 +37,7 @@ Once imported, you can reference the font name in a CSS stylesheet, CSS Module, 
 
 ```css
 body {
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
 }
 ```
 


### PR DESCRIPTION
Otherwise the default Times New Roman serif font will be used before the Open Sans loads.

Generic fallback font family is considered as a good practice. It usually make font switch less obvious for users, so it’s good to have it in the code sample as a reminder.