### PR TITLE
chore(website): add more fonts with overlap issues

### DIFF
--- a/website/src/components/FontPreview.tsx
+++ b/website/src/components/FontPreview.tsx
@@ -81,7 +81,7 @@ export const FontPreview = ({
   const selectHeadingColor = useColorModeValue("gray.500", "gray.100");
 
   // Refer to https://github.com/fontsource/fontsource/issues/243
-  const affectedVariableFonts = ["exo-2", "inter"];
+  const affectedVariableFonts = ["exo-2", "inter", "jost", "montserrat"];
 
   return (
     <>


### PR DESCRIPTION
Adds Montserrat and Jost to the list of affected fonts for overlap issues. A disclaimer is shown on the website that recommends the usage of variable fonts.

Closes #424.