### PR TITLE
perf(publish): use queue for calculating file hashes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/cli",
-	"version": "0.2.0-beta.27",
+	"version": "0.3.0",
 	"description": "Fontsource CLI",
 	"bin": {
 		"fontsource": "./dist/cli.mjs"

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/publish",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Fontsource Publish CLI",
 	"bin": {
 		"fontsource-publish": "./dist/cli.mjs"

--- a/packages/publish/src/changed.ts
+++ b/packages/publish/src/changed.ts
@@ -6,14 +6,35 @@ import colors from 'picocolors';
 import type { ChangedFlags, ChangedList, Context, PackageJson } from './types';
 import { getPackages, mergeFlags } from './utils';
 import { getHash, hasher } from './hash';
+import PQueue from 'p-queue';
 
 // Iterate through all packages in directory and return a list of changed packages
 const getChanged = async (ctx: Context) => {
 	const changedList: ChangedList = [];
-	const newHash = await hasher();
+	// Generate 4 hasher instances
+	const hashers = await Promise.all([hasher(), hasher(), hasher(), hasher()]);
+	const queue = new PQueue({ concurrency: 8 });
+
+	const handleHash = async (
+		packagePath: string,
+		packageJson: PackageJson,
+		hasher: number
+	) => {
+		// Get hash of current package and compare with old hash
+		const hash = await getHash(packagePath, hashers[hasher]);
+		if (packageJson.publishHash !== hash || ctx.forcePublish) {
+			changedList.push({
+				name: packageJson.name,
+				hash,
+				path: packagePath,
+				version: packageJson.version,
+			});
+		}
+	};
 
 	for (const packageDir of ctx.packages) {
 		const packages = await getPackages(packageDir);
+		let hasherIndex = 0;
 		for (const packageName of packages) {
 			const packagePath = path.join(packageDir, packageName);
 
@@ -22,19 +43,13 @@ const getChanged = async (ctx: Context) => {
 				path.join(process.cwd(), packagePath, 'package.json')
 			);
 
-			// Get hash of current package and compare with old hash
-			const hash = await getHash(packagePath, newHash);
-			if (packageJson.publishHash !== hash || ctx.forcePublish) {
-				changedList.push({
-					name: packageJson.name,
-					hash,
-					path: packagePath,
-					version: packageJson.version,
-				});
-			}
+			queue.add(() => handleHash(packagePath, packageJson, hasherIndex++));
+
+			if (hasherIndex === 4) hasherIndex = 0;
 		}
 	}
 
+	await queue.onIdle();
 	return changedList;
 };
 


### PR DESCRIPTION
#677 was not sufficient and thus trying a queue + concurrency may help with speeding up generating the changelist for the publish CLI.