### PR TITLE
Added $type parameter to fontFaceVariableCustom mixin

### DIFF
--- a/scripts/templates/scss.ts
+++ b/scripts/templates/scss.ts
@@ -106,6 +106,7 @@ $stretch: <%= variableWdth %>;
   $style: $style,
   $display: $display,
   $weight: $weightVariable,
+  $type: $type,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/tests/google/data/cabin/scss/mixins.scss
+++ b/scripts/tests/google/data/cabin/scss/mixins.scss
@@ -99,6 +99,7 @@ $stretch: 75% 100%;
   $style: $style,
   $display: $display,
   $weight: $weightVariable,
+  $type: $type,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/tests/google/data/changa/scss/mixins.scss
+++ b/scripts/tests/google/data/changa/scss/mixins.scss
@@ -99,6 +99,7 @@ $stretch: null;
   $style: $style,
   $display: $display,
   $weight: $weightVariable,
+  $type: $type,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues

--- a/scripts/tests/google/data/recursive/scss/mixins.scss
+++ b/scripts/tests/google/data/recursive/scss/mixins.scss
@@ -99,6 +99,7 @@ $stretch: null;
   $style: $style,
   $display: $display,
   $weight: $weight,
+  $type: $type,
   $woff2Path: null,
   $unicodeRange: $unicodeRange,
   $unicodeRangeValues: $unicodeRangeValues


### PR DESCRIPTION
Added $type parameter to the fontFaceVariableCustom mixin, so you are able to use it for "full" and not only "wghtOnly".
This issue is also reported here: #419

`SassError: No argument named $type.`