### PR TITLE
Add astro docs for fontsource

### DIFF
--- a/website/src/configs/docsList.json
+++ b/website/src/configs/docsList.json
@@ -95,6 +95,12 @@
     "path": "/docs/guides/sveltejs"
   },
   {
+    "key": "astro",
+    "title": "Astro",
+    "path": "https://docs.astro.build/en/guides/fonts/#using-fontsource",
+    "isExternal": "true"
+  },
+  {
     "key": "api",
     "title": "API",
     "isParent": true

--- a/website/src/configs/docsList.json
+++ b/website/src/configs/docsList.json
@@ -98,7 +98,7 @@
     "key": "astro",
     "title": "Astro",
     "path": "https://docs.astro.build/en/guides/fonts/#using-fontsource",
-    "isExternal": "true"
+    "isExternal": true
   },
   {
     "key": "api",

--- a/website/src/configs/docsList.json
+++ b/website/src/configs/docsList.json
@@ -56,6 +56,12 @@
     "path": "/docs/guides/angular"
   },
   {
+    "key": "astro",
+    "title": "Astro",
+    "path": "https://docs.astro.build/en/guides/fonts/#using-fontsource",
+    "isExternal": true
+  },
+  {
     "key": "chakra-ui",
     "title": "Chakra UI",
     "path": "https://chakra-ui.com/community/recipes/using-fonts",
@@ -93,12 +99,6 @@
     "key": "sveltejs",
     "title": "Svelte / SvelteKit",
     "path": "/docs/guides/sveltejs"
-  },
-  {
-    "key": "astro",
-    "title": "Astro",
-    "path": "https://docs.astro.build/en/guides/fonts/#using-fontsource",
-    "isExternal": true
   },
   {
     "key": "api",


### PR DESCRIPTION
Astro has support for fontsource via its ability to import node_module css.

I've added a link to the astro docs for fontsource, it's our recommendation for inlining webfonts.