### PR TITLE
fix: typeerrors introduced in #421 and #432

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "mass-publish publish patch",
     "deploy:ci": "mass-publish publish patch --yes",
     "format": "yarn format:scripts && yarn format:packages",
-    "format:scripts": "prettier --write ./scripts/**/*.{js,jsx,ts,tsx,json,md} && prettier --write ./tests/**/*.{js,jsx,ts,tsx}",
+    "format:scripts": "prettier --write ./scripts/**/*.{js,jsx,ts,tsx,json,md}",
     "format:packages": "dprint fmt",
     "lint": "manypkg run scripts lint",
     "postinstall": "manypkg check",

--- a/scripts/google/download-google.ts
+++ b/scripts/google/download-google.ts
@@ -12,11 +12,13 @@ fs.ensureDirSync("packages");
 fs.ensureDirSync("scripts/temp_packages");
 
 // Create an async queue object
-const processQueue = async (fontId: string, cb: () => void) => {
+const processQueue = async (fontId: string) => {
   console.log(`Downloading ${fontId}`);
   await run(fontId, force);
   console.log(`Finished processing ${fontId}`);
-  cb();
+  Promise.resolve().catch(error => {
+    throw error;
+  });
 };
 
 // EventEmitter listener is usually set at a default limit of 10, below chosen 12 concurrent workers


### PR DESCRIPTION
Seems like new TypeErrors were getting called in https://github.com/fontsource/fontsource/actions/runs/1826963746 after the update in #421 and #432. This updates the async code in `download-google.ts` to use promises instead of callbacks. 

Also fixed a Prettier script since tests have moved to a new location.