### PR TITLE
add: metadata category to font preview

### DIFF
--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -16,6 +16,7 @@ import {
   SliderFilledTrack,
   SliderThumb,
   SliderTrack,
+  Tag,
   Text,
   useColorModeValue,
 } from "@chakra-ui/react";
@@ -91,6 +92,7 @@ export const FontPreview = ({
         <SimpleGrid columns={{ base: 1, sm: 2 }}>
           <Heading size="2xl">{metadata.fontName}</Heading>
           <HStack display={{ base: "none", sm: "flex" }} ml="auto">
+            <Tag>{metadata.category}</Tag>
             <Link
               isExternal
               href={`https://www.npmjs.com/package/@fontsource/${metadata.fontId}`}


### PR DESCRIPTION
I added a Tag with `metadata.category` as content to show on the font preview page what kind of font it is. 
It's a useful information I think.

<img width="834" alt="Bildschirmfoto 2021-10-21 um 16 22 40" src="https://user-images.githubusercontent.com/26602940/138297499-853f2142-19bf-464c-9792-3cfe51920a8d.png">

It's only a proposal. Feel free to merge or discard this PR :)
