### PR TITLE
feat(website): add carbon ads and preview routing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       react-instantsearch-hooks-web:
         specifier: ^6.44.0
         version: 6.44.0(algoliasearch@4.17.0)(react-dom@17.0.2)(react@17.0.2)
+      react-wrap-balancer:
+        specifier: ^0.5.0
+        version: 0.5.0(react@17.0.2)
       rehype-autolink-headings:
         specifier: ^6.1.1
         version: 6.1.1
@@ -468,7 +471,7 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@8.40.0)
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.40.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.40.0)
       eslint-plugin-promise: 6.1.1(eslint@8.40.0)
@@ -3275,7 +3278,7 @@ packages:
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.40.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.40.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.40.0)
@@ -5633,7 +5636,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.40.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -5666,7 +5669,7 @@ packages:
       '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       eslint: 8.40.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.40.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
     dev: true
 
   /eslint-config-airbnb-typescript@17.0.0(@typescript-eslint/eslint-plugin@5.59.6)(@typescript-eslint/parser@5.59.6)(eslint-plugin-import@2.27.5)(eslint@8.41.0):
@@ -5696,7 +5699,7 @@ packages:
     dependencies:
       eslint: 8.40.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.40.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.40.0)
       eslint-plugin-react: 7.32.2(eslint@8.40.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.40.0)
@@ -5763,7 +5766,7 @@ packages:
       enhanced-resolve: 5.14.0
       eslint: 8.40.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
       is-core-module: 2.12.1
@@ -5869,39 +5872,6 @@ packages:
       eslint: 8.40.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.40.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
-      has: 1.0.3
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.2
-      semver: 6.3.0
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.41.0):
@@ -10362,6 +10332,14 @@ packages:
       use-latest: 1.2.1(@types/react@18.2.6)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
+    dev: false
+
+  /react-wrap-balancer@0.5.0(react@17.0.2):
+    resolution: {integrity: sha512-5vwe5QDczQ9zwAtv3iEVj8hdMbNwQtM/QlSNLJfDUzRE9noPtxevb+Kon916Mu2RUorCrAtashQ1F9BVBjdeZg==}
+    peerDependencies:
+      react: '>=16.8.0 || ^17.0.0 || ^18'
+    dependencies:
+      react: 17.0.2
     dev: false
 
   /react@17.0.2:

--- a/website/app/components/CarbonAd.tsx
+++ b/website/app/components/CarbonAd.tsx
@@ -1,0 +1,72 @@
+import type { BoxProps } from '@mantine/core';
+import { rem } from '@mantine/core';
+import { Box, createStyles } from '@mantine/core';
+import { useLocation } from '@remix-run/react';
+import { useEffect } from 'react';
+import Balancer from 'react-wrap-balancer';
+
+const useStyles = createStyles((theme) => ({
+	wrapper: {
+		display: 'flex',
+		marginTop: rem(24),
+		marginLeft: 'auto',
+		justifyContent: 'center',
+
+		a: {
+			color:
+				theme.colorScheme === 'dark'
+					? theme.colors.text[0]
+					: theme.colors.text[1],
+			textDecoration: 'none',
+		},
+
+		'#carbonads > span': {
+			textAlign: 'center',
+			display: 'grid',
+			padding: '1em',
+			boxSizing: 'border-box',
+			borderRadius: '4px',
+			width: rem(238),
+		},
+
+		'#carbonads .carbon-wrap': {
+			display: 'grid',
+			rowGap: rem(8),
+		},
+
+		'#carbonads .carbon-text': {
+			fontSize: rem(12),
+			marginBottom: rem(4),
+		},
+
+		'#carbonads .carbon-poweredby': {
+			fontSize: '0.75em',
+			opacity: 0.5,
+			textTransform: 'uppercase',
+			fontWeight: 600,
+			letterSpacing: 0.5,
+		},
+	},
+}));
+
+export const CarbonAd = ({ ...props }: BoxProps) => {
+	const { classes } = useStyles();
+	const location = useLocation();
+
+	useEffect(() => {
+		const script = document.createElement('script');
+		script.src =
+			'//cdn.carbonads.com/carbon.js?serve=CEAI42QN&placement=fontsourceorg';
+		script.id = '_carbonads_js';
+		script.async = true;
+		document.getElementById('carbonads')?.replaceWith(script);
+	}, [location]);
+
+	return (
+		<Box className={classes.wrapper} {...props}>
+			<Balancer>
+				<span id="carbonads" />
+			</Balancer>
+		</Box>
+	);
+};

