### PR TITLE
ci: add republish script

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,88 @@
+name: Build and Release [Manual Republish] # When publish fails mid action
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    if: github.actor == 'ayuhito'
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+
+      - name: Enable PNPM
+        uses: pnpm/action-setup@v2
+
+      - name: Set node version to 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install
+        run: pnpm i
+
+      - name: Fetch API # Calls Google Font Metadata to fetch the latest data from Google's Developer API
+        run: pnpm --filter scripts exec gfm generate $GOOGLE_API_KEY
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+
+      - name: Parse API # Process generated API data
+        run: pnpm --filter scripts exec gfm parse
+
+      - name: Build fonts # Build all updated Google Fonts in repository
+        run: pnpm run build:google
+
+      - name: Generate fontlist # Generate FONTLIST.json and FONTLIST.md
+        run: pnpm run util:fontlist
+
+      - name: Generate Algolia index # Generate Algolia search index for website
+        run: pnpm run util:algolia
+        env:
+          ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
+
+      - name: Lint files
+        run: pnpm run lint
+
+      - name: Format files
+        run: pnpm run format
+
+      - name: Stage, commit and push files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: "fontsource-bot"
+          commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): update packages [Manual]"
+        continue-on-error: true
+
+      - name: Check font files # Detects if all binaries are downloaded successfully and in the right place
+        run: pnpm run util:run-check
+
+      - name: If error, commit again before publishing
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: "fontsource-bot"
+          commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
+          commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
+          commit_message: "chore(build): resolve file check errors [Manual]"
+        continue-on-error: true
+
+      - name: Configure CI Git
+        run: |
+          git config --global user.email "83556432+fontsource-bot@users.noreply.github.com"
+          git config --global user.name "fontsource-bot"
+
+      - name: Publish package # Call mass-publish
+        run: pnpm run deploy:republish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,4 +1,4 @@
-name: Build and Release [Manual Republish] # When publish fails mid action
+name: Build and Release [Force Rebuild] [Manual Republish] # Rebuilds and republishes
 
 on: [workflow_dispatch]
 
@@ -26,19 +26,19 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Install
-        run: pnpm i
-
       - name: Fetch API # Calls Google Font Metadata to fetch the latest data from Google's Developer API
         run: pnpm --filter scripts exec gfm generate $GOOGLE_API_KEY
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
-      - name: Parse API # Process generated API data
-        run: pnpm --filter scripts exec gfm parse
+      - name: Parse API # Process ALL generated API data
+        run: pnpm --filter scripts exec gfm parse --force
 
-      - name: Build fonts # Build all updated Google Fonts in repository
-        run: pnpm run build:google
+      - name: Build fonts (Google) # Forcefully rebuild all Google Fonts in repository without skipping any fonts
+        run: pnpm run build:google-force
+
+      - name: Rebuild non-Google fonts # Forcefully rebuild all non-Google fonts in repository with generic packager
+        run: pnpm run build:generic-force
 
       - name: Generate fontlist # Generate FONTLIST.json and FONTLIST.md
         run: pnpm run util:fontlist
@@ -47,9 +47,6 @@ jobs:
         run: pnpm run util:algolia
         env:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
-
-      - name: Lint files
-        run: pnpm run lint
 
       - name: Format files
         run: pnpm run format
@@ -60,7 +57,7 @@ jobs:
           commit_user_name: "fontsource-bot"
           commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
           commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
-          commit_message: "chore(build): update packages [Manual]"
+          commit_message: "chore(build): update packages [Force Rebuild]"
         continue-on-error: true
 
       - name: Check font files # Detects if all binaries are downloaded successfully and in the right place
@@ -72,7 +69,7 @@ jobs:
           commit_user_name: "fontsource-bot"
           commit_user_email: "83556432+fontsource-bot@users.noreply.github.com"
           commit_author: "fontsource-bot <83556432+fontsource-bot@users.noreply.github.com>"
-          commit_message: "chore(build): resolve file check errors [Manual]"
+          commit_message: "chore(build): resolve file check errors [Force Rebuild]"
         continue-on-error: true
 
       - name: Configure CI Git

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:google-force": "tsx scripts/google/download-google.ts force",
     "deploy": "mass-publish publish patch",
     "deploy:ci": "mass-publish publish patch --yes",
+    "deploy:republish": "mass-publish publish from-package --yes --force-publish",
     "format": "pnpm run format:scripts && pnpm run format:fonts",
     "format:scripts": "prettier --write ./scripts/**/*.{js,jsx,ts,tsx,json,md}",
     "format:fonts": "dprint fmt",


### PR DESCRIPTION
Let's us use `mass-publish publish from-package` in CI actions rather than relying on a local machine.