### PR TITLE
fix: throw on any errors for font gen

### DIFF
--- a/scripts/google/download-google.ts
+++ b/scripts/google/download-google.ts
@@ -41,7 +41,7 @@ queue.drain(async () => {
 });
 
 queue.error((err, fontid) => {
-  console.error(`${fontid} experienced an error.`, err);
+  throw new Error(`Error processing ${fontid}: ${err}`);
 });
 
 // Testing


### PR DESCRIPTION
This should fail any builds that have any failed font downloads. E.g. #541 where league gothic and ballet are experiencing a packaging error.