--- a/website/app/components/docs/DocsHeader.tsx
+++ b/website/app/components/docs/DocsHeader.tsx
@@ -52,9 +52,9 @@ const DocsSearchBar = ({ ...others }: TextInputProps) => {
 export const DocsHeader = () => {
 	return (
 		<ContentHeader>
-			<Title order={1} color="purple">
+			<Title order={1} color="purple.0">
 				Documentation
 			</Title>
 		</ContentHeader>
-	)
-}
+	);
+};

--- a/website/app/components/docs/TableOfContents.tsx
+++ b/website/app/components/docs/TableOfContents.tsx
@@ -1,8 +1,9 @@
-import type { TextProps} from '@mantine/core';
+import type { TextProps } from '@mantine/core';
 import { Box, createStyles, rem, Text, UnstyledButton } from '@mantine/core';
 import { Link, useParams } from '@remix-run/react';
 import { useState } from 'react';
 
+import { CarbonAd } from '@/components/CarbonAd';
 import type { HeadingsData } from '@/hooks/useHeadingsData';
 import { useHeadingsData } from '@/hooks/useHeadingsData';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
@@ -43,18 +44,27 @@ const HeadingItem = (heading: HeadingItemProps) => {
 				sx={(theme) => ({
 					borderLeft: isActive
 						? `${rem(1)} solid ${theme.colors.purple[0]}`
-						: theme.colorScheme === 'dark' ? `${rem(1)} solid ${theme.colors.border[1]}` : `${rem(1)} solid ${theme.colors.border[0]}`,
+						: theme.colorScheme === 'dark'
+						? `${rem(1)} solid ${theme.colors.border[1]}`
+						: `${rem(1)} solid ${theme.colors.border[0]}`,
 				})}
 			>
 				<UnstyledButton key={heading.id} component={Link} to={`#${heading.id}`}>
-					<Text fz={15} fw={isActive ? 700 : 400} pl={heading.pl ?? 16} py={4}>{heading.title}</Text>
+					<Text fz={15} fw={isActive ? 700 : 400} pl={heading.pl ?? 16} py={4}>
+						{heading.title}
+					</Text>
 				</UnstyledButton>
 			</Box>
 			<div className={classes.nestedWrapper}>
 				{heading.items &&
 					heading.items.length > 0 &&
 					heading.items.map((child) => (
-						<HeadingItem key={child.id} active={heading.active} pl={32} {...child} />
+						<HeadingItem
+							key={child.id}
+							active={heading.active}
+							pl={32}
+							{...child}
+						/>
 					))}
 			</div>
 		</>
@@ -80,6 +90,7 @@ export const TableOfContents = () => {
 					<HeadingItem key={heading.id} active={activeId} {...heading} />
 				))}
 			</div>
+			<CarbonAd />
 		</nav>
 	);
 };

