### PR TITLE
ci: fix pnpm exec gfm command

### DIFF
--- a/.github/workflows/cron-run.yml
+++ b/.github/workflows/cron-run.yml
@@ -27,12 +27,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Fetch API # Calls Google Font Metadata to fetch the latest data from Google's Developer API
-        run: npx gfm generate $GOOGLE_API_KEY
+        run: pnpm --filter scripts exec gfm generate $GOOGLE_API_KEY
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Parse API # Process generated API data
-        run: npx gfm parse
+        run: pnpm --filter scripts exec gfm parse
 
       - name: Build fonts
         run: pnpm run build:google

--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -27,12 +27,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Fetch API # Calls Google Font Metadata to fetch the latest data from Google's Developer API
-        run: npx gfm generate $GOOGLE_API_KEY
+        run: pnpm --filter scripts exec gfm generate $GOOGLE_API_KEY
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Parse API # Process ALL generated API data
-        run: npx gfm parse --force
+        run: pnpm --filter scripts exec gfm parse --force
 
       - name: Build fonts (Google) # Forcefully rebuild all Google Fonts in repository without skipping any fonts
         run: pnpm run build:google-force

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -30,12 +30,12 @@ jobs:
         run: pnpm i
 
       - name: Fetch API # Calls Google Font Metadata to fetch the latest data from Google's Developer API
-        run: npx gfm generate $GOOGLE_API_KEY
+        run: pnpm --filter scripts exec gfm generate $GOOGLE_API_KEY
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Parse API # Process generated API data
-        run: npx gfm parse
+        run: pnpm --filter scripts exec gfm parse
 
       - name: Build fonts # Build all updated Google Fonts in repository
         run: pnpm run build:google


### PR DESCRIPTION
`gfm` wasn't getting called since pnpm protects against phantom dep usage compared to yarn.