### PR TITLE
fix: add hashbangs to start of cli scripts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"scripts": {
-		"build": "pkgroll --target=node18",
+		"build": "pkgroll --target=node18 && tsx ./scripts/add-hashbang.ts",
 		"cli": "tsx ./src/cli.ts",
 		"lint": "eslint --fix",
 		"coverage": "vitest run --coverage",
@@ -53,6 +53,7 @@
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.1.3",
 		"eslint": "^8.40.0",
+		"magic-string": "^0.30.0",
 		"pkgroll": "^1.10.0",
 		"tsx": "^3.12.7",
 		"typescript": "^5.0.4"

--- a/packages/cli/scripts/add-hashbang.ts
+++ b/packages/cli/scripts/add-hashbang.ts
@@ -1,0 +1,19 @@
+import MagicString from 'magic-string';
+import * as fs from 'node:fs';
+import { join } from 'pathe';
+
+// Until pkgroll fixes the shebang bug, this needs to be run postbuild
+
+const addHashbang = (filepath: string) => {
+	const path = join(process.cwd(), filepath);
+	const s = new MagicString(fs.readFileSync(path, 'utf8'));
+
+	// Only add the hashbang if it's not already there
+	if (!s.toString().startsWith('#!')) {
+		s.prepend('#!/usr/bin/env node\n');
+		fs.writeFileSync(path, s.toString());
+	}
+};
+
+addHashbang('dist/cli.mjs');
+addHashbang('dist/cli.cjs');

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
 	"include": [
 		"src/**/*.ts",
 		"src/**/*.json",
+		"scripts/**/*.ts",
 		"tests/**/*.ts",
 		"tests/**/*.json",
 		"vitest.config.ts"

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -6,7 +6,7 @@
 		"fontsource-publish": "./dist/cli.mjs"
 	},
 	"scripts": {
-		"build": "pkgroll --target=node14",
+		"build": "pkgroll --target=node14 && tsx ./scripts/add-hashbang.ts",
 		"dev": "pnpm run build && node ./dist/cli.mjs",
 		"lint": "eslint --fix",
 		"coverage": "vitest run --coverage",
@@ -46,6 +46,7 @@
 		"@types/parse-git-config": "^3.0.1",
 		"@types/semver": "^7.5.0",
 		"eslint": "^8.41.0",
+		"magic-string": "^0.30.0",
 		"pkgroll": "^1.9.0",
 		"tsx": "^3.12.3",
 		"typescript": "^5.0.4"

--- a/packages/publish/scripts/add-hashbang.ts
+++ b/packages/publish/scripts/add-hashbang.ts
@@ -1,0 +1,19 @@
+import MagicString from 'magic-string';
+import * as fs from 'node:fs';
+import { join } from 'pathe';
+
+// Until pkgroll fixes the shebang bug, this needs to be run postbuild
+
+const addHashbang = (filepath: string) => {
+	const path = join(process.cwd(), filepath);
+	const s = new MagicString(fs.readFileSync(path, 'utf8'));
+
+	// Only add the hashbang if it's not already there
+	if (!s.toString().startsWith('#!')) {
+		s.prepend('#!/usr/bin/env node\n');
+		fs.writeFileSync(path, s.toString());
+	}
+};
+
+addHashbang('dist/cli.mjs');
+// addHashbang('dist/cli.cjs');

--- a/packages/publish/src/hash.ts
+++ b/packages/publish/src/hash.ts
@@ -1,5 +1,5 @@
 import { createXXHash64 } from 'hash-wasm';
-import * as fs from 'fs-extra';
+import fs from 'fs-extra';
 import * as path from 'pathe';
 
 const getAllFiles = async (dir: string): Promise<string[]> => {

--- a/packages/publish/tsconfig.json
+++ b/packages/publish/tsconfig.json
@@ -3,6 +3,7 @@
 	"include": [
 		"src/**/*.ts",
 		"src/**/*.json",
+		"scripts/**/*.ts",
 		"tests/**/*.ts",
 		"tests/**/*.json",
 		"vitest.config.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       eslint:
         specifier: ^8.40.0
         version: 8.40.0
+      magic-string:
+        specifier: ^0.30.0
+        version: 0.30.0
       pkgroll:
         specifier: ^1.10.0
         version: 1.10.0(typescript@5.0.4)
@@ -189,6 +192,9 @@ importers:
       eslint:
         specifier: ^8.41.0
         version: 8.41.0
+      magic-string:
+        specifier: ^0.30.0
+        version: 0.30.0
       pkgroll:
         specifier: ^1.9.0
         version: 1.10.0(typescript@5.0.4)
@@ -506,7 +512,7 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@8.41.0)
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.41.0)
       eslint-plugin-promise: 6.1.1(eslint@8.41.0)
@@ -5870,7 +5876,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.41.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -5903,7 +5909,7 @@ packages:
       '@typescript-eslint/parser': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
       eslint: 8.41.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
     dev: true
 
   /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.40.0):
@@ -5938,7 +5944,7 @@ packages:
     dependencies:
       eslint: 8.41.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.41.0)
       eslint-plugin-react: 7.32.2(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
@@ -6009,7 +6015,7 @@ packages:
       enhanced-resolve: 5.14.0
       eslint: 8.41.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
       is-core-module: 2.12.1
@@ -6112,39 +6118,6 @@ packages:
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
-      has: 1.0.3
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.2
-      semver: 6.3.0
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.41.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -8587,7 +8560,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}


### PR DESCRIPTION
pkgroll has a bug where the node hashbang is not added when generated on Windows machines for the CLI's. This adds a small helper in the build script to manage that if there is no hashbang present in the dist CLI.