--- a/website/app/components/preview/Configure.tsx
+++ b/website/app/components/preview/Configure.tsx
@@ -12,6 +12,7 @@ import {
 import { IconRotate } from '@/components/icons';
 import type { AxisRegistry, Metadata, VariableData } from '@/utils/types';
 
+import { CarbonAd } from '../CarbonAd';
 import { NormalButtonsGroup } from './Buttons';
 import { previewState, variableState } from './observables';
 import { VariableButtonsGroup } from './VariableButtons';
@@ -61,32 +62,35 @@ const Configure = ({ metadata, variable, axisRegistry }: ConfigureProps) => {
 	};
 
 	return (
-		<ScrollArea.Autosize mah="50vh" className={classes.scrollWrapper}>
-			<Flex gap="xs" className={classes.wrapper}>
-				<Text className={classes.title} mb={4}>
-					Settings
-				</Text>
-				<NormalButtonsGroup
-					subsets={metadata.subsets}
-					hasItalic={metadata.styles.includes('italic')}
-				/>
-				{metadata.variable && (
-					<>
-						<Divider mt="sm" />
-						<Group position="apart">
-							<Text className={classes.title}>Variable Axes</Text>
-							<ActionIcon onClick={resetVariation}>
-								<IconRotate />
-							</ActionIcon>
-						</Group>
-						<VariableButtonsGroup
-							variable={variable}
-							axisRegistry={axisRegistry}
-						/>
-					</>
-				)}
-			</Flex>
-		</ScrollArea.Autosize>
+		<>
+			<ScrollArea.Autosize mah="50vh" className={classes.scrollWrapper}>
+				<Flex gap="xs" className={classes.wrapper}>
+					<Text className={classes.title} mb={4}>
+						Settings
+					</Text>
+					<NormalButtonsGroup
+						subsets={metadata.subsets}
+						hasItalic={metadata.styles.includes('italic')}
+					/>
+					{metadata.variable && (
+						<>
+							<Divider mt="sm" />
+							<Group position="apart">
+								<Text className={classes.title}>Variable Axes</Text>
+								<ActionIcon onClick={resetVariation}>
+									<IconRotate />
+								</ActionIcon>
+							</Group>
+							<VariableButtonsGroup
+								variable={variable}
+								axisRegistry={axisRegistry}
+							/>
+						</>
+					)}
+				</Flex>
+			</ScrollArea.Autosize>
+			<CarbonAd w={332} />
+		</>
 	);
 };
 

--- a/website/app/components/preview/Install.tsx
+++ b/website/app/components/preview/Install.tsx
@@ -27,6 +27,8 @@ import { Code } from '@/components/code/Code';
 import { PackageManagerCode } from '@/components/code/PackageManagerCode';
 import type { Metadata, VariableData } from '@/utils/types';
 
