### PR TITLE
fix(repo): resolve mdx errors affecting ts files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,5 @@ yarn.lock
 jest.config.js
 tests/coverage
 coverage
-api
-website
 packages
 .eslintrc.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,3 @@
 yarn.lock
-website
-api
 coverage
 packages

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -26,10 +26,15 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/typescript",
     "plugin:import/warnings",
-    "plugin:mdx/recommended",
     "next",
     "next/core-web-vitals",
     "plugin:prettier/recommended",
+  ],
+  overrides: [
+    {
+      files: "*.mdx",
+      extends: "plugin:mdx/recommended", // ESLint Parser/Plugin for MDX
+    },
   ],
   rules: {
     "@typescript-eslint/explicit-module-boundary-types": "off",


### PR DESCRIPTION
MDX eslint errors were affecting normal TS files. This adds an override to the configs to only run MDX rules on only MDX files
