### PR TITLE
fix(website): slider label styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 80
 
-[*.ts]
+[*.{ts,tsx}]
 quote_type = single
 
 [*.{md, mdx}]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,13 @@ name: Packager Tests
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "packages/**"
 
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "packages/**"
 
 jobs:
   build:

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -28,5 +28,5 @@ jobs:
           url: "https://staging.fontsource.org/actions/update"
           method: "POST"
           bearerToken: ${{ secrets.WEBSITE_UPDATE_TOKEN }}
-          data: '{"fonts": true, "algolia": true, "download": true, "axisRegistry": true, "docs": true}'
+          data: '{"download": true, "axisRegistry": true, "docs": true}'
           preventFailureOnNoResponse: true

--- a/website/app/components/Slider.tsx
+++ b/website/app/components/Slider.tsx
@@ -6,6 +6,24 @@ import { Slider as MantineSlider } from '@mantine/core';
 const Slider = (props: SliderProps) => (
 	<MantineSlider
 		{...props}
+		sx={(theme) => ({
+			'& .mantine-Slider-label': {
+				position: 'absolute',
+				top: rem(-40),
+				backgroundColor:
+					theme.colorScheme === 'dark'
+						? theme.colors.dark[4]
+						: theme.colors.gray[9],
+				fontSize: theme.fontSizes.xs,
+				color: theme.white,
+				padding: `calc(${theme.spacing.xs} / 2)`,
+				borderRadius: theme.radius.sm,
+				whiteSpace: 'nowrap',
+				pointerEvents: 'none',
+				userSelect: 'none',
+				touchAction: 'none',
+			},
+		})}
 		styles={(theme) => ({
 			track: {
 				'&::before': {
@@ -25,23 +43,6 @@ const Slider = (props: SliderProps) => (
 				border: `${rem(4)} solid white`,
 
 				boxShadow: `0 0 0 ${rem(1)} ${theme.colors.border[0]}`,
-			},
-
-			label: {
-				position: 'absolute',
-				top: rem(-40),
-				backgroundColor:
-					theme.colorScheme === 'dark'
-						? theme.colors.dark[4]
-						: theme.colors.gray[9],
-				fontSize: theme.fontSizes.xs,
-				color: theme.white,
-				padding: `calc(${theme.spacing.xs} / 2)`,
-				borderRadius: theme.radius.sm,
-				whiteSpace: 'nowrap',
-				pointerEvents: 'none',
-				userSelect: 'none',
-				touchAction: 'none',
 			},
 
 			dragging: {

--- a/website/app/components/Slider.tsx
+++ b/website/app/components/Slider.tsx
@@ -1,4 +1,4 @@
-import type { SliderProps} from '@mantine/core';
+import type { SliderProps } from '@mantine/core';
 import { rem } from '@mantine/core';
 import { Slider as MantineSlider } from '@mantine/core';
 
@@ -27,9 +27,26 @@ const Slider = (props: SliderProps) => (
 				boxShadow: `0 0 0 ${rem(1)} ${theme.colors.border[0]}`,
 			},
 
+			label: {
+				position: 'absolute',
+				top: rem(-40),
+				backgroundColor:
+					theme.colorScheme === 'dark'
+						? theme.colors.dark[4]
+						: theme.colors.gray[9],
+				fontSize: theme.fontSizes.xs,
+				color: theme.white,
+				padding: `calc(${theme.spacing.xs} / 2)`,
+				borderRadius: theme.radius.sm,
+				whiteSpace: 'nowrap',
+				pointerEvents: 'none',
+				userSelect: 'none',
+				touchAction: 'none',
+			},
+
 			dragging: {
 				boxShadow: `0 0 0 ${rem(2)} ${theme.colors.border[0]}`,
-			}
+			},
 		})}
 	/>
 );

--- a/website/app/components/preview/VariableButtons.tsx
+++ b/website/app/components/preview/VariableButtons.tsx
@@ -72,8 +72,7 @@ const VariableButton = ({
 	};
 
 	const resetVariation = () => {
-		if (tag === 'ital')
-			previewState.italic.set(false);
+		if (tag === 'ital') previewState.italic.set(false);
 
 		variableState.set({ ...variableState.get(), [tag]: undefined });
 	};

--- a/website/app/components/preview/VariableButtons.tsx
+++ b/website/app/components/preview/VariableButtons.tsx
@@ -99,22 +99,6 @@ const VariableButton = ({
 				precision={1}
 				onChange={handleVariation}
 				value={variable[tag] ?? Number(axes.default)}
-
-				styles={(theme) => ({
-					label: {
-						position: 'absolute',
-						top: rem(-40),
-						backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[9],
-						fontSize: theme.fontSizes.xs,
-						color: theme.white,
-						padding: `calc(${theme.spacing.xs} / 2)`,
-						borderRadius: theme.radius.sm,
-						whiteSpace: 'nowrap',
-						pointerEvents: 'none',
-						userSelect: 'none',
-						touchAction: 'none',
-					},
-				})}
 			/>
 			<Group position="apart" px={3} mt={8}>
 				<Text fz="sm">{axes.min}</Text>


### PR DESCRIPTION
Slider labels don't seem to show up in production due to an emotion bug. Forcefully applying it returns the expected labels.

Also disable packager tests from running if `packages` directory does not change.