### PR TITLE
fix(repo): fix gitignore for #461

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ api/dist
 *.tsbuildinfo
 
 # No binary font files
-.ttf
-.otf
-.woff
-.woff2
+*.ttf
+*.otf
+*.woff
+*.woff2


### PR DESCRIPTION
I somehow wrote the wrong glob for the gitignore. This corrects it so it affects file extensions, not directories.