### PR TITLE
Resolve new font check errors

### DIFF
--- a/.github/workflows/cron-run.yml
+++ b/.github/workflows/cron-run.yml
@@ -57,6 +57,18 @@ jobs:
           commit_message: "chore(build): update packages [Weekly]"
         continue-on-error: true
 
+      - name: Check font files # Detects if all binaries are downloaded successfully and in the right place
+        run: yarn util:run-check
+
+      - name: If error, commit again before publishing
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: "fontsource-bot"
+          commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): resolve file check errors [Weekly]"
+        continue-on-error: true
+
       - name: Configure CI Git
         run: |
           git config --global user.email "83556432+fontsource-bot@users.noreply.github.com"

--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -56,3 +56,15 @@ jobs:
           commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
           commit_message: "chore(build): update packages [Force Rebuild]"
         continue-on-error: true
+
+      - name: Check font files # Detects if all binaries are downloaded successfully and in the right place
+        run: yarn util:run-check
+
+      - name: If error, commit again before publishing
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: "fontsource-bot"
+          commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): resolve file check errors [Force Rebuild]"
+        continue-on-error: true

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -57,6 +57,18 @@ jobs:
           commit_message: "chore(build): update packages [Manual]"
         continue-on-error: true
 
+      - name: Check font files # Detects if all binaries are downloaded successfully and in the right place
+        run: yarn util:run-check
+
+      - name: If error, commit again before publishing
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: "fontsource-bot"
+          commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): resolve file check errors [Manual]"
+        continue-on-error: true
+
       - name: Configure CI Git
         run: |
           git config --global user.email "83556432+fontsource-bot@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "readme-update:google": "ts-node scripts/google/google-readme-updater.ts",
     "util:algolia": "ts-node scripts/utils/algolia-index.ts",
     "util:fontlist": "ts-node scripts/utils/fontlist-generator.ts",
+    "util:run-check": "ts-node scripts/google/run-checks.ts",
     "util:generic-renamer": "ts-node scripts/generic/renamer.ts",
     "util:package-json-rebuild": "ts-node scripts/utils/package-json-rebuild.ts",
     "util:subsets": "ts-node scripts/utils/subset-list.ts",

--- a/scripts/google/download-google.ts
+++ b/scripts/google/download-google.ts
@@ -4,12 +4,7 @@ import fs from "fs-extra";
 import { APIv2, APIVariable } from "google-font-metadata";
 import { EventEmitter } from "events";
 
-import {
-  downloadFileCheck,
-  findChangedPackages,
-} from "scripts/utils/file-check";
 import { run } from "./run";
-import { deleteDuplicates, duplicates } from "./new-font-check";
 
 const force = process.argv[2];
 
@@ -31,44 +26,12 @@ const processQueue = async (fontId: string) => {
   });
 };
 
-/**
- * Function that force downloads the font as it comes from a failing font file check.
- *
- * @param fontId font to be processed
- */
-const processQueueCheck = async (fontId: string) => {
-  if (fontId in APIv2) {
-    console.log(`Downloading ${fontId} [QUEUECHECK]`);
-    await run(fontId, "force");
-    console.log(`Finished processing ${fontId} [QUEUECHECK]`);
-  } else {
-    throw new Error(`${fontId} not a Google Font! [QUEUECHECK]`);
-  }
-  Promise.resolve().catch(error => {
-    throw error;
-  });
-};
-
 // EventEmitter listener is usually set at a default limit of 10, below chosen 12 concurrent workers
 EventEmitter.defaultMaxListeners = 0;
 
 const queue = async.queue(processQueue, 3);
