### PR TITLE
perf(website): move PageContainer to _app page

### DIFF
--- a/website/src/components/PageContainer.tsx
+++ b/website/src/components/PageContainer.tsx
@@ -1,4 +1,5 @@
 import { Box, FlexProps, useColorModeValue } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 import { PropsWithChildren, useEffect, useState } from "react";
 
 import { Container } from "./Container";
@@ -6,19 +7,9 @@ import { Footer } from "./Footer";
 import { Navbar } from "./Navbar/Navbar";
 import { Sidebar } from "./Sidebar";
 
-interface SidebarProp {
-  ifSidebar?: boolean;
-  ifDocs: boolean;
-}
+export type PageContainerProps = PropsWithChildren<FlexProps>;
 
-export type PageContainerProps = PropsWithChildren<FlexProps> & SidebarProp;
-
-export const PageContainer = ({
-  ifSidebar = true,
-  ifDocs,
-  children,
-  ...props
-}: PageContainerProps) => {
+export const PageContainer = ({ children, ...props }: PageContainerProps) => {
   const bgColor = useColorModeValue("white", "gray.900");
   const color = useColorModeValue("black", "white");
 
@@ -28,6 +19,15 @@ export const PageContainer = ({
   useEffect(() => {
     setShowSidebar(true);
   }, []);
+
+  const { pathname } = useRouter();
+
+  if (pathname === "/_error") return <>{children}</>;
+
+  const ifDocs = pathname.startsWith("/docs");
+  const ifFonts = pathname.startsWith("/fonts");
+
+  const ifSidebar = ifDocs || ifFonts;
 
   let sidebar;
   if (showSidebar) {

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
+import { PageContainer } from "../components/PageContainer";
 import theme from "../theme";
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -17,7 +18,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <Component {...pageProps} key={asPath} />
+      <PageContainer>
+        <Component {...pageProps} key={asPath} />
+      </PageContainer>
     </ChakraProvider>
   );
 }

--- a/website/src/pages/docs/[...slug].tsx
+++ b/website/src/pages/docs/[...slug].tsx
@@ -9,7 +9,6 @@ import remarkGfm from "remark-gfm";
 
 import { Main } from "../../components/Main";
 import CustomMdxComponents from "../../components/MdxComponents";
-import { PageContainer } from "../../components/PageContainer";
 import { DOCS_PATH, docsFilePaths } from "../../utils/mdxUtils";
 
 // MDX components since Webpack isn't importing them
@@ -19,7 +18,7 @@ const components = {
 
 export default function DocsPage({ source, frontMatter }) {
   return (
-    <PageContainer ifDocs={true}>
+    <>
       <Head>
         <title>Fontsource | {frontMatter.title}</title>
       </Head>
@@ -34,7 +33,7 @@ export default function DocsPage({ source, frontMatter }) {
       >
         <MDXRemote {...source} components={components} />
       </Main>
-    </PageContainer>
+    </>
   );
 }
 

--- a/website/src/pages/fonts/[font].tsx
+++ b/website/src/pages/fonts/[font].tsx
@@ -14,7 +14,6 @@ import {
 } from "../../@types/[font]";
 import { FontPreview } from "../../components/FontPreview";
 import { Main } from "../../components/Main";
-import { PageContainer } from "../../components/PageContainer";
 import fontListAlgolia from "../../configs/algolia.json";
 // Import when testing and don't want to build 1000+ pages
 // import fontListAlgolia from "../../configs/fontListTemp.json";
@@ -40,17 +39,9 @@ export default function FontPage({
           <meta name="robots" content="noindex" />
           <title>Loading... | Fontsource</title>
         </Head>
-        <PageContainer ifDocs={false}>
-          <Main
-            width="100%"
-            mr={{ md: 0 }}
-            pr={{ md: 0 }}
-            mb={12}
-            ml={{ md: 8 }}
-          >
-            <Skeleton height="50px" />
-          </Main>
-        </PageContainer>
+        <Main width="100%" mr={{ md: 0 }} pr={{ md: 0 }} mb={12} ml={{ md: 8 }}>
+          <Skeleton height="50px" />
+        </Main>
       </>
     );
   }
@@ -60,15 +51,13 @@ export default function FontPage({
       <Head>
         <title>{metadata.fontName} | Fontsource</title>
       </Head>
-      <PageContainer ifDocs={false}>
-        <Main width="100%" mr={{ md: 0 }} pr={{ md: 0 }} mb={12} ml={{ md: 8 }}>
-          <FontPreview
-            defPreviewText={defPreviewText}
-            metadata={metadata}
-            fontCss={fontCss}
-          />
-        </Main>
-      </PageContainer>
+      <Main width="100%" mr={{ md: 0 }} pr={{ md: 0 }} mb={12} ml={{ md: 8 }}>
+        <FontPreview
+          defPreviewText={defPreviewText}
+          metadata={metadata}
+          fontCss={fontCss}
+        />
+      </Main>
     </>
   );
 }

--- a/website/src/pages/fonts/index.tsx
+++ b/website/src/pages/fonts/index.tsx
@@ -4,11 +4,10 @@ import { CarbonAd } from "website/src/components/CarbonAd";
 
 import { Container } from "../../components/Container";
 import { Main } from "../../components/Main";
-import { PageContainer } from "../../components/PageContainer";
 import { SearchModal } from "../../components/Search/Modal";
 
 const Index = () => (
-  <PageContainer ifDocs={false} ifSidebar={true}>
+  <>
     <Head>
       <title>Preview | Fontsource</title>
     </Head>
@@ -25,7 +24,7 @@ const Index = () => (
       </Container>
       <CarbonAd />
     </Main>
-  </PageContainer>
+  </>
 );
 
 export default Index;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -3,10 +3,9 @@ import Head from "next/head";
 
 import { Main } from "../components/Main";
 import { NextChakraLink } from "../components/NextChakraLink";
-import { PageContainer } from "../components/PageContainer";
 
 const Index = () => (
-  <PageContainer ifDocs={false} ifSidebar={false}>
+  <>
     <Head>
       <title>Fontsource</title>
     </Head>
@@ -33,7 +32,7 @@ const Index = () => (
         </NextChakraLink>
       </SimpleGrid>
     </Main>
-  </PageContainer>
+  </>
 );
 
 export default Index;


### PR DESCRIPTION
This moves where the `PageContainer` component is used into the `_app` page to prevent remounting of the `PageContainer`. It includes the header and side navigation and should be especially useful for the fonts page so it's not rerendering however many thousand fonts each time.