### PR TITLE
fix(montserrat): use distinct variable names

### DIFF
--- a/packages/cabin/scss/mixins.scss
+++ b/packages/cabin/scss/mixins.scss
@@ -62,17 +62,17 @@ $unicodeRangeValues: (U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+0
   }
 }
 
-$fontName: "CabinVariable";
-$weight: 400 700;
+$fontNameVariable: "CabinVariable";
+$weightVariable: 400 700;
 $type: "wghtOnly";
 $stretch: 75% 100%;
-  
+
 @mixin fontFaceVariable(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $fontDir: $fontDir,
   $type: $type,
   $stretch: $stretch,
@@ -94,11 +94,11 @@ $stretch: 75% 100%;
 }
 
 @mixin fontFaceVariableCustom(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/packages/changa/scss/mixins.scss
+++ b/packages/changa/scss/mixins.scss
@@ -62,17 +62,17 @@ $unicodeRangeValues: (U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+0
   }
 }
 
-$fontName: "ChangaVariable";
-$weight: 200 800;
+$fontNameVariable: "ChangaVariable";
+$weightVariable: 200 800;
 $type: "wghtOnly";
 $stretch: null;
-  
+
 @mixin fontFaceVariable(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $fontDir: $fontDir,
   $type: $type,
   $stretch: $stretch,
@@ -94,11 +94,11 @@ $stretch: null;
 }
 
 @mixin fontFaceVariableCustom(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/templates/scss.ts
+++ b/scripts/templates/scss.ts
@@ -67,17 +67,17 @@ $unicodeRangeValues: (<%= defUnicode %>);
   }
 }
 
-<% if (variableFlag) { %>$fontName: "<%= fontName %>Variable";
-$weight: <%= variableWeight %>;
+<% if (variableFlag) { %>$fontNameVariable: "<%= fontName %>Variable";
+$weightVariable: <%= variableWeight %>;
 $type: "wghtOnly";
 $stretch: <%= variableWdth %>;
-  
+
 @mixin fontFaceVariable(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $fontDir: $fontDir,
   $type: $type,
   $stretch: $stretch,
@@ -99,11 +99,11 @@ $stretch: <%= variableWdth %>;
 }
 
 @mixin fontFaceVariableCustom(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/tests/google/data/cabin/scss/mixins.scss
+++ b/scripts/tests/google/data/cabin/scss/mixins.scss
@@ -62,17 +62,17 @@ $unicodeRangeValues: (U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+0
   }
 }
 
-$fontName: "CabinVariable";
-$weight: 400 700;
+$fontNameVariable: "CabinVariable";
+$weightVariable: 400 700;
 $type: "wghtOnly";
 $stretch: 75% 100%;
-  
+
 @mixin fontFaceVariable(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $fontDir: $fontDir,
   $type: $type,
   $stretch: $stretch,
@@ -94,11 +94,11 @@ $stretch: 75% 100%;
 }
 
 @mixin fontFaceVariableCustom(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/tests/google/data/changa/scss/mixins.scss
+++ b/scripts/tests/google/data/changa/scss/mixins.scss
@@ -62,17 +62,17 @@ $unicodeRangeValues: (U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+0
   }
 }
 
-$fontName: "ChangaVariable";
-$weight: 200 800;
+$fontNameVariable: "ChangaVariable";
+$weightVariable: 200 800;
 $type: "wghtOnly";
 $stretch: null;
-  
+
 @mixin fontFaceVariable(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $fontDir: $fontDir,
   $type: $type,
   $stretch: $stretch,
@@ -94,11 +94,11 @@ $stretch: null;
 }
 
 @mixin fontFaceVariableCustom(
-  $fontName: $fontName,
+  $fontName: $fontNameVariable,
   $fontId: $fontId,
   $style: $style,
   $display: $display,
-  $weight: $weight,
+  $weight: $weightVariable,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues


### PR DESCRIPTION
While I was trying to debug #424 I noticed that the default values of the variable font interfere with the default values of the normal font. Therefore I created this PR which makes sure all variable names are unique.

A quick search revealed that there are about 200 more `fontFaceVariable()` definitions which probably also cause naming conflicts. Do we need to update all those manually?