### PR TITLE
fix(docs): italics typo on v5 migration docs

### DIFF
--- a/website/docs/getting-started/migrate-v5.mdx
+++ b/website/docs/getting-started/migrate-v5.mdx
@@ -30,9 +30,9 @@ import "@fontsource/roboto-flex/variable-full-italic.css";
 
 ```js
 import "@fontsource-variable/roboto-flex";
-import "@fontsource-variable/roboto-flex/wght-ital.css";
+import "@fontsource-variable/roboto-flex/wght-italic.css";
 import "@fontsource-variable/roboto-flex/full.css";
-import "@fontsource-variable/roboto-flex/full-ital.css";
+import "@fontsource-variable/roboto-flex/full-italic.css";
 ```
 
 ### Variable Font Family Names

--- a/website/docs/getting-started/variable.mdx
+++ b/website/docs/getting-started/variable.mdx
@@ -28,7 +28,7 @@ This will import the standard weight of the font. If you want to use a specific 
 
 ```jsx
 // Supports weights 100-900 in italic style.
-import "@fontsource-variable/roboto-flex/wght-ital.css";
+import "@fontsource-variable/roboto-flex/wght-italic.css";
 ```
 
 ### 3. CSS
@@ -76,9 +76,9 @@ Fontsource's variable axes encompass a range of standard and custom options. The
 
 ```jsx
 import "@fontsource-variable/roboto-flex/wght.css";
-import "@fontsource-variable/roboto-flex/wdth-ital.css";
+import "@fontsource-variable/roboto-flex/wdth-italic.css";
 import "@fontsource-variable/roboto-flex/slnt.css";
-import "@fontsource-variable/roboto-flex/opsz-ital.css";
+import "@fontsource-variable/roboto-flex/opsz-italic.css";
 ```
 
 > **Note:** Every import includes the `wght` axis as multiple imports of different axes are not supported. You **must** use a single import when importing variable fonts.


### PR DESCRIPTION
During a V5 migration to `@fontsource-variable/exo-2`, I found a little typo on the docs regarding the `italic` variable typing.

Below its a capture of the `node_modules` for `"@fontsource-variable/exo-2": "5.0.1"`:
![image](https://github.com/fontsource/fontsource/assets/16224847/4bf8a3bd-923e-47b6-b329-7508428c3d6f)