+import { CarbonAd } from '../CarbonAd';
+
 const useStyles = createStyles((theme) => ({
 	wrapper: {
 		maxWidth: '1440px',
@@ -442,6 +444,7 @@ export const Install = ({
 						</Group>
 					</Stack>
 				</div>
+				<CarbonAd w={332} />
 			</Grid.Col>
 		</Grid>
 	);

--- a/website/app/routes/__boundary/fonts/$id/index.tsx
+++ b/website/app/routes/__boundary/fonts/$id/index.tsx
@@ -1,0 +1,92 @@
+import { createStyles, Grid } from '@mantine/core';
+import type { LoaderFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+import invariant from 'tiny-invariant';
+
+import { Configure } from '@/components/preview/Configure';
+import { TabsWrapper } from '@/components/preview/Tabs';
+import { TextArea } from '@/components/preview/TextArea';
+import { getPreviewText } from '@/utils/language/language.server';
+import { getDownloadCountTotal } from '@/utils/metadata/download.server';
+import { getMetadata } from '@/utils/metadata/metadata.server';
+import { getAxisRegistry, getVariable } from '@/utils/metadata/variable.server';
+import type { AxisRegistry, Metadata, VariableData } from '@/utils/types';
+
+export const loader: LoaderFunction = async ({ params }) => {
+	const { id } = params;
+	invariant(id, 'Missing font ID!');
+	const metadata = await getMetadata(id);
+	let variable;
+	let axisRegistry;
+	if (metadata.variable) {
+		variable = await getVariable(id);
+		axisRegistry = await getAxisRegistry();
+	}
+	const downloadCount = await getDownloadCountTotal(id);
+	const defSubsetText = getPreviewText(metadata.id, metadata.defSubset);
+
+	return json({
+		metadata,
+		variable,
+		axisRegistry,
+		defSubsetText,
+		downloadCount,
+	});
+};
+
+interface FontMetadata {
+	metadata: Metadata;
+	variable: VariableData;
+	axisRegistry: Record<string, AxisRegistry>;
+	defSubsetText: string;
+	downloadCount: number;
+}
+
+const useStyles = createStyles((theme) => ({
+	wrapperPreview: {
+		maxWidth: '1440px',
+		marginLeft: 'auto',
+		marginRight: 'auto',
+		padding: '40px 64px',
+
+		[theme.fn.smallerThan('lg')]: {
+			padding: '40px 40px',
+		},
+
+		[theme.fn.smallerThan('xs')]: {
+			padding: '40px 24px',
+		},
+	},
+}));
+
+export default function Font() {
+	const data: FontMetadata = useLoaderData();
+	const { metadata, variable, axisRegistry, defSubsetText } = data;
+	const { classes } = useStyles();
+
+	return (
+		<TabsWrapper metadata={metadata} tabsValue="preview">
+			<Grid className={classes.wrapperPreview}>
+				<Grid.Col span={12} md={8}>
+					<TextArea metadata={metadata} previewText={defSubsetText} />
+				</Grid.Col>
+				<Grid.Col
+					span={12}
+					md={4}
+					sx={(theme) => ({
+						[theme.fn.smallerThan('md')]: {
+							display: 'none',
+						},
+					})}
+				>
+					<Configure
+						metadata={metadata}
+						variable={variable}
+						axisRegistry={axisRegistry}
+					/>
+				</Grid.Col>
+			</Grid>
+		</TabsWrapper>
+	);
+}

--- a/website/app/routes/__boundary/fonts/$id/install.tsx
+++ b/website/app/routes/__boundary/fonts/$id/install.tsx
@@ -1,0 +1,50 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+import invariant from 'tiny-invariant';
+
+import { Install } from '@/components/preview/Install';
+import { TabsWrapper } from '@/components/preview/Tabs';
+import { getDownloadCountTotal } from '@/utils/metadata/download.server';
+import { getMetadata } from '@/utils/metadata/metadata.server';
+import { getVariable } from '@/utils/metadata/variable.server';
+import type { Metadata, VariableData } from '@/utils/types';
+
+export const loader: LoaderFunction = async ({ params }) => {
+	const { id } = params;
+	console.log('id', id);
+	invariant(id, 'Missing font ID!');
+	const metadata = await getMetadata(id);
+	let variable;
+	if (metadata.variable) {
+		variable = await getVariable(id);
+	}
+	const downloadCount = await getDownloadCountTotal(id);
+
+	return json({
+		metadata,
+		variable,
+		downloadCount,
+	});
+};
+
+interface FontMetadata {
+	metadata: Metadata;
+	variable: VariableData;
+	downloadCount: number;
+}
+
+export default function InstallPage() {
+	const data: FontMetadata = useLoaderData();
+	const { metadata, variable, downloadCount } = data;
+
+	return (
+		<TabsWrapper metadata={metadata} tabsValue="install">
+			<Install
+				metadata={metadata}
+				variable={variable}
+				downloadCount={downloadCount}
+			/>
+		</TabsWrapper>
+	);
+}

--- a/website/package.json
+++ b/website/package.json
@@ -45,6 +45,7 @@
 		"react-dom": "^17.0.2",
 		"react-instantsearch-hooks-server": "^6.44.0",
 		"react-instantsearch-hooks-web": "^6.44.0",
+		"react-wrap-balancer": "^0.5.0",
 		"rehype-autolink-headings": "^6.1.1",
 		"rehype-slug": "^5.1.0",
 		"remark-gfm": "^3.0.1",


### PR DESCRIPTION
This adds unobtrusive Carbon Ads to the website to help sponsor the project. This also includes a major refactor to the Preview tabs so that clicking on `Install` tab will change the nav route to `fonts/[id]/install` when previously it did not change the routing.