### PR TITLE
fix: temporarily force download all google fonts

### DIFF
--- a/.github/workflows/cron-run.yml
+++ b/.github/workflows/cron-run.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn parser:variable
 
       - name: Build fonts
-        run: yarn build:google
+        run: yarn build:google-force
 
       - name: Generate fontlist
         run: yarn util:fontlist

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn parser:variable
 
       - name: Build fonts # Build all updated Google Fonts in repository
-        run: yarn build:google
+        run: yarn build:google-force
 
       - name: Generate fontlist # Generate FONTLIST.json and FONTLIST.md
         run: yarn util:fontlist


### PR DESCRIPTION
I didn't account for the fact that fonts can be updated on Fontsource's end without Google updating their binary files (in relation to #456 and #464). Now that we are not storing binary files, we have to figure out which projects are getting bumped on Fontsource's end and then download their relevant font files.

This temporarily enables the force flag for all builds till we reach a solution.