### PR TITLE
feat(api): add ttf download route

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -39,7 +39,8 @@
     "p-queue": "6",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.3.0"
+    "rxjs": "^7.3.0",
+    "wawoff2": "^2.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.1.1",

--- a/api/src/fonts/fonts.controller.ts
+++ b/api/src/fonts/fonts.controller.ts
@@ -35,7 +35,7 @@ export class FontsController {
     @Param('id') id: string,
     @Param('file') file: string,
     @Query() query,
-  ): Promise<Buffer | undefined> {
+  ): Promise<Buffer> {
     return await this.findService.findFile(id, file, query);
   }
 

--- a/api/src/fonts/fonts.controller.ts
+++ b/api/src/fonts/fonts.controller.ts
@@ -30,6 +30,15 @@ export class FontsController {
     return await this.findService.findOne(id, query);
   }
 
+  @Get(':id/:file')
+  async findFile(
+    @Param('id') id: string,
+    @Param('file') file: string,
+    @Query() query,
+  ): Promise<Buffer | undefined> {
+    return await this.findService.findFile(id, file, query);
+  }
+
   /* Test routes
   @Post('update')
   async updateFonts() {

--- a/api/src/fonts/fonts.controller.ts
+++ b/api/src/fonts/fonts.controller.ts
@@ -1,5 +1,14 @@
-import { Controller, Get, Param, Query, Post, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Post,
+  Delete,
+  Response,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { FastifyReply } from 'fastify';
 
 import { FontsService } from './services/fonts.service';
 import { FindService } from './services/find.service';
@@ -32,11 +41,14 @@ export class FontsController {
 
   @Get(':id/:file')
   async findFile(
+    @Response() res: FastifyReply,
     @Param('id') id: string,
     @Param('file') file: string,
     @Query() query,
-  ): Promise<Buffer> {
-    return await this.findService.findFile(id, file, query);
+  ): Promise<void> {
+    const fontFile = await this.findService.findFile(id, file, query);
+    res.type(fontFile.type);
+    res.send(fontFile.data);
   }
 
   /* Test routes

--- a/api/src/fonts/interfaces/font.interface.ts
+++ b/api/src/fonts/interfaces/font.interface.ts
@@ -24,7 +24,13 @@ export interface UnicodeRange {
 export interface Variants {
   [weight: number]: {
     [style: string]: {
-      [subset: string]: { url: { woff2: string; woff: string } };
+      [subset: string]: {
+        url: {
+          woff2: string;
+          woff: string;
+          ttf: string;
+        };
+      };
     };
   };
 }

--- a/api/src/fonts/schemas/downloads.schema.ts
+++ b/api/src/fonts/schemas/downloads.schema.ts
@@ -7,6 +7,9 @@ class Url {
 
   @Prop()
   woff: string;
+
+  @Prop()
+  ttf: string;
 }
 
 const UrlSchema = SchemaFactory.createForClass(Url);

--- a/api/src/fonts/schemas/files.schema.ts
+++ b/api/src/fonts/schemas/files.schema.ts
@@ -1,0 +1,27 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+@Schema()
+export class Files {
+  @Prop()
+  subset: string;
+
+  @Prop()
+  weight: number;
+
+  @Prop()
+  style: string;
+
+  @Prop()
+  ext: string;
+
+  @Prop()
+  data: Buffer;
+
+  @Prop()
+  hash: string;
+
+  @Prop([String])
+  versions: string[];
+}
+
+export const FilesSchema = SchemaFactory.createForClass(Files);

--- a/api/src/fonts/schemas/font.schema.ts
+++ b/api/src/fonts/schemas/font.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
+import { Files, FilesSchema } from './files.schema';
 import { Variants, VariantsSchema } from './variants.schema';
 
 export type FontDocument = Font & Document;
@@ -47,6 +48,9 @@ export class Font {
 
   @Prop({ type: [VariantsSchema], default: [], _id: false })
   variants: Variants[];
+
+  @Prop({ type: [FilesSchema], default: [], _id: false })
+  files: Files[];
 }
 
 export const FontSchema = SchemaFactory.createForClass(Font);
@@ -76,6 +80,7 @@ export const example = {
             woff2:
               'https://cdn.jsdelivr.net/npm/@fontsource/abeezee/files/abeezee-latin-400-normal.woff2',
             woff: 'https://cdn.jsdelivr.net/npm/@fontsource/abeezee/files/abeezee-latin-400-normal.woff',
+            ttf: 'https://api.fontsource.org/v1/fonts/abeezee/latin-400-normal.ttf',
           },
         },
         {
@@ -85,6 +90,7 @@ export const example = {
             woff2:
               'https://cdn.jsdelivr.net/npm/@fontsource/abeezee/files/abeezee-latin-400-italic.woff2',
             woff: 'https://cdn.jsdelivr.net/npm/@fontsource/abeezee/files/abeezee-latin-400-italic.woff',
+            ttf: 'https://api.fontsource.org/v1/fonts/abeezee/latin-400-italic.ttf',
           },
         },
       ],

--- a/api/src/fonts/services/find.service.ts
+++ b/api/src/fonts/services/find.service.ts
@@ -138,11 +138,7 @@ export class FindService {
     return metadata;
   }
 
-  async findFile(
-    id: string,
-    file: string,
-    query: QueriesOne,
-  ): Promise<Buffer | undefined> {
+  async findFile(id: string, file: string, query: QueriesOne): Promise<Buffer> {
     const fontObj = await this.fontModel.findOne({ id }).exec();
 
     const parsedPath = fontFilePath(file);

--- a/api/src/fonts/services/find.service.ts
+++ b/api/src/fonts/services/find.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { merge } from 'lodash';
 
@@ -16,11 +20,20 @@ import {
   QueriesOne,
   QueryMongoose,
 } from '../interfaces/queries.interface';
+import { fontFilePath } from '../utils/fontFilePath';
+import { fontLink } from '../utils/cdnLinks';
+import { HttpService } from '@nestjs/axios';
+import { lastValueFrom } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { latestFontVersion } from '../utils/latestFontVersion';
+import { genHash } from '../utils/genHash';
 
 @Injectable()
 export class FindService {
   constructor(
-    @InjectModel(Font.name) private readonly fontModel: Model<FontDocument>,
+    @InjectModel(Font.name)
+    private readonly fontModel: Model<FontDocument>,
+    private readonly httpService: HttpService,
   ) {}
 
   async findAll(queries: QueriesAll): Promise<FontAllResponse[]> {
@@ -123,5 +136,102 @@ export class FindService {
     };
 
     return metadata;
+  }
+
+  async findFile(
+    id: string,
+    file: string,
+    query: QueriesOne,
+  ): Promise<Buffer | undefined> {
+    const fontObj = await this.fontModel.findOne({ id }).exec();
+
+    const parsedPath = fontFilePath(file);
+
+    if (!parsedPath) throw new BadRequestException(`Bad font path: ${file}`);
+
+    const version =
+      query.version || (await latestFontVersion(this.httpService, id));
+
+    // Search for existing file
+    const fontObjFile = fontObj.files.find(
+      (file) =>
+        file.subset === parsedPath.subset &&
+        file.weight === parsedPath.weight &&
+        file.style === parsedPath.style &&
+        file.ext === parsedPath.ext &&
+        file.versions.includes(version),
+    );
+
+    if (fontObjFile) return fontObjFile.data;
+
+    const throwNotFound = () => {
+      throw new NotFoundException(`Not found: ${id}/${file}`);
+    };
+
+    const fontObjVariant = fontObj.variants.find(
+      (variant) => variant.subset === parsedPath.subset,
+    );
+
+    if (!fontObjVariant) throwNotFound();
+
+    const fontObjVariantDownload = fontObjVariant.downloads.find(
+      (download) =>
+        download.weight === parsedPath.weight &&
+        download.style === parsedPath.style,
+    );
+
+    if (!fontObjVariantDownload) throwNotFound();
+
+    const fontObjUrl = fontLink(
+      id,
+      parsedPath.subset,
+      parsedPath.weight,
+      parsedPath.style,
+      version,
+    )[parsedPath.ext === 'ttf' ? 'woff2' : parsedPath.ext];
+
+    if (!fontObjUrl) throwNotFound();
+
+    let fontBuffer: Buffer;
+
+    await lastValueFrom(
+      this.httpService.get(fontObjUrl, { responseType: 'arraybuffer' }),
+    )
+      .then((res: AxiosResponse<Buffer>) => {
+        fontBuffer = res.data;
+      })
+      .catch(throwNotFound);
+
+    if (parsedPath.ext === 'ttf') {
+      fontBuffer = Buffer.from(
+        await (await import('wawoff2')).decompress(fontBuffer),
+      );
+    }
+
+    const fontBufferHash = genHash(fontBuffer);
+
+    const fontObjFileFromHash = fontObj.files.find(
+      (file) =>
+        file.subset === parsedPath.subset &&
+        file.weight === parsedPath.weight &&
+        file.style === parsedPath.style &&
+        file.ext === parsedPath.ext &&
+        file.hash === fontBufferHash,
+    );
+
+    if (fontObjFileFromHash) {
+      fontObjFileFromHash.versions.push(version);
+    } else {
+      fontObj.files.push({
+        ...parsedPath,
+        data: fontBuffer,
+        hash: fontBufferHash,
+        versions: [version],
+      });
+    }
+
+    await fontObj.save();
+
+    return fontBuffer;
   }
 }

--- a/api/src/fonts/services/find.service.ts
+++ b/api/src/fonts/services/find.service.ts
@@ -27,6 +27,7 @@ import { lastValueFrom } from 'rxjs';
 import { AxiosResponse } from 'axios';
 import { latestFontVersion } from '../utils/latestFontVersion';
 import { genHash } from '../utils/genHash';
+import { mimes } from '../utils/mimes';
 
 @Injectable()
 export class FindService {
@@ -138,7 +139,11 @@ export class FindService {
     return metadata;
   }
 
-  async findFile(id: string, file: string, query: QueriesOne): Promise<Buffer> {
+  async findFile(
+    id: string,
+    file: string,
+    query: QueriesOne,
+  ): Promise<{ data: Buffer; type: string }> {
     const fontObj = await this.fontModel.findOne({ id }).exec();
 
     const parsedPath = fontFilePath(file);
@@ -158,7 +163,8 @@ export class FindService {
         file.versions.includes(version),
     );
 
-    if (fontObjFile) return fontObjFile.data;
+    if (fontObjFile)
+      return { data: fontObjFile.data, type: mimes[parsedPath.ext] };
 
     const throwNotFound = () => {
       throw new NotFoundException(`Not found: ${id}/${file}`);
@@ -228,6 +234,6 @@ export class FindService {
 
     await fontObj.save();
 
-    return fontBuffer;
+    return { data: fontBuffer, type: mimes[parsedPath.ext] };
   }
 }

--- a/api/src/fonts/utils/cdnLinks.ts
+++ b/api/src/fonts/utils/cdnLinks.ts
@@ -1,3 +1,6 @@
+export const packageLink = (fontId: string) =>
+  `https://cdn.jsdelivr.net/npm/@fontsource/${fontId}/package.json`;
+
 export const metadataLink = (fontId: string) =>
   `https://cdn.jsdelivr.net/npm/@fontsource/${fontId}/metadata.json`;
 
@@ -9,10 +12,20 @@ export const fontLink = (
   subset: string,
   weight: number,
   style: string,
+  version?: string,
 ) => {
+  const linkVersion = version ? `@${version}` : '';
+
   const url = {
-    woff2: `https://cdn.jsdelivr.net/npm/@fontsource/${id}/files/${id}-${subset}-${weight}-${style}.woff2`,
-    woff: `https://cdn.jsdelivr.net/npm/@fontsource/${id}/files/${id}-${subset}-${weight}-${style}.woff`,
+    woff2: `https://cdn.jsdelivr.net/npm/@fontsource/${
+      id + linkVersion
+    }/files/${id}-${subset}-${weight}-${style}.woff2`,
+    woff: `https://cdn.jsdelivr.net/npm/@fontsource/${
+      id + linkVersion
+    }/files/${id}-${subset}-${weight}-${style}.woff`,
+    ttf: `https://api.fontsource.org/v1/fonts/${
+      id + linkVersion
+    }/${subset}-${weight}-${style}.ttf`,
   };
   return url;
 };

--- a/api/src/fonts/utils/fontFilePath.ts
+++ b/api/src/fonts/utils/fontFilePath.ts
@@ -1,0 +1,23 @@
+const fontFilePathRegex = /(.+)-(.+)-(.+)\.(.+)$/;
+
+export const fontFilePath = (
+  path: string,
+):
+  | {
+      subset: string;
+      weight: number;
+      style: string;
+      ext: string;
+    }
+  | undefined => {
+  const regexResults = fontFilePathRegex.exec(path);
+
+  return regexResults
+    ? {
+        subset: regexResults[1],
+        weight: Number(regexResults[2]),
+        style: regexResults[3],
+        ext: regexResults[4],
+      }
+    : undefined;
+};

--- a/api/src/fonts/utils/genHash.ts
+++ b/api/src/fonts/utils/genHash.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'crypto';
+
+export const genHash = (data: Buffer): string => {
+  return createHash('md5').update(data).digest('base64');
+};

--- a/api/src/fonts/utils/latestFontVersion.ts
+++ b/api/src/fonts/utils/latestFontVersion.ts
@@ -1,0 +1,15 @@
+import { HttpService } from '@nestjs/axios';
+import { lastValueFrom } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { packageLink } from './cdnLinks';
+
+export const latestFontVersion = async (
+  httpService: HttpService,
+  id: string,
+): Promise<string> => {
+  const res: AxiosResponse = await lastValueFrom(
+    httpService.get(packageLink(id)),
+  );
+
+  return res.data.version;
+};

--- a/api/src/fonts/utils/mimes.ts
+++ b/api/src/fonts/utils/mimes.ts
@@ -1,0 +1,7 @@
+const mimes: Record<string, string> = {
+  ttf: 'font/ttf',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+};
+
+export { mimes };

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -5295,6 +5295,13 @@ watchpack@^2.2.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+wawoff2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wawoff2/-/wawoff2-2.0.0.tgz#df0ab96b0ef0539d7277292b9ad9884599c0e61f"
+  integrity sha512-5gjFj+fyQO9cMrg5vYaVM7+T37xSHpqUWM/S6UCEiBx8wRmfpvuhYjPM3toB2UujpmWQt1hSPKRo/jIRE/j9Eg==
+  dependencies:
+    argparse "^2.0.1"
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
This adds routes for direct downloads of font files including `ttf`, `woff`, and `woff2` (other extension could be added in the future). The route is as follows: `https://api.fontsource.org/v1/fonts/[id]/[subset]-[weight]-[style].[ext]?version=[package-version]`. Any version with the same font file is pointed to the same location (so no duplicate files). The metadata route was also updated to include a link to the `ttf` file for each subset, weight, and style.