### PR TITLE
fix(cli): store publish hash when force rebuilding google packages

### DIFF
--- a/.changeset/tender-zoos-talk.md
+++ b/.changeset/tender-zoos-talk.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+When using the force flag, the stored publish hash was removed. This PR stores the hash even when force rebuilding.

--- a/packages/cli/src/templates/package.ts
+++ b/packages/cli/src/templates/package.ts
@@ -48,18 +48,19 @@ const template = (
 
 const packageJson = async (metadata: Metadata, opts: BuildOptions) => {
 	let oldVersion;
+	let oldPublishHash;
 	try {
 		await fs.access(path.join(opts.dir, 'package.json'));
-		oldVersion = JSON.parse(
-			await fs.readFile(path.join(opts.dir, 'package.json'), 'utf8')
-		).version;
+		const file = await fs.readJson(path.join(opts.dir, 'package.json'));
+		oldVersion = file.version;
+		oldPublishHash = file.publishHash;
 	} catch {
 		// Continue
 	}
 
 	const file = template(metadata, opts.isVariable, {
 		oldVersion: opts.version ?? oldVersion,
-		publishHash: opts.publishHash,
+		publishHash: opts.publishHash ?? oldPublishHash,
 	});
 	await fs.writeFile(path.join(opts.dir, 'package.json'), stringify(file));
 };


### PR DESCRIPTION
Force rebuilding the repo nukes the saved publish hashes (the way we determine whether a package has changed or not. This stores the hash even when using the force flag packages.