### PR TITLE
feat: rename variable font families with a different name

### DIFF
--- a/utils/generate/package.json
+++ b/utils/generate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/generate",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "A CSS font-face generator",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",

--- a/utils/generate/src/index.ts
+++ b/utils/generate/src/index.ts
@@ -17,7 +17,7 @@ const generateFontFace = (font: FontObject) => {
   // If variable, modify output
   const { wght, stretch, slnt } = variable ?? {};
   let result = '@font-face {';
-  result += `${spacer}font-family: '${family}';`;
+  result += `${spacer}font-family: '${family}${variable ? ' Variable' : ''}';`;
 
   // If slnt is present, switch to oblique style
   result += `${spacer}font-style: ${

--- a/utils/generate/tests/__snapshots__/generate.test.ts.snap
+++ b/utils/generate/tests/__snapshots__/generate.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`generate font face > should generate a single font face with all variable axis 1`] = `
 "/* latin */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Open Sans Variable';
   font-style: oblique -25deg 15deg;
   font-display: swap;
   font-weight: 400 700;
@@ -35,7 +35,7 @@ exports[`generate font face > should generate a single font face with different 
 
 exports[`generate font face > should generate a single font face with font stretch 1`] = `
 "@font-face {
-  font-family: 'Open Sans';
+  font-family: 'Open Sans Variable';
   font-style: normal;
   font-display: swap;
   font-weight: 400;
@@ -56,7 +56,7 @@ exports[`generate font face > should generate a single font face with multiple f
 
 exports[`generate font face > should generate a single font face with slnt axis 1`] = `
 "@font-face {
-  font-family: 'Open Sans';
+  font-family: 'Open Sans Variable';
   font-style: oblique -20deg 10deg;
   font-display: swap;
   font-weight: 400;
@@ -88,7 +88,7 @@ exports[`generate font face > should generate a single font face with variable f
 
 exports[`generate font face > should generate a single font face with variable wght 1`] = `
 "@font-face {
-  font-family: 'Open Sans';
+  font-family: 'Open Sans Variable';
   font-style: normal;
   font-display: swap;
   font-weight: 400 700;

--- a/utils/generate/tsconfig.json
+++ b/utils/generate/tsconfig.json
@@ -1,42 +1,42 @@
 {
-  /* Visit https://aka.ms/tsconfig.json to read more about this file */
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.json",
-    "tests/**/*.ts",
-    "tests/**/*.json",
-    "vitest.config.ts"
-  ],
-  "exclude": [".eslintrc.cjs"],
-  "compilerOptions": {
-    /* Projects */
-    //"incremental": true,
+	/* Visit https://aka.ms/tsconfig.json to read more about this file */
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.json",
+		"tests/**/*.ts",
+		"tests/**/*.json",
+		"vitest.config.ts"
+	],
+	"exclude": [".eslintrc.cjs"],
+	"compilerOptions": {
+		/* Projects */
+		//"incremental": true,
 
-    /* Language and Environment */
-    "target": "esnext",
-    "useDefineForClassFields": true,
+		/* Language and Environment */
+		"target": "esnext",
+		"useDefineForClassFields": true,
 
-    /* Modules */
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
+		/* Modules */
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
 
-    /* Interop Constraints */
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+		/* Interop Constraints */
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
 
-    /* Type Checking */
-    "strict": true,
-    "types": ["vitest/importMeta"],
-    "isolatedModules": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
+		/* Type Checking */
+		"strict": true,
+		"types": ["vitest/importMeta"],
+		"isolatedModules": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
 
-    /* Completeness */
-    "skipLibCheck": true // Skip type checking all .d.ts files.
-  },
-  "$schema": "https://json.schemastore.org/tsconfig"
+		/* Completeness */
+		"skipLibCheck": true // Skip type checking all .d.ts files.
+	},
+	"$schema": "https://json.schemastore.org/tsconfig"
 }


### PR DESCRIPTION
Revisits #385. We determined that it makes sense to distinguish variable fonts with a different font family names. It makes writing fallbacks for older browsers much much easier.