### PR TITLE
fix(publish): expose no verify flag and incorrect bump values

### DIFF
--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/publish",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Fontsource Publish CLI",
 	"bin": {
 		"fontsource-publish": "./dist/cli.mjs"

--- a/packages/publish/src/bump.ts
+++ b/packages/publish/src/bump.ts
@@ -43,11 +43,14 @@ export const bumpValue = (
 		if (bumpArg === 'minor') {
 			const newNum = Number(arr[1]) + 1;
 			arr[1] = String(newNum);
+			arr[2] = '0';
 			return arr.join('.');
 		}
 		if (bumpArg === 'major') {
 			const newNum = Number(arr[0]) + 1;
 			arr[0] = String(newNum);
+			arr[1] = '0';
+			arr[2] = '0';
 			return arr.join('.');
 		}
 		if (bumpArg === 'from-package') {
@@ -130,13 +133,16 @@ export const bumpPackages = async (
 	}
 
 	// Check if package versions are free of conflicts on NPM
-	const pendingObjects = [];
-	for (const pkg of bumpObjects) {
-		const newPkg = queue.add(() => verifyVersion(pkg, version));
-		pendingObjects.push(newPkg);
+	let pendingObjects;
+	if (!config.noVerify) {
+		pendingObjects = [];
+		for (const pkg of bumpObjects) {
+			const newPkg = queue.add(() => verifyVersion(pkg, version));
+			pendingObjects.push(newPkg);
+		}
 	}
 	// Wait for queue to finish
-	const verifiedObjects = await Promise.all(pendingObjects);
+	const verifiedObjects = await Promise.all(pendingObjects ?? bumpObjects);
 	consola.info(colors.bold(colors.blue('All packages verified.')));
 
 	// Print out all new versions and prompt user to continue

--- a/packages/publish/src/cli.ts
+++ b/packages/publish/src/cli.ts
@@ -52,6 +52,7 @@ cli
 	)
 	.option('--commit-message', 'Change commit message')
 	.option('--packages', 'Package directory')
+	.option('--no-verify', 'Skip version verification')
 	.action(async (version: string, opts: BumpFlags) => {
 		try {
 			await bump(version, opts);


### PR DESCRIPTION
This adds a few more tests to the bumping logic of the publish CLI which led to a couple of bugs being discovered:

- When bumping values such as `1.1.1` with minor or major, you would end up with `1.2.1` or `2.1.1` instead of `1.2.0` or `2.0.0`.
- Expose `noVerify` flag to CLI and actually skip verifying when bumping.