### PR TITLE
fix: update google-font-metadata to include force flag

### DIFF
--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -23,10 +23,10 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Parse APIv1
-        run: yarn parser:v1
+        run: yarn parser:v1 --force
 
       - name: Parse APIv2
-        run: yarn parser:v2
+        run: yarn parser:v2 --force
 
       - name: Parse Variable
         run: yarn parser:variable

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "flat": "^5.0.2",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
-    "google-font-metadata": "^3.0.2",
+    "google-font-metadata": "^3.1.0",
     "got": "^11.8.2",
     "is-absolute-url": "^3.0.3",
     "jsonfile": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,10 +2892,10 @@ globby@^11.0.1, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-google-font-metadata@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/google-font-metadata/-/google-font-metadata-3.0.2.tgz#9963f5685b6445326f3a5900e73a6adf1c22344e"
-  integrity sha512-GdVxvNh2bFPm5sRam3vDxb7bjooW1RkevhdyoKO/wyiWlZbgmvLuHuHtkkriL0AmN49fj1tBcOpCXqCvaOM/Cw==
+google-font-metadata@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/google-font-metadata/-/google-font-metadata-3.1.0.tgz#ec21c4e25a2cac37c9349351249106cbc22b5143"
+  integrity sha512-RXvWMsRRVbZFFFj96ZbGLLQWnWEY14A5X+xO55J0c07RcSZ6b1xzUllhNiarsVjF1Iwx7XF1a+50/5bMS8e4xg==
   dependencies:
     async "^3.2.0"
     cheerio "^1.0.0-rc.9"


### PR DESCRIPTION
Resolves #353 by updating google-font-metadata which now has a force flag for the parser to skip version checking.