### PR TITLE
fix(publish): write version before running publish

### DIFF
--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontsource-utils/publish",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Fontsource Publish CLI",
 	"bin": {
 		"fontsource-publish": "./dist/cli.mjs"


### PR DESCRIPTION
NPM reads the package version, so we must write the new version before calling the publish command. On successful publish, update the publish hash as well.