### PR TITLE
feat(cli): add rebuild command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/cli",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Fontsource CLI",
 	"bin": {
 		"fontsource": "./dist/cli.mjs"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -62,6 +62,11 @@ cli
 				}`
 			);
 			await processGoogle(options, fonts);
+			if (options.force) {
+				consola.info('Rebuilding custom packages...');
+				await rebuild();
+				consola.success('Finished rebuilding custom packages.');
+			}
 		} catch (error) {
 			consola.error(error);
 		}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,8 +16,9 @@ import colors from 'picocolors';
 
 import { version } from '../package.json';
 import { create } from './custom/create';
-import { verify } from './custom/verify';
+import { verify, verifyAll } from './custom/verify';
 import { processGoogle } from './google/queue';
+import { rebuild } from './custom/rebuilder';
 
 const cli = cac('fontsource');
 
@@ -79,9 +80,28 @@ cli
 	.option('-i, --id <id>', 'ID of the font to verify')
 	.option('--cwd <cwd>', 'Directory to run verification in')
 	.option('--ci', 'Run in CI mode and throw errors instead of fancy prompts')
+	.option('--all', 'Verify all fonts')
 	.action(async (options) => {
 		try {
-			await verify({ font: options.id, ci: options.ci, cwd: options.cwd });
+			if (options.all) {
+				await verifyAll();
+				consola.success('All packages valid.');
+			} else {
+				await verify({ font: options.id, ci: options.ci, cwd: options.cwd });
+			}
+		} catch (error) {
+			consola.error(error);
+		}
+	});
+
+cli
+	.command('create-rebuild')
+	.option('--cwd <cwd>', 'Directory to run rebuild in')
+	.action(async (options) => {
+		try {
+			consola.info('Rebuilding custom packages...');
+			await rebuild({ cwd: options.cwd });
+			consola.success('Finished rebuilding custom packages.');
 		} catch (error) {
 			consola.error(error);
 		}

--- a/packages/cli/src/custom/build.ts
+++ b/packages/cli/src/custom/build.ts
@@ -10,17 +10,27 @@ import { readme } from '../templates/readme';
 import type { Metadata } from '../types';
 import { packagerCustom } from './packager';
 
-export const buildCustom = async (metadata: Metadata) => {
+interface CustomOptions {
+	dir?: string;
+	version?: string;
+	publishHash?: string;
+}
+
+export const buildCustom = async (metadata: Metadata, opts?: CustomOptions) => {
 	// Create the directory for the font
-	const dir = `./${metadata.id}`;
+	const dir = opts?.dir ? path.join(opts.dir, metadata.id) : `./${metadata.id}`;
 	fs.ensureDirSync(dir);
 	fs.ensureDirSync(path.join(dir, '/files'));
 
 	// Generate CSS files
-	await packagerCustom(metadata);
+	await packagerCustom(metadata, { dir });
 
 	// Write metadata.scss
-	await fs.mkdir(path.join(dir, 'scss'));
+	try {
+		await fs.mkdir(path.join(dir, 'scss'));
+	} catch (err) {
+		// Continue as it may exist
+	}
 	await fs.writeFile(
 		path.join(dir, 'scss/metadata.scss'),
 		sassMetadata(metadata, {}, false)
@@ -47,5 +57,7 @@ export const buildCustom = async (metadata: Metadata) => {
 		isVariable: false,
 		tmpDir: '',
 		force: false,
+		version: opts?.version,
+		publishHash: opts?.publishHash,
 	});
 };

--- a/packages/cli/src/custom/packager.ts
+++ b/packages/cli/src/custom/packager.ts
@@ -6,9 +6,16 @@ import path from 'pathe';
 import { Metadata } from '../types';
 import { findClosest, makeFontFilePath } from '../utils';
 
-export const packagerCustom = async (metadata: Metadata) => {
+interface PackagerOptions {
+	dir?: string;
+}
+
+export const packagerCustom = async (
+	metadata: Metadata,
+	opts?: PackagerOptions
+) => {
 	const { id, family, subsets, weights, styles } = metadata;
-	const dir = `./${id}`;
+	const dir = opts?.dir ? opts.dir : `./${id}`;
 
 	// Find the weight for index.css in the case weight 400 does not exist.
 	const indexWeight = findClosest(weights, 400);

--- a/packages/cli/src/custom/rebuilder.ts
+++ b/packages/cli/src/custom/rebuilder.ts
@@ -1,0 +1,54 @@
+import fs from 'fs-extra';
+import path from 'pathe';
+import { Metadata } from '../types';
+import { buildCustom } from './build';
+import { getDirectories } from './utils';
+import { verifyAll } from './verify';
+import { consola } from 'consola';
+
+const getMetadata = async (dir: string): Promise<Metadata> => {
+	return await fs.readJson(path.join(dir, 'metadata.json'), 'utf-8');
+};
+
+interface PackageJson {
+	version: string;
+	publishHash?: string;
+}
+
+const getPackageJson = async (dir: string): Promise<PackageJson> => {
+	return await fs.readJson(path.join(dir, 'package.json'), 'utf-8');
+};
+
+interface RebuildOptions {
+	cwd?: string;
+}
+
+// Run rebuild
+export const rebuild = async (opts?: RebuildOptions) => {
+	const dir = './fonts/other';
+	const directories = getDirectories(dir, opts?.cwd);
+
+	for (const directory of directories) {
+		const fontDir = path.join(opts?.cwd ?? process.cwd(), dir, directory);
+		const metadata = await getMetadata(fontDir);
+		const pkgJson = await getPackageJson(fontDir);
+
+		// Delete everything in dir except files
+		const files = await fs.readdir(fontDir);
+		for (const file of files) {
+			if (file !== 'files') {
+				await fs.remove(path.join(fontDir, file));
+			}
+		}
+
+		await buildCustom(metadata, {
+			dir,
+			version: pkgJson.version,
+			publishHash: pkgJson.publishHash,
+		});
+
+		consola.info(`Rebuilt ${metadata.id}.`);
+	}
+
+	await verifyAll();
+};

--- a/packages/cli/src/custom/rebuilder.ts
+++ b/packages/cli/src/custom/rebuilder.ts
@@ -36,7 +36,7 @@ export const rebuild = async (opts?: RebuildOptions) => {
 		// Delete everything in dir except files
 		const files = await fs.readdir(fontDir);
 		for (const file of files) {
-			if (file !== 'files') {
+			if (file !== 'files' && file !== 'LICENSE') {
 				await fs.remove(path.join(fontDir, file));
 			}
 		}

--- a/packages/cli/src/custom/utils.ts
+++ b/packages/cli/src/custom/utils.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'pathe';
+
+export const getDirectories = (dir: string, cwd?: string) => {
+	try {
+		return fs
+			.readdirSync(path.join(cwd ?? process.cwd(), dir), {
+				withFileTypes: true,
+			})
+			.filter((dirent) => dirent.isDirectory())
+			.map((dirent) => dirent.name);
+	} catch {
+		return [];
+	}
+};

--- a/packages/cli/src/custom/verify.ts
+++ b/packages/cli/src/custom/verify.ts
@@ -6,6 +6,7 @@ import colors from 'picocolors';
 
 import { Metadata } from '../types';
 import { consola } from 'consola';
+import { getDirectories } from './utils';
 
 export const verifyFilenames = async (metadata: Metadata, dir: string) => {
 	// Read all the filenames in the files directory
@@ -153,5 +154,26 @@ export const verify = async ({ font, ci, cwd }: VerifyProps): Promise<void> => {
 				'All checks passed! Feel free to send a PR over to the main repo adding the package to the appropriate fonts directory.'
 			)
 		);
+	}
+};
+
+export const verifyAll = async (): Promise<void> => {
+	const fontDir = './fonts/other';
+	const directories = getDirectories(fontDir);
+	let hasErrors = false;
+
+	for (const directory of directories) {
+		try {
+			await verify({ font: directory, ci: true, cwd: fontDir });
+		} catch (error) {
+			consola.warn(`Error verifying ${directory}.`);
+			consola.warn(error);
+			hasErrors = true;
+		}
+	}
+
+	if (hasErrors) {
+		consola.error('Errors found. Exiting.');
+		process.exit(1);
 	}
 };

--- a/packages/cli/src/templates/package.ts
+++ b/packages/cli/src/templates/package.ts
@@ -2,40 +2,52 @@ import fs from 'fs-extra';
 import stringify from 'json-stringify-pretty-compact';
 import * as path from 'pathe';
 
-import { BuildOptions,Metadata } from '../types';
+import { BuildOptions, Metadata } from '../types';
+
+interface ExistingData {
+	oldVersion?: string;
+	publishHash?: string;
+}
 
 const template = (
-	{ id, family, license, type }: Metadata, isVariable: boolean,
-	oldVersion?: string
+	{ id, family, license, type }: Metadata,
+	isVariable: boolean,
+	existing?: ExistingData
 ) => ({
-		name: isVariable ? `@fontsource-variable/${id}` : `@fontsource/${id}`,
-		version: oldVersion ?? JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')).version,
-		description: `Self-host the ${family} font in a neatly bundled NPM package.`,
-		main: 'index.css',
-		publishConfig: { access: 'public' },
-		keywords: [
-			'fontsource',
-			'font',
-			'font family',
-			'google fonts',
-			id,
-			family,
-			'css',
-			'sass',
-			'front-end',
-			'web',
-			'typeface',
-			'variable'
-		],
+	name: isVariable ? `@fontsource-variable/${id}` : `@fontsource/${id}`,
+	version:
+		existing?.oldVersion ??
+		JSON.parse(
+			fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+		).version,
+	description: `Self-host the ${family} font in a neatly bundled NPM package.`,
+	main: 'index.css',
+	publishConfig: { access: 'public' },
+	keywords: [
+		'fontsource',
+		'font',
+		'font family',
+		'google fonts',
+		id,
+		family,
+		'css',
+		'sass',
+		'front-end',
+		'web',
+		'typeface',
+		'variable',
+	],
 	author: type === 'other' ? license.attribution : 'Google Inc.',
-		license: license.type,
-		homepage: `https://fontsource.org/fonts/${id}`,
-		repository: {
-			type: 'git',
-			url: 'https://github.com/fontsource/font-files.git',
-			directory: `fonts/${isVariable ? 'variable' : type}/${id}`,
-		},
-	});
+	license: license.type,
+	homepage: `https://fontsource.org/fonts/${id}`,
+	repository: {
+		type: 'git',
+		url: 'https://github.com/fontsource/font-files.git',
+		directory: `fonts/${isVariable ? 'variable' : type}/${id}`,
+	},
+	// If publish hash exists, add it to the package.json
+	...(existing?.publishHash && { publishHash: existing.publishHash }),
+});
 
 const packageJson = async (metadata: Metadata, opts: BuildOptions) => {
 	let oldVersion;
@@ -48,7 +60,10 @@ const packageJson = async (metadata: Metadata, opts: BuildOptions) => {
 		// Continue
 	}
 
-	const file = template(metadata, opts.isVariable, oldVersion);
+	const file = template(metadata, opts.isVariable, {
+		oldVersion: opts.version ?? oldVersion,
+		publishHash: opts.publishHash,
+	});
 	await fs.writeFile(path.join(opts.dir, 'package.json'), stringify(file));
 };
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -9,6 +9,8 @@ export interface BuildOptions {
 	force: boolean;
 	isVariable: boolean;
 	isIcon?: boolean;
+	version?: string;
+	publishHash?: string;
 }
 
 export interface Axes {


### PR DESCRIPTION
This adds the `rebuild` command which should also be called when the `force` flag is set to true when building packages, allowing custom fonts to also be refreshed with new CSS files or other changes that may happen from Fontsource's end.

Additionally, the script from [`font-files`](https://github.com/fontsource/font-files/blob/main/scripts/test.ts) to verify packages was moved into `create-verify --all` to simplify the codebase.