### PR TITLE
fix(publish): enable force flag

### DIFF
--- a/.changeset/tender-taxis-serve.md
+++ b/.changeset/tender-taxis-serve.md
@@ -2,4 +2,4 @@
 "@fontsource-utils/publish": patch
 ---
 
-fix(publish): enable force flag
+Enable force flag in publisher.

--- a/.changeset/tender-taxis-serve.md
+++ b/.changeset/tender-taxis-serve.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/publish": patch
+---
+
+fix(publish): enable force flag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Release

--- a/packages/publish/src/changed.ts
+++ b/packages/publish/src/changed.ts
@@ -16,7 +16,7 @@ const getChanged = async (ctx: Context) => {
 	const handleHash = async (packagePath: string, packageJson: PackageJson) => {
 		// Get hash of current package and compare with old hash
 		const hash = await getHash(packagePath);
-		if (packageJson.publishHash !== hash || ctx.forcePublish) {
+		if (packageJson.publishHash !== hash || ctx.force) {
 			changedList.push({
 				name: packageJson.name,
 				hash,

--- a/packages/publish/src/cli.ts
+++ b/packages/publish/src/cli.ts
@@ -32,6 +32,7 @@ cli
 		'changed',
 		'Calculates hashes and lists all packages that have changes made to them'
 	)
+	.option('--force', 'Force publish ALL packages regardless if changed or not')
 	.option('--commit-message', 'Change commit message')
 	.option('--packages', 'Package directory')
 	.action(async (opts: ChangedFlags) => {

--- a/packages/publish/src/types.ts
+++ b/packages/publish/src/types.ts
@@ -15,7 +15,7 @@ export interface Context {
 	updateMessage?: string;
 	git?: Git;
 	noVerify?: boolean;
-	forcePublish?: boolean;
+	force?: boolean;
 	yes?: boolean;
 }
 

--- a/packages/publish/tests/changed.test.ts
+++ b/packages/publish/tests/changed.test.ts
@@ -8,7 +8,7 @@ describe('get changed packages', () => {
 		ignoreExtension: [],
 		commitMessage: 'chore: release new versions',
 	};
-	it('lists all the packages', async () => {
+	it('lists all changed packages', async () => {
 		const packages = await getChanged(config);
 		// Package 1 has no hash, so it should generate a new one
 		// Package 2 has a matching existing hash, so it should not generate a new one
@@ -19,6 +19,33 @@ describe('get changed packages', () => {
 				path: 'packages/publish/tests/fixtures/package1',
 				hash: '2d7f1808da1fa63c',
 				version: '0.1.0',
+			},
+			{
+				name: 'package3',
+				path: 'packages/publish/tests/fixtures/package3diff',
+				hash: 'd4a613dee558a143',
+				version: '0.3.0',
+			},
+		]);
+	});
+
+	it('lists all packages with force flag', async () => {
+		const packages = await getChanged({
+			...config,
+			force: true,
+		});
+		expect(packages).toEqual([
+			{
+				name: 'package1',
+				path: 'packages/publish/tests/fixtures/package1',
+				hash: '2d7f1808da1fa63c',
+				version: '0.1.0',
+			},
+			{
+				name: 'package2',
+				path: 'packages/publish/tests/fixtures/package2',
+				hash: '2d7f1808da1fa63c',
+				version: '0.2.0',
 			},
 			{
 				name: 'package3',


### PR DESCRIPTION
The `--force` flag was not mapped correctly to the `forcePublish` config. This PR changes the config to just be `force` now.