### PR TITLE
fix(publish): invalid merge flags

### DIFF
--- a/.changeset/witty-steaks-compare.md
+++ b/.changeset/witty-steaks-compare.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/publish": patch
+---
+
+Fix invalid merge flags function leading to missing publish context.

--- a/packages/publish/src/utils.ts
+++ b/packages/publish/src/utils.ts
@@ -8,16 +8,21 @@ const getPackages = async (dir: string): Promise<string[]> => {
 		withFileTypes: true,
 	});
 	return packages
-		.filter(dirent => dirent.isDirectory())
-		.map(dirent => dirent.name);
+		.filter((dirent) => dirent.isDirectory())
+		.map((dirent) => dirent.name);
 };
 
 const mergeFlags = async (options: Flags): Promise<Context> => {
 	const flags = {} as Context;
 	// CLI args come in string format
-	if (options.packages) flags.packages = options.packages.split(',');
+	if (options.packages) {
+		flags.packages = options.packages.split(',');
+		delete options.packages;
+	}
+
+	Object.assign(flags, options);
 
 	return defu(flags, await fs.readJson('font-publish.json'));
 };
 
-export { getPackages,mergeFlags };
+export { getPackages, mergeFlags };

--- a/packages/publish/tests/utils.test.ts
+++ b/packages/publish/tests/utils.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs-extra';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mergeFlags } from '../src/utils';
+
+vi.mock('fs-extra');
+
+describe('utils', () => {
+	vi.mocked(fs.readJSON).mockResolvedValue({
+		packages: ['./packages/'],
+		commitMessage: 'chore: release new versions',
+	});
+
+	it('merges flags correctly', async () => {
+		const result = await mergeFlags({
+			yes: true,
+		});
+
+		expect(result).toEqual({
+			packages: ['./packages/'],
+			commitMessage: 'chore: release new versions',
+			yes: true,
+		});
+	});
+});


### PR DESCRIPTION
Merge flags was losing context for CLI flags other than packages such as `--yes`, leading to unexpected outputs. This fixes the mergeFlags function to properly assign properties into context.