### PR TITLE
fix: remove publish verifier

### DIFF
--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/publish",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Fontsource Publish CLI",
 	"bin": {
 		"fontsource-publish": "./dist/cli.mjs"

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -27,7 +27,6 @@
 		"fs-extra": "^11.1.0",
 		"hash-wasm": "^4.9.0",
 		"json-stringify-pretty-compact": "^4.0.0",
-		"latest-version": "^7.0.0",
 		"libnpmpublish": "4",
 		"p-queue": "^7.3.4",
 		"pacote": "11",

--- a/packages/publish/src/bump.ts
+++ b/packages/publish/src/bump.ts
@@ -1,21 +1,9 @@
-import { confirm, isCancel } from '@clack/prompts';
 import { consola } from 'consola';
-import fs from 'fs-extra';
-import stringify from 'json-stringify-pretty-compact';
-import latestVersion from 'latest-version';
-import PQueue from 'p-queue';
-import path from 'pathe';
 import colors from 'picocolors';
 import semver from 'semver';
 
 import { getChanged } from './changed';
-import type {
-	BumpFlags,
-	BumpObject,
-	ChangedList,
-	Context,
-	PackageJson,
-} from './types';
+import type { BumpFlags, BumpObject, ChangedList } from './types';
 import { mergeFlags } from './utils';
 
 export const isValidBumpArg = (bumpArg: string): boolean => {
@@ -66,56 +54,7 @@ export const bumpValue = (
 	return false;
 };
 
-export const verifyVersion = async (
-	pkg: BumpObject,
-	bumpArg: string
-): Promise<BumpObject> => {
-	let npmVersion: string | boolean;
-	const newPkg = pkg;
-
-	try {
-		// Get latest version from NPM registry and compare if bumped version is greater than NPM
-		npmVersion = await latestVersion(pkg.name);
-		if (semver.gt(pkg.bumpVersion as string, npmVersion)) {
-			return pkg;
-		}
-	} catch (error: any) {
-		// If package isn't published on NPM yet, revert bump
-		if (error.name === 'PackageNotFoundError') {
-			newPkg.bumpVersion = newPkg.version;
-		}
-
-		return newPkg;
-	}
-
-	// If failed, do not publish
-	newPkg.noPublish = true;
-	if (bumpArg === 'from-package') {
-		return newPkg;
-	}
-
-	throw new Error(
-		colors.red(
-			`${newPkg.name} version mismatch. Not publishing.\n- NPM: ${npmVersion}\n- Bumped version: ${pkg.bumpVersion}`
-		)
-	);
-};
-
-export const writeUpdate = async (pkg: BumpObject): Promise<void> => {
-	const pkgPath = path.join(pkg.path, 'package.json');
-	const pkgJson: PackageJson = await fs.readJson(pkgPath);
-	pkgJson.version = pkg.bumpVersion;
-	pkgJson.publishHash = pkg.hash;
-	await fs.writeFile(pkgPath, stringify(pkgJson));
-};
-
-const queue = new PQueue({ concurrency: 12 });
-
-export const bumpPackages = async (
-	diff: ChangedList,
-	config: Context,
-	version: string
-) => {
+export const bumpPackages = async (diff: ChangedList, version: string) => {
 	// Create bump objects with bumped version
 	const bumpObjects: BumpObject[] = [];
 	for (const pkg of diff) {
@@ -132,22 +71,9 @@ export const bumpPackages = async (
 		bumpObjects.push(bumpObject);
 	}
 
-	// Check if package versions are free of conflicts on NPM
-	let pendingObjects;
-	if (!config.noVerify) {
-		pendingObjects = [];
-		for (const pkg of bumpObjects) {
-			const newPkg = queue.add(() => verifyVersion(pkg, version));
-			pendingObjects.push(newPkg);
-		}
-	}
-	// Wait for queue to finish
-	const verifiedObjects = await Promise.all(pendingObjects ?? bumpObjects);
-	consola.info(colors.bold(colors.blue('All packages verified.')));
-
 	// Print out all new versions and prompt user to continue
 	let count = 0;
-	for (const pkg of verifiedObjects) {
+	for (const pkg of bumpObjects) {
 		if (!pkg) {
 			throw new Error('Package object is undefined.');
 		}
@@ -156,33 +82,16 @@ export const bumpPackages = async (
 		);
 		count += 1;
 	}
+	consola.info(colors.magenta(`${count} packages will be updated.`));
 
-	if (!config.yes) {
-		const yes = await confirm({ message: `Bump ${count} packages?` });
-		if (!yes || isCancel(yes)) {
-			throw new Error('Bump cancelled.');
-		}
-	} else {
-		consola.info(colors.bold(colors.blue(`Bumping ${count} packages...`)));
-	}
-
-	// Update all padkage.json files
-	for (const pkg of verifiedObjects) {
+	// Sanity check
+	for (const pkg of bumpObjects) {
 		if (!pkg) {
 			throw new Error('Package object is undefined.');
 		}
-
-		// Skip if noPublish flag is set
-		if (!pkg.noPublish) {
-			await writeUpdate(pkg);
-		} else {
-			consola.info(
-				colors.yellow(`Skipping ${pkg.name} as it is set to not publish.`)
-			);
-		}
 	}
 
-	return verifiedObjects as unknown as BumpObject[];
+	return bumpObjects;
 };
 
 export const bump = async (version: string, options: BumpFlags) => {
@@ -196,5 +105,5 @@ export const bump = async (version: string, options: BumpFlags) => {
 	);
 	const config = await mergeFlags(options);
 	const diff = await getChanged(config);
-	await bumpPackages(diff, config, version);
+	await bumpPackages(diff, version);
 };

--- a/packages/publish/src/cli.ts
+++ b/packages/publish/src/cli.ts
@@ -52,7 +52,6 @@ cli
 	)
 	.option('--commit-message', 'Change commit message')
 	.option('--packages', 'Package directory')
-	.option('--no-verify', 'Skip version verification')
 	.action(async (version: string, opts: BumpFlags) => {
 		try {
 			await bump(version, opts);

--- a/packages/publish/tests/bump.test.ts
+++ b/packages/publish/tests/bump.test.ts
@@ -1,15 +1,8 @@
-import latestVersion from 'latest-version';
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'fs-extra';
 
-import {
-	bumpPackages,
-	bumpValue,
-	isValidBumpArg,
-	verifyVersion,
-} from '../src/bump';
+import { bumpPackages, bumpValue, isValidBumpArg } from '../src/bump';
 import { ChangedList } from '../src/types';
-import stringify from 'json-stringify-pretty-compact';
 
 vi.mock('fs-extra');
 vi.mock('latest-version');
@@ -73,252 +66,109 @@ describe('bump values', () => {
 	});
 });
 
-describe('verify version', () => {
-	it('successfully passes verification', async () => {
-		vi.mocked(latestVersion).mockResolvedValueOnce('1.0.0');
-		const bump = await verifyVersion(
-			{
-				name: 'test',
-				version: '1.0.0',
-				bumpVersion: '1.0.1',
-				path: 'test',
-				hash: 'test',
-			},
-			'patch'
-		);
-		expect(bump).toEqual({
-			name: 'test',
-			version: '1.0.0',
-			bumpVersion: '1.0.1',
-			path: 'test',
-			hash: 'test',
-		});
-	});
+describe('bumps packages with changelist', async () => {
+	const changelist: ChangedList = [
+		{
+			name: 'package1',
+			path: 'packages/publish/tests/fixtures/package1',
+			hash: '2d7f1808da1fa63c',
+			version: '0.1.0',
+		},
+		{
+			name: 'package3',
+			path: 'packages/publish/tests/fixtures/package3diff',
+			hash: 'd4a613dee558a143',
+			version: '0.3.0',
+		},
+	];
 
-	it('revert bump to base as package does not exist', async () => {
-		vi.mocked(latestVersion).mockRejectedValueOnce({
-			name: 'PackageNotFoundError',
+	it('bumps package with changelist patch', async () => {
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.1.0',
+			publishHash: '2d7f1808da1fa63c',
 		});
-		const bump = await verifyVersion(
-			{
-				name: 'test',
-				version: '1.0.0',
-				bumpVersion: '1.0.1',
-				path: 'test',
-				hash: 'test',
-			},
-			'patch'
-		);
-		expect(bump).toEqual({
-			name: 'test',
-			version: '1.0.0',
-			bumpVersion: '1.0.0',
-			path: 'test',
-			hash: 'test',
+
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.3.0',
+			publishHash: 'd4a613dee558a143',
 		});
-	});
 
-	it('throws error as version is less than latest', async () => {
-		vi.mocked(latestVersion).mockResolvedValueOnce('1.0.1');
-		await expect(
-			verifyVersion(
-				{
-					name: 'test',
-					version: '1.0.0',
-					bumpVersion: '1.0.1',
-					path: 'test',
-					hash: 'test',
-				},
-				'patch'
-			)
-		).rejects.toThrow('test version mismatch');
-	});
-
-	it('applies no publish as version is less than latest and from-package is used', async () => {
-		vi.mocked(latestVersion).mockResolvedValueOnce('1.0.1');
-		const bump = await verifyVersion(
-			{
-				name: 'test',
-				version: '1.0.0',
-				bumpVersion: '1.0.1',
-				path: 'test',
-				hash: 'test',
-			},
-			'from-package'
-		);
-		expect(bump).toEqual({
-			name: 'test',
-			version: '1.0.0',
-			bumpVersion: '1.0.1',
-			noPublish: true,
-			path: 'test',
-			hash: 'test',
-		});
-	});
-
-	describe('bumps packages with changelist', async () => {
-		const changelist: ChangedList = [
+		const bumpObjects = await bumpPackages(changelist, 'patch');
+		expect(bumpObjects).toEqual([
 			{
 				name: 'package1',
 				path: 'packages/publish/tests/fixtures/package1',
 				hash: '2d7f1808da1fa63c',
 				version: '0.1.0',
+				bumpVersion: '0.1.1',
 			},
 			{
 				name: 'package3',
 				path: 'packages/publish/tests/fixtures/package3diff',
 				hash: 'd4a613dee558a143',
 				version: '0.3.0',
+				bumpVersion: '0.3.1',
 			},
-		];
+		]);
+	});
 
-		const config = {
-			packages: ['./packages/publish/tests/fixtures/'],
-			ignoreExtension: [],
-			commitMessage: 'chore: release new versions',
-			noVerify: true,
-			yes: true,
-		};
-
-		it('bumps package with changelist patch', async () => {
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
-				version: '0.1.0',
-				publishHash: '2d7f1808da1fa63c',
-			});
-
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
-				version: '0.3.0',
-				publishHash: 'd4a613dee558a143',
-			});
-
-			vi.mocked(latestVersion).mockResolvedValueOnce('0.1.0');
-			vi.mocked(latestVersion).mockResolvedValueOnce('0.3.0');
-
-			const bumpObjects = await bumpPackages(changelist, config, 'patch');
-			expect(bumpObjects).toEqual([
-				{
-					name: 'package1',
-					path: 'packages/publish/tests/fixtures/package1',
-					hash: '2d7f1808da1fa63c',
-					version: '0.1.0',
-					bumpVersion: '0.1.1',
-				},
-				{
-					name: 'package3',
-					path: 'packages/publish/tests/fixtures/package3diff',
-					hash: 'd4a613dee558a143',
-					version: '0.3.0',
-					bumpVersion: '0.3.1',
-				},
-			]);
-
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledTimes(2);
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(
-				'packages/publish/tests/fixtures/package1/package.json',
-				stringify({
-					version: '0.1.1',
-					publishHash: '2d7f1808da1fa63c',
-				})
-			);
-
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(
-				'packages/publish/tests/fixtures/package3diff/package.json',
-				stringify({
-					version: '0.3.1',
-					publishHash: 'd4a613dee558a143',
-				})
-			);
+	it('throws with changelist from-package with existing version', async () => {
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.1.0',
+			publishHash: '2d7f1808da1fa63c',
 		});
 
-		it('throws with changelist from-package with existing version', async () => {
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
-				version: '0.1.0',
-				publishHash: '2d7f1808da1fa63c',
-			});
-
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
-				version: '0.3.0',
-				publishHash: 'd4a613dee558a143',
-			});
-
-			vi.mocked(latestVersion).mockResolvedValueOnce('0.1.0');
-			vi.mocked(latestVersion).mockResolvedValueOnce('0.3.0');
-
-			const newConfig = { ...config, noVerify: false };
-			expect(await bumpPackages(changelist, newConfig, 'from-package')).toEqual(
-				[
-					{
-						name: 'package1',
-						path: 'packages/publish/tests/fixtures/package1',
-						hash: '2d7f1808da1fa63c',
-						noPublish: true,
-						version: '0.1.0',
-						bumpVersion: '0.1.0',
-					},
-					{
-						name: 'package3',
-						path: 'packages/publish/tests/fixtures/package3diff',
-						hash: 'd4a613dee558a143',
-						noPublish: true,
-						version: '0.3.0',
-						bumpVersion: '0.3.0',
-					},
-				]
-			);
-
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledTimes(0);
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.3.0',
+			publishHash: 'd4a613dee558a143',
 		});
 
-		it('bumps package with changelist noVerify from-package', async () => {
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
+		expect(await bumpPackages(changelist, 'from-package')).toEqual([
+			{
+				name: 'package1',
+				path: 'packages/publish/tests/fixtures/package1',
+				hash: '2d7f1808da1fa63c',
 				version: '0.1.0',
-				publishHash: '2d7f1808da1fa63c',
-			});
-
-			vi.mocked(fs.readJSON).mockResolvedValueOnce({
+				bumpVersion: '0.1.0',
+			},
+			{
+				name: 'package3',
+				path: 'packages/publish/tests/fixtures/package3diff',
+				hash: 'd4a613dee558a143',
 				version: '0.3.0',
-				publishHash: 'd4a613dee558a143',
-			});
+				bumpVersion: '0.3.0',
+			},
+		]);
+	});
 
-			const bumpObjects = await bumpPackages(
-				changelist,
-				config,
-				'from-package'
-			);
-
-			expect(bumpObjects).toEqual([
-				{
-					name: 'package1',
-					path: 'packages/publish/tests/fixtures/package1',
-					hash: '2d7f1808da1fa63c',
-					version: '0.1.0',
-					bumpVersion: '0.1.0',
-				},
-				{
-					name: 'package3',
-					path: 'packages/publish/tests/fixtures/package3diff',
-					hash: 'd4a613dee558a143',
-					version: '0.3.0',
-					bumpVersion: '0.3.0',
-				},
-			]);
-
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledTimes(2);
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(
-				'packages/publish/tests/fixtures/package1/package.json',
-				stringify({
-					version: '0.1.0',
-					publishHash: '2d7f1808da1fa63c',
-				})
-			);
-
-			expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(
-				'packages/publish/tests/fixtures/package3diff/package.json',
-				stringify({
-					version: '0.3.0',
-					publishHash: 'd4a613dee558a143',
-				})
-			);
+	it('bumps package with changelist noVerify from-package', async () => {
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.1.0',
+			publishHash: '2d7f1808da1fa63c',
 		});
+
+		vi.mocked(fs.readJSON).mockResolvedValueOnce({
+			version: '0.3.0',
+			publishHash: 'd4a613dee558a143',
+		});
+
+		const bumpObjects = await bumpPackages(changelist, 'from-package');
+
+		expect(bumpObjects).toEqual([
+			{
+				name: 'package1',
+				path: 'packages/publish/tests/fixtures/package1',
+				hash: '2d7f1808da1fa63c',
+				version: '0.1.0',
+				bumpVersion: '0.1.0',
+			},
+			{
+				name: 'package3',
+				path: 'packages/publish/tests/fixtures/package3diff',
+				hash: 'd4a613dee558a143',
+				version: '0.3.0',
+				bumpVersion: '0.3.0',
+			},
+		]);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       json-stringify-pretty-compact:
         specifier: ^4.0.0
         version: 4.0.0
-      latest-version:
-        specifier: ^7.0.0
-        version: 7.0.0
       libnpmpublish:
         specifier: '4'
         version: 4.0.0
@@ -512,7 +509,7 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@8.41.0)
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.41.0)
       eslint-plugin-promise: 6.1.1(eslint@8.41.0)
@@ -3068,21 +3065,6 @@ packages:
       tslib: 2.5.2
     dev: true
 
-  /@pnpm/network.ca-file@1.0.2:
-    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
-    engines: {node: '>=12.22.0'}
-    dependencies:
-      graceful-fs: 4.2.10
-    dev: false
-
-  /@pnpm/npm-conf@1.0.5:
-    resolution: {integrity: sha512-hD8ml183638O3R6/Txrh0L8VzGOrFXgRtRDG4qQC4tONdZ5Z1M+tlUUDUvrjYdmK6G+JTBTeaCLMna11cXzi8A==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@pnpm/network.ca-file': 1.0.2
-      config-chain: 1.1.13
-    dev: false
-
   /@puppeteer/browsers@0.5.0(typescript@5.0.4):
     resolution: {integrity: sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==}
     engines: {node: '>=14.1.0'}
@@ -5091,13 +5073,6 @@ packages:
       well-known-symbols: 2.0.0
     dev: false
 
-  /config-chain@1.1.13:
-    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
-    dependencies:
-      ini: 1.3.8
-      proto-list: 1.2.4
-    dev: false
-
   /confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
     dev: true
@@ -5876,7 +5851,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.41.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -5909,7 +5884,7 @@ packages:
       '@typescript-eslint/parser': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
       eslint: 8.41.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
     dev: true
 
   /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.40.0):
@@ -5944,7 +5919,7 @@ packages:
     dependencies:
       eslint: 8.41.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.41.0)
       eslint-plugin-react: 7.32.2(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
@@ -6015,7 +5990,7 @@ packages:
       enhanced-resolve: 5.14.0
       eslint: 8.41.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
       is-core-module: 2.12.1
@@ -6118,6 +6093,39 @@ packages:
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      has: 1.0.3
+      is-core-module: 2.12.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.2
+      semver: 6.3.0
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.41.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -7368,10 +7376,6 @@ packages:
       responselike: 3.0.0
     dev: false
 
-  /graceful-fs@4.2.10:
-    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
-
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -8371,13 +8375,6 @@ packages:
     dependencies:
       language-subtag-registry: 0.3.22
     dev: true
-
-  /latest-version@7.0.0:
-    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      package-json: 8.1.0
-    dev: false
 
   /levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
@@ -10175,16 +10172,6 @@ packages:
       ip: 1.1.8
       netmask: 2.0.2
 
-  /package-json@8.1.0:
-    resolution: {integrity: sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      got: 12.6.0
-      registry-auth-token: 5.0.1
-      registry-url: 6.0.1
-      semver: 7.5.1
-    dev: false
-
   /pacote@11.3.5:
     resolution: {integrity: sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==}
     engines: {node: '>=10'}
@@ -10603,10 +10590,6 @@ packages:
 
   /property-information@6.2.0:
     resolution: {integrity: sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==}
-
-  /proto-list@1.2.4:
-    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
-    dev: false
 
   /proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -11081,20 +11064,6 @@ packages:
       regjsparser: 0.9.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
-
-  /registry-auth-token@5.0.1:
-    resolution: {integrity: sha512-UfxVOj8seK1yaIOiieV4FIP01vfBDLsY0H9sQzi9EbbUdJiuuBjJgLa1DpImXMNPnVkBD4eVxTEXcrZA6kfpJA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@pnpm/npm-conf': 1.0.5
-    dev: false
-
-  /registry-url@6.0.1:
-    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
-    engines: {node: '>=12'}
-    dependencies:
-      rc: 1.2.8
-    dev: false
 
   /regjsparser@0.9.1:
     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}


### PR DESCRIPTION
Removes an unnecessary step as we can just save a file hash after a successful publish. Thus if a publish fails, the hash won't be saved and will be automatically retried. 

There seemed to be some broken logic when trying to verify packages which led to incorrect bumps.