### PR TITLE
Fix license metadata in package.json

### DIFF
--- a/fonts/google/montserrat/package.json
+++ b/fonts/google/montserrat/package.json
@@ -6,7 +6,7 @@
   "publishConfig": { "access": "public" },
   "keywords": ["fontsource", "font", "font family", "google fonts", "Montserrat", "montserrat"],
   "author": "Lotus <declininglotus@gmail.com>",
-  "license": "MIT",
+  "license": "OFL-1.1",
   "homepage": "https://github.com/fontsource/fontsource/tree/main/fonts/google/montserrat#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/JulietaUla/Montserrat/blob/master/OFL.txt and quoting the README : 
>  The goal is to rescue what is in Montserrat and set it free, under a free, libre and open source license, the SIL Open Font License.