### PR TITLE
[website] Persist sidebar scroll position across navigation

### DIFF
--- a/website/src/components/Sidebar.tsx
+++ b/website/src/components/Sidebar.tsx
@@ -4,15 +4,18 @@ import {
   Button,
   ButtonProps,
   Divider,
+  forwardRef,
   Heading,
   Stack,
   StackProps,
   useColorModeValue,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useRef } from "react";
 
 import docsList from "../configs/docsList.json";
 import fontList from "../configs/fontList.json";
+import { usePersistedScrollTop } from "../utils/usePersistedScrollTop";
 import { NextChakraLink } from "./NextChakraLink";
 
 const SidebarHeading = ({ title, ...props }) => {
@@ -95,17 +98,20 @@ const SidebarButton = ({
   );
 };
 
-const SidebarContainer = (props: StackProps) => (
-  <Stack
-    as="aside"
-    py={4}
-    direction="column"
-    marginTop={4}
-    height="80vh"
-    overflowY="auto"
-    sx={{ overscrollBehavior: "contain" }}
-    {...props}
-  />
+const SidebarContainer = forwardRef<StackProps, "div">(
+  (props: StackProps, ref) => (
+    <Stack
+      ref={ref}
+      as="aside"
+      py={4}
+      direction="column"
+      marginTop={4}
+      height="80vh"
+      overflowY="auto"
+      sx={{ overscrollBehavior: "contain" }}
+      {...props}
+    />
+  )
 );
 
 interface SidebarProps extends StackProps {
@@ -120,8 +126,12 @@ export const Sidebar = ({
   isOpen,
   ...rest
 }: SidebarProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  usePersistedScrollTop(ref);
+
   return (
-    <SidebarContainer {...rest}>
+    <SidebarContainer ref={ref} {...rest}>
       <SidebarHeading title={"Contents"} pt={{ base: 6, md: 2 }} />
       {ifDocs
         ? docsList.map((page) => (

--- a/website/src/utils/usePersistedScrollTop.ts
+++ b/website/src/utils/usePersistedScrollTop.ts
@@ -1,0 +1,56 @@
+import React, { useLayoutEffect } from "react";
+
+// Pass this the ref of an element which you expect to maintain scroll
+// position across navigation. It uses localStorage (if possible), to
+// write the current scrollTop when we detect navigation to a new URL.
+// The next page which mounts this component will try to read the last
+// persisted scrollTop, and scroll to that position.
+//
+// Note: We're avoiding the unload/beforeunload events here because
+// they're not as reliable as visibilitychange/pagehide, which also
+// account for things like cached navigation on Safari. Source:
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon#sending_analytics_at_the_end_of_a_session
+
+const LOCAL_STORAGE_ITEM_NAME = "sidebar-scroll-top";
+
+export const usePersistedScrollTop = (ref: React.RefObject<HTMLElement>) =>
+  useLayoutEffect(() => {
+    let scrollTop = 0;
+
+    try {
+      scrollTop = +localStorage.getItem(LOCAL_STORAGE_ITEM_NAME);
+    } catch (err) {
+      console.log(err);
+    }
+
+    if (scrollTop !== 0) {
+      ref.current.scrollTop = scrollTop;
+    }
+
+    const listener = (event: Event) => {
+      if (event.type === "pagehide" || document.visibilityState === "hidden") {
+        stopListening();
+
+        try {
+          localStorage.setItem(
+            LOCAL_STORAGE_ITEM_NAME,
+            String(ref.current.scrollTop)
+          );
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    };
+
+    const stopListening = () => {
+      document.removeEventListener("visibilitychange", listener);
+      document.removeEventListener("pagehide", listener);
+    };
+
+    document.addEventListener("visibilitychange", listener);
+    document.addEventListener("pagehide", listener);
+
+    return () => {
+      stopListening();
+    };
+  }, [ref]);

--- a/website/src/utils/usePersistedScrollTop.ts
+++ b/website/src/utils/usePersistedScrollTop.ts
@@ -27,18 +27,21 @@ export const usePersistedScrollTop = (ref: React.RefObject<HTMLElement>) =>
       ref.current.scrollTop = scrollTop;
     }
 
+    const persist = () => {
+      try {
+        localStorage.setItem(
+          LOCAL_STORAGE_ITEM_NAME,
+          String(ref.current.scrollTop)
+        );
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     const listener = (event: Event) => {
       if (event.type === "pagehide" || document.visibilityState === "hidden") {
         stopListening();
-
-        try {
-          localStorage.setItem(
-            LOCAL_STORAGE_ITEM_NAME,
-            String(ref.current.scrollTop)
-          );
-        } catch (err) {
-          console.error(err);
-        }
+        persist();
       }
     };
 
@@ -52,5 +55,6 @@ export const usePersistedScrollTop = (ref: React.RefObject<HTMLElement>) =>
 
     return () => {
       stopListening();
+      persist();
     };
   }, [ref]);


### PR DESCRIPTION
I was getting a bit frustrated when selecting fonts to preview from the looooooong list in the sidebar, as it kept jumping back to the top of the list (naturally) every time I picked a font to preview.

This PR introduces a new React hook (`usePersistedScrollTop`) that is capable of persisting an element's `scrollTop` to localStorage, ensuring it can be maintained as we navigate the site.

Applying the hook to the `Sidebar` component (with a correctly forwarded ref into the underlying Chakra UI component, keeps your scroll position inside the fonts list.

I hope you find this useful enough to add to the website. I've tried to maintain your code style (thanks prettier/eslint), but if you have issues I'm happy to correct them. Also, if `utils` is the wrong place to house the hook, I can move it elsewhere.

Cheers for such an amazing resource. A little bit of UX polish is the least I could give in return.