### PR TITLE
fix: gracefully handle any read errors to fix builds

### DIFF
--- a/scripts/generic/rebuilder.ts
+++ b/scripts/generic/rebuilder.ts
@@ -26,47 +26,53 @@ interface UnicodeRange {
 
 directories.forEach(directory => {
   const fontDir = `./packages/${directory}`;
-  const metadata: Metadata = jsonfile.readFileSync(`${fontDir}/metadata.json`);
+  try {
+    const metadata: Metadata = jsonfile.readFileSync(
+      `${fontDir}/metadata.json`
+    );
 
-  let unicodeRange: UnicodeRange = {};
-  if (fs.existsSync(`${fontDir}/unicode.json`)) {
-    unicodeRange = jsonfile.readFileSync(`${fontDir}/unicode.json`);
-  }
+    let unicodeRange: UnicodeRange = {};
+    if (fs.existsSync(`${fontDir}/unicode.json`)) {
+      unicodeRange = jsonfile.readFileSync(`${fontDir}/unicode.json`);
+    }
 
-  // Rebuild only non-Google fonts
-  if (metadata.type !== "google") {
-    const packageJSONData = jsonfile.readFileSync(`${fontDir}/package.json`);
+    // Rebuild only non-Google fonts
+    if (metadata.type !== "google") {
+      const packageJSONData = jsonfile.readFileSync(`${fontDir}/package.json`);
 
-    // Clear directory
-    fs.copySync(`${fontDir}/files`, `./scripts/temp_packages/${directory}`);
-    fs.emptyDirSync(fontDir);
-    fs.copySync(`./scripts/temp_packages/${directory}`, `./${fontDir}/files`);
-    fs.removeSync(`./scripts/temp_packages/${directory}`);
+      // Clear directory
+      fs.copySync(`${fontDir}/files`, `./scripts/temp_packages/${directory}`);
+      fs.emptyDirSync(fontDir);
+      fs.copySync(`./scripts/temp_packages/${directory}`, `./${fontDir}/files`);
+      fs.removeSync(`./scripts/temp_packages/${directory}`);
 
-    // Create object to store all necessary data to run package function
-    const fontObject = {
-      fontId: metadata.fontId,
-      fontName: metadata.fontName,
-      subsets: metadata.subsets,
-      weights: metadata.weights.map(weight => Number(weight)),
-      styles: metadata.styles,
-      defSubset: metadata.defSubset,
-      unicodeRange,
-      variable: false,
-      lastModified: metadata.lastModified,
-      version: metadata.version,
-      category: metadata.category,
-      source: metadata.source,
-      license: metadata.license,
-      type: metadata.type,
+      // Create object to store all necessary data to run package function
+      const fontObject = {
+        fontId: metadata.fontId,
+        fontName: metadata.fontName,
+        subsets: metadata.subsets,
+        weights: metadata.weights.map(weight => Number(weight)),
+        styles: metadata.styles,
+        defSubset: metadata.defSubset,
+        unicodeRange,
+        variable: false,
+        lastModified: metadata.lastModified,
+        version: metadata.version,
+        category: metadata.category,
+        source: metadata.source,
+        license: metadata.license,
+        type: metadata.type,
 
-      fontDir,
-      packageVersion: packageJSONData.version,
-    };
+        fontDir,
+        packageVersion: packageJSONData.version,
+      };
 
-    // Generate files (true for rebuildFlag)
-    packager(fontObject, true);
+      // Generate files (true for rebuildFlag)
+      packager(fontObject, true);
 
-    console.log(`Finished processing ${metadata.fontId}.`);
+      console.log(`Finished processing ${metadata.fontId}.`);
+    }
+  } catch (error) {
+    console.error(error);
   }
 });

--- a/scripts/utils/algolia-index.ts
+++ b/scripts/utils/algolia-index.ts
@@ -13,12 +13,16 @@ const indexArray: Metadata[] = [];
 // Copy all metadatas into one array
 directories.forEach(directory => {
   const fontDir = `./packages/${directory}`;
-  const metadata = jsonfile.readFileSync(`${fontDir}/metadata.json`);
-  metadata.objectID = metadata.fontId;
-  if (metadata.variable) {
-    metadata.variable = true;
+  try {
+    const metadata = jsonfile.readFileSync(`${fontDir}/metadata.json`);
+    metadata.objectID = metadata.fontId;
+    if (metadata.variable) {
+      metadata.variable = true;
+    }
+    indexArray.push(metadata);
+  } catch (error) {
+    console.error(error);
   }
-  indexArray.push(metadata);
 });
 
 // Written as it is used by the website getStaticPaths

--- a/scripts/utils/fontlist-generator.ts
+++ b/scripts/utils/fontlist-generator.ts
@@ -20,34 +20,37 @@ interface Metadata {
 
 directories.forEach(directory => {
   const fontDir = `./packages/${directory}`;
-  const metadata: Metadata = jsonfile.readFileSync(`${fontDir}/metadata.json`);
-  const object = { [metadata.fontId]: metadata.type };
-  fontlist.push(object);
 
-  switch (metadata.type) {
-    case "league": {
-      league.push(metadata.fontId);
+  try {
+    const metadata: Metadata = jsonfile.readFileSync(
+      `${fontDir}/metadata.json`
+    );
+    const object = { [metadata.fontId]: metadata.type };
+    fontlist.push(object);
 
-      break;
+    switch (metadata.type) {
+      case "league": {
+        league.push(metadata.fontId);
+        break;
+      }
+      case "icons": {
+        icons.push(metadata.fontId);
+        break;
+      }
+      case "other": {
+        other.push(metadata.fontId);
+        break;
+      }
+      case "google": {
+        // Empty to prevent calling unknown type catch
+        break;
+      }
+      default: {
+        console.log(`${metadata.fontId} has unknown type ${metadata.type}.`);
+      }
     }
-    case "icons": {
-      icons.push(metadata.fontId);
-
-      break;
-    }
-    case "other": {
-      other.push(metadata.fontId);
-
-      break;
-    }
-    case "google": {
-      // Empty to prevent calling unknown type catch
-
-      break;
-    }
-    default: {
-      console.log(`${metadata.fontId} has unknown type ${metadata.type}.`);
-    }
+  } catch (error) {
+    console.error(error);
   }
 });
 


### PR DESCRIPTION
I have no clue why league gothic metadata reads are failing in CI with ENOENT. It works fine on local builds and that confuses me since the file does exist.

Rather than failing the build, I'll try to gracefully handle the situation using try catch. It shouldn't affect any other fonts but league gothic is probably not going to see any updates for the time being.