### PR TITLE
fix: prevent standard variable variants from being skipped

### DIFF
--- a/scripts/google/variable.ts
+++ b/scripts/google/variable.ts
@@ -44,7 +44,7 @@ const variable = (id: string): void => {
   // full CSS Generation
   // Temporary fix for standard fonts that don't have a full variant until v5
   if (
-    fontVariable.variants.standard !== undefined &&
+    "standard" in fontVariable.variants &&
     fontVariable.variants.full === undefined
   ) {
     fontVariable.variants.full = fontVariable.variants.standard;
@@ -60,9 +60,8 @@ const variable = (id: string): void => {
         let newStyle = style;
         if ("slnt" in fontVariable.axes && style === "normal") {
           // SLNT has a different style linked to it.
-          newStyle = `oblique ${Number(fontVariable.axes.slnt.max) * -1}deg ${
-            Number(fontVariable.axes.slnt.min) * -1
-          }deg`;
+          newStyle = `oblique ${Number(fontVariable.axes.slnt.max) * -1}deg ${Number(fontVariable.axes.slnt.min) * -1
+            }deg`;
         }
         const cssStyle: string[] = [];
         font.subsets.forEach(subset => {
@@ -102,9 +101,8 @@ const variable = (id: string): void => {
         let newStyle = style;
         if ("slnt" in fontVariable.axes && style === "normal") {
           // SLNT has a different style linked to it.
-          newStyle = `oblique ${Number(fontVariable.axes.slnt.max) * -1}deg ${
-            Number(fontVariable.axes.slnt.min) * -1
-          }deg`;
+          newStyle = `oblique ${Number(fontVariable.axes.slnt.max) * -1}deg ${Number(fontVariable.axes.slnt.min) * -1
+            }deg`;
         }
         const cssStyle: string[] = [];
         font.subsets.forEach(subset => {


### PR DESCRIPTION
Amends #583, closes #581.