-const queueCheck = async.queue(processQueueCheck, 3);
 
 queue.drain(async () => {
-  console.log("\nChecking font files...");
-  const changedPackages = downloadFileCheck(await findChangedPackages());
-  console.log(changedPackages);
-  for (const changedPackage of changedPackages) {
-    queueCheck.push(changedPackage);
-  }
-
-  // If Google adds an existing generic font, there will be duplicates in two directories
-  // This deletes the duplicate font
-  const deletedDuplicates = deleteDuplicates(duplicates);
-  if (deletedDuplicates.length > 0)
-    console.log(`Deleted duplicate fonts ${deletedDuplicates}.`);
-
   console.log(
     `All ${Object.keys(APIv2).length} Google Fonts have been processed.`
   );
@@ -79,16 +42,6 @@ queue.drain(async () => {
 
 queue.error((err, fontid) => {
   console.error(`${fontid} experienced an error.`, err);
-});
-
-queueCheck.drain(async () => {
-  console.log("Re-checking all fonts... [QUEUECHECK]");
-  downloadFileCheck(await findChangedPackages(), true); // This time will throw and fail build if fails
-  console.log("Success. [QUEUECHECK]");
-});
-
-queueCheck.error((err, fontid) => {
-  console.error(`${fontid} experienced an error. [QUEUECHECK]`, err);
 });
 
 // Testing

--- a/scripts/google/new-font-check.ts
+++ b/scripts/google/new-font-check.ts
@@ -1,10 +1,17 @@
 import fs from "node:fs";
+
 import _ from "lodash";
 import path from "node:path";
 import { getDirectories } from "scripts/utils/utils";
 
-// Google may sometimes push a new font that already exists in the generic folder
-// This checks if there are any duplicates between the two font folders and purges the duplicate from generic
+/**
+ * Google may sometimes push a new font that already exists in the generic folder
+ * This checks if there are any duplicates between the two font folders and purges the duplicate from generic
+ */
+
+/**
+ * Gets all directories in all font folders
+ */
 const directories = [
   ...getDirectories("google"),
   ...getDirectories("league"),
@@ -12,7 +19,11 @@ const directories = [
   ...getDirectories("other"),
 ];
 
-// Finds duplicates between the directories
+/**
+ * Find all the duplicate values in the given array
+ * @param dirs array of directory names
+ * @returns the duplicate values
+ */
 const findDuplicates = (dirs: string[]) =>
   _.filter(dirs, (value, index, iteratee) =>
     _.includes(iteratee, value, index + 1)
@@ -20,7 +31,11 @@ const findDuplicates = (dirs: string[]) =>
 
 const duplicates = findDuplicates(directories);
 
-// Delete all duplicate dirs
+/**
+ * Delete all the duplicate directories from the font folder
+ * @param duplicateDirs array of directory names
+ * @returns
+ */
 const deleteDuplicates = (duplicateDirs: string[]): string[] => {
   duplicateDirs.forEach(dir => {
     try {

--- a/scripts/google/run-checks.ts
+++ b/scripts/google/run-checks.ts
@@ -1,0 +1,63 @@
+import async from "async";
+import { APIv2 } from "google-font-metadata";
+
+import {
+  downloadFileCheck,
+  findChangedPackages,
+} from "scripts/utils/file-check";
+import { deleteDuplicates, duplicates } from "./new-font-check";
+import { run } from "./run";
+
+/**
+ * Function that force downloads the font as it comes from a failing font file check.
+ *
+ * @param fontId font to be processed
+ */
+const processQueueCheck = async (fontId: string) => {
+  if (fontId in APIv2) {
+    console.log(`Downloading ${fontId} [QUEUECHECK]`);
+    await run(fontId, "force");
+    console.log(`Finished processing ${fontId} [QUEUECHECK]`);
+  } else {
+    throw new Error(`${fontId} not a Google Font! [QUEUECHECK]`);
+  }
+  Promise.resolve().catch(error => {
+    throw error;
+  });
+};
+
+/**
+ * Async queue to run all checks.
+ */
+const queueCheck = async.queue(processQueueCheck, 3);
+
+// When queue is finished
+queueCheck.drain(async () => {
+  console.log("Re-checking all fonts... [QUEUECHECK]");
+  downloadFileCheck(await findChangedPackages(), true); // This time will throw and fail build if fails
+  console.log("Success. [QUEUECHECK]");
+});
+
+queueCheck.error((err, fontid) => {
+  console.error(`${fontid} experienced an error. [QUEUECHECK]`, err);
+});
+
+/**
+ * Main function that runs when this file is called directly with ts-node. Driver logic.
+ */
+const runChecks = async () => {
+  console.log("\nChecking font files...");
+  const changedPackages = downloadFileCheck(await findChangedPackages());
+  console.log(changedPackages);
+  for (const changedPackage of changedPackages) {
+    queueCheck.push(changedPackage);
+  }
+
+  // If Google adds an existing generic font, there will be duplicates in two directories
+  // This deletes the duplicate font
+  const deletedDuplicates = deleteDuplicates(duplicates);
+  if (deletedDuplicates.length > 0)
+    console.log(`Deleted duplicate fonts ${deletedDuplicates}.`);
+};
+
+runChecks();

--- a/scripts/tests/google/new-font-check.test.ts
+++ b/scripts/tests/google/new-font-check.test.ts
@@ -9,24 +9,24 @@ describe("New font check", () => {
       fonts: {
         google: {
           abel: {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
           cabin: {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
           "noto-sans-jp": {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
         },
         other: {
           abel: {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
           "not-cabin": {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
           "noto-sans-jp": {
-            "package.json": "{}",
+            "package.json": '{"version": "1.0.0"}',
           },
         },
       },

--- a/scripts/utils/file-check.ts
+++ b/scripts/utils/file-check.ts
@@ -42,9 +42,11 @@ const downloadFileCheck = (
     if (fs.existsSync(path.join(changedPackage, "package.json"))) {
       // Check if files directory exists
       if (!fs.existsSync(path.join(changedPackage, "files"))) {
+        const message = `${changedPackage}/files does not exist`;
         if (throwError) {
-          throw new Error(`${changedPackages}/files does not exist`);
+          throw new Error(message);
         } else {
+          console.log(message);
           fontIds.push(path.basename(changedPackage));
         }
       }
@@ -57,9 +59,11 @@ const downloadFileCheck = (
       // Check binary files
       for (const file of files) {
         if (!fs.existsSync(file)) {
+          const message = `${file} does not exist`;
           if (throwError) {
-            throw new Error(`${file} does not exist`);
+            throw new Error(message);
           } else {
+            console.log(`${file} does not exist`);
             fontIds.push(path.basename(changedPackage));
           }
         }


### PR DESCRIPTION
Resolves #479, but also moves the font checking scripts to run after the first round of commits is made. This is because findChangedPackages is dependent on whether a file is committed or not. This led to no changes being detected even if there are changes, only for it to be picked up on the next CI action.