### PR TITLE
ci: use pull request target to trigger workflow

### DIFF
--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -1,6 +1,6 @@
 name: Website Staging Deploy
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -13,6 +13,9 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://staging.fontsource.org/
     defaults:
       run:
         working-directory: website

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -10,9 +10,17 @@ permissions:
   pull-requests: write
 
 jobs:
+  approve:
+    name: Approve PR to deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: echo For security reasons, all pull requests from a fork need to be approved first before deploying.
+
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    needs: [approve]
     environment:
       name: staging
       url: https://staging.fontsource.org/


### PR DESCRIPTION
This should fix the missing Fly API token for staging PRs. Technically secrets can't go to forks, so using `pull_request_target` runs the workflow in this repo instead. That has security implications, so I've also enabled an approval step.