### PR TITLE
fix(cli): rework font downloading

### DIFF
--- a/.changeset/blue-panthers-deny.md
+++ b/.changeset/blue-panthers-deny.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+Remove duplicated WOFF file downloads of different content for Google Font packages.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,6 @@
 		"cac": "^6.7.14",
 		"consola": "^3.1.0",
 		"dotenv": "^16.0.3",
-		"flat": "^5.0.2",
 		"fs-extra": "^11.1.1",
 		"google-font-metadata": "^5.2.0",
 		"json-stringify-pretty-compact": "^4.0.0",
@@ -49,7 +48,6 @@
 	},
 	"devDependencies": {
 		"@ayuhito/eslint-config": "^0.2.4",
-		"@types/flat": "^5.0.2",
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.1.3",
 		"eslint": "^8.40.0",

--- a/packages/cli/src/google/download.ts
+++ b/packages/cli/src/google/download.ts
@@ -11,7 +11,11 @@ import PQueue from 'p-queue';
 import * as path from 'pathe';
 
 import { BuildOptions } from '../types';
-import { makeFontDownloadPath, makeVariableFontDownloadPath } from '../utils';
+import {
+	assertNever,
+	makeFontDownloadPath,
+	makeVariableFontDownloadPath,
+} from '../utils';
 
 const writeDownload = async (url: string, dest: fs.PathLike) => {
 	const response = await fetch(url).then((res) => res.arrayBuffer());
@@ -125,8 +129,7 @@ const getDownloadPath = (
 			variant.style
 		);
 	}
-	// Makes sure that all variants are handled above.
-	return variant;
+	return assertNever(variant);
 };
 
 const variantsToLinks = (

--- a/packages/cli/src/google/download.ts
+++ b/packages/cli/src/google/download.ts
@@ -1,4 +1,3 @@
-import flatten from 'flat';
 import fs from 'fs-extra';
 import type { FontVariants, FontVariantsVariable } from 'google-font-metadata';
 import {
@@ -19,34 +18,82 @@ const writeDownload = async (url: string, dest: fs.PathLike) => {
 	await fs.writeFile(dest, Buffer.from(response));
 };
 
-// Parse API and split into variant + link array pairs.
-const pairGenerator = (
-	variants: FontVariants | FontVariantsVariable
-): string[][] => {
-	// [['weight.style.subset.url.extension', 'link to font or local name'], ...]
-	const flattenedPairs: [string, string][] = Object.entries(flatten(variants));
-	// Split ['weight.style.subset.url|local.extension'] into individual array elements
-	const splitPairs = flattenedPairs.map((pair) => [
-		pair[0].split('.'),
-		pair[1],
-	]) as string[][];
+type StaticVariant = {
+	kind: 'static';
+	weight: number;
+	style: string;
+	subset: string;
+	url: string;
+	extension: 'woff' | 'woff2';
+};
 
-	// Ensure that the pair has a valid URL to download
-	const ABSOLUTE_URL_REGEX = /^https?:\/\//;
-	const urlPairs = splitPairs.filter((pair) =>
-		ABSOLUTE_URL_REGEX.test(pair[1].toString())
-	);
+type VariableVariant = {
+	kind: 'variable';
+	axes: string;
+	style: string;
+	subset: string;
+	url: string;
+	extension: 'woff2';
+};
 
-	// Filter out TTF and OTF files as they are not needed for NPM
-	const cleanedPairs = urlPairs.filter((pair) => {
-		const extension = pair[0][4];
-		if (extension === 'truetype' || extension === 'opentype') {
-			return false;
+type Variant = StaticVariant | VariableVariant;
+
+const isAbsoluteURL = (url: string): boolean => {
+	return /^https?:\/\//.test(url);
+};
+
+const getStaticVariantList = (variants: FontVariants): StaticVariant[] => {
+	const variantList: StaticVariant[] = [];
+	for (const [weight, styles] of Object.entries(variants)) {
+		for (const [style, subsets] of Object.entries(styles)) {
+			for (const [subset, { url }] of Object.entries(subsets)) {
+				const props = {
+					kind: 'static' as const,
+					weight: Number(weight),
+					style,
+					subset: subset.replace('[', '').replace(']', ''),
+				};
+				if (isAbsoluteURL(url.woff2)) {
+					variantList.push({
+						...props,
+						url: url.woff2,
+						extension: 'woff2',
+					});
+				}
+				if (isAbsoluteURL(url.woff)) {
+					variantList.push({
+						...props,
+						url: url.woff,
+						extension: 'woff',
+					});
+				}
+			}
 		}
-		return true;
-	});
+	}
+	return variantList;
+};
 
-	return cleanedPairs;
+const getVariableVariantList = (
+	variants: FontVariantsVariable
+): VariableVariant[] => {
+	const variantList: VariableVariant[] = [];
+	for (const [axes, styles] of Object.entries(variants)) {
+		for (const [style, subsets] of Object.entries(styles)) {
+			for (const [subset, url] of Object.entries(subsets)) {
+				if (isAbsoluteURL(url)) {
+					variantList.push({
+						kind: 'variable',
+						axes,
+						style,
+						subset: subset.replace('[', '').replace(']', ''),
+						url: url,
+						extension: 'woff2',
+					});
+				}
+			}
+		}
+	}
+	return variantList;
 };
 
 interface DownloadLinks {
@@ -54,145 +101,86 @@ interface DownloadLinks {
 	dest: string;
 }
 
-// Generates pairs of URLs and destinations filtering unsupported formats
-const generateLinks = (id: string, opts: BuildOptions): DownloadLinks[] => {
-	const fontV1 = APIv1[id];
-	const fontV2 = APIv2[id];
-
-	// Parses variants into readable pairs of data
-	// If noSubset is true, we can skip parsing V1 variants
-	let downloadURLPairsV1 = opts.noSubset ? [] : pairGenerator(fontV1.variants);
-	const downloadURLPairsV2 = pairGenerator(fontV2.variants);
-
-	// Flag to check whether font has unicode subsets like [132]
-	let hasUnicodeSubsets = false;
-	const re = /\[.*?]/g;
-	for (const pair of downloadURLPairsV2) {
-		if (re.test(pair[0][2])) {
-			hasUnicodeSubsets = true;
-		}
-	}
-
-	// If true, we need to download the woff2 files from V1. Else remove all woff2 files
-	if (!hasUnicodeSubsets) {
-		downloadURLPairsV1 = downloadURLPairsV1.filter(
-			(pair) => pair[0][4] !== 'woff2'
-		);
-	}
-
-	// V1 { url, dest } pairs
-	const linksV1 = downloadURLPairsV1.map((pair) => {
-		const types = pair[0];
-		const dest = makeFontDownloadPath(
+const getDownloadPath = (
+	id: string,
+	variant: Variant,
+	opts: BuildOptions
+): string => {
+	if (variant.kind === 'static') {
+		return makeFontDownloadPath(
 			opts.dir,
 			id,
-			types[2],
-			Number(types[0]),
-			types[1],
-			types[4]
+			variant.subset,
+			variant.weight,
+			variant.style,
+			variant.extension
 		);
-		const url = pair[1];
-		return {
-			url,
-			dest,
-		};
-	});
-
-	// V2 { url, dest } pairs
-	const linksV2 = downloadURLPairsV2.map((pair) => {
-		const types = pair[0];
-		const dest = makeFontDownloadPath(
+	}
+	if (variant.kind === 'variable') {
+		return makeVariableFontDownloadPath(
 			opts.dir,
 			id,
-			types[2].replace('[', '').replace(']', ''),
-			Number(types[0]),
-			types[1],
-			types[4]
+			variant.subset,
+			variant.axes,
+			variant.style
 		);
+	}
+	// Makes sure that all variants are handled above.
+	return variant;
+};
 
-		const url = pair[1];
-		return { url, dest };
-	});
+const variantsToLinks = (
+	id: string,
+	variants: Variant[],
+	opts: BuildOptions
+): DownloadLinks[] => {
+	// Map of destination paths to download URLs
+	let linkMap = new Map<string, string>();
 
-	const links = [...linksV1, ...linksV2];
+	// We add all variants to the map, later variants will overwrite equivalent earlier variants.
+	// This is to ensure that we don't download the same file twice, and that we select V2 variants over V1 variants.
+	for (const variant of variants) {
+		linkMap.set(getDownloadPath(id, variant, opts), variant.url);
+	}
+
+	const links: DownloadLinks[] = [];
+
+	for (const [dest, url] of linkMap.entries()) {
+		links.push({ url, dest });
+	}
+
 	return links;
+};
+
+// Generates list of URLs and destinations for static fonts
+const staticLinks = (id: string, opts: BuildOptions): DownloadLinks[] => {
+	let variants: Variant[];
+
+	if (opts.isIcon) {
+		const font = APIIconStatic[id];
+		variants = getStaticVariantList(font.variants);
+	} else {
+		const fontV1 = APIv1[id];
+		const fontV2 = APIv2[id];
+
+		// V1 variants are only needed because sometimes V2 variants don't have
+		// language subsets, but if noSubset is true, we can skip parsing them.
+		const variantsV1 = opts.noSubset
+			? []
+			: getStaticVariantList(fontV1.variants);
+		const variantsV2 = getStaticVariantList(fontV2.variants);
+
+		// Order is important here, as we want V2 variants to overwrite V1 variants when deduplicating.
+		variants = [...variantsV1, ...variantsV2];
+	}
+
+	return variantsToLinks(id, variants, opts);
 };
 
 const variableLinks = (id: string, opts: BuildOptions): DownloadLinks[] => {
-	const fontVariable = APIVariable[id];
-
-	const downloadURLPairsVariable = pairGenerator(fontVariable.variants);
-
-	// Variable { url, dest } pairs
-	// Types [type, style, subset]
-	const links = downloadURLPairsVariable.map((pair) => {
-		const types = pair[0];
-		const dest = makeVariableFontDownloadPath(
-			opts.dir,
-			id,
-			types[2].replace('[', '').replace(']', ''),
-			types[0],
-			types[1]
-		);
-		const url = pair[1];
-		return {
-			url,
-			dest,
-		};
-	});
-
-	return links;
-};
-
-const iconStaticLinks = (id: string, opts: BuildOptions): DownloadLinks[] => {
-	const iconStatic = APIIconStatic[id];
-
-	const downloadURLPairsIconStatic = pairGenerator(iconStatic.variants);
-
-	// Icon Static { url, dest } pairs
-	// Types [type, style, subset]
-	const links = downloadURLPairsIconStatic.map((pair) => {
-		const types = pair[0];
-		const dest = makeFontDownloadPath(
-			opts.dir,
-			id,
-			types[2].replace('[', '').replace(']', ''),
-			Number(types[0]),
-			types[1],
-			types[4]
-		);
-		const url = pair[1];
-		return {
-			url,
-			dest,
-		};
-	});
-
-	return links;
-};
-
-const iconVariableLinks = (id: string, opts: BuildOptions): DownloadLinks[] => {
-	const iconVariable = APIIconVariable[id];
-
-	const downloadURLPairsIconVariable = pairGenerator(iconVariable.variants);
-
-	// Icon Variable { url, dest } pairs
-	// Types [type, style, subset]
-	const links = downloadURLPairsIconVariable.map((pair) => {
-		const types = pair[0];
-		const dest = makeVariableFontDownloadPath(
-			opts.dir,
-			id,
-			types[2].replace('[', '').replace(']', ''),
-			types[0],
-			types[1]
-		);
-
-		const url = pair[1];
-		return { url, dest };
-	});
-
-	return links;
+	const font = opts.isIcon ? APIIconVariable[id] : APIVariable[id];
+	const variants = getVariableVariantList(font.variants);
+	return variantsToLinks(id, variants, opts);
 };
 
 const queue = new PQueue({ concurrency: 30 });
@@ -201,14 +189,7 @@ const download = async (id: string, opts: BuildOptions) => {
 	await fs.ensureDir(path.join(opts.dir, 'files'));
 
 	// Get download URLs of font files
-	let links: DownloadLinks[];
-	if (opts.isIcon) {
-		links = opts.isVariable
-			? iconVariableLinks(id, opts)
-			: iconStaticLinks(id, opts);
-	} else {
-		links = opts.isVariable ? variableLinks(id, opts) : generateLinks(id, opts);
-	}
+	let links = opts.isVariable ? variableLinks(id, opts) : staticLinks(id, opts);
 
 	// Download all font files
 	for (const link of links) {
@@ -219,11 +200,9 @@ const download = async (id: string, opts: BuildOptions) => {
 };
 
 export {
-	download,
-	generateLinks,
-	iconStaticLinks,
-	iconVariableLinks,
-	pairGenerator,
+	getStaticVariantList,
+	getVariableVariantList,
+	staticLinks,
 	variableLinks,
-	writeDownload,
+	download,
 };

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -60,9 +60,12 @@ export const licenseShort = (license: string): string | undefined =>
 export const sassVar = (key: string, value: string) =>
 	`$${key}: ${value} !default;\n`;
 
-// `assertNever` will result in a type error if the passed in value is not of type `never`. Useful for exhaustiveness checking.
-// This will never actually be called, will never return, but its return type can be used in place of any value.
-export const assertNever = (value: never): never => value;
+// `assertNever` will result in a type error at compile time, or an exception at runtime,
+// if the passed in value is not of type `never`. Useful for exhaustiveness checking.
+// The result of this function can be used in place of any value (as it will never return).
+export const assertNever = (value: never): never => {
+	throw new Error(`Unhandled union member: ${JSON.stringify(value)}`);
+};
 
 export {
 	findClosest,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -60,6 +60,10 @@ export const licenseShort = (license: string): string | undefined =>
 export const sassVar = (key: string, value: string) =>
 	`$${key}: ${value} !default;\n`;
 
+// `assertNever` will result in a type error if the passed in value is not of type `never`. Useful for exhaustiveness checking.
+// This will never actually be called, will never return, but its return type can be used in place of any value.
+export const assertNever = (value: never): never => value;
+
 export {
 	findClosest,
 	makeFontDownloadPath,

--- a/packages/cli/tests/google/__snapshots__/download.test.ts.snap
+++ b/packages/cli/tests/google/__snapshots__/download.test.ts.snap
@@ -3,10 +3,6 @@
 exports[`download google > download links > should generate links for base font (abel) 1`] = `
 [
   {
-    "dest": "fonts/google/abel/files/abel-latin-400-normal.woff",
-    "url": "https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE2V9BOw.woff",
-  },
-  {
     "dest": "fonts/google/abel/files/abel-latin-400-normal.woff2",
     "url": "https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE2V9BPQ.woff2",
   },

--- a/packages/cli/tests/google/download.test.ts
+++ b/packages/cli/tests/google/download.test.ts
@@ -2,10 +2,9 @@ import * as gfm from 'google-font-metadata';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-	generateLinks,
-	iconStaticLinks,
-	iconVariableLinks,
-	pairGenerator,
+	getStaticVariantList,
+	getVariableVariantList,
+	staticLinks,
 	variableLinks,
 } from '../../src/google/download';
 import testData from './fixtures/download-file-data.json';
@@ -21,17 +20,19 @@ describe('download google', () => {
 	describe('pair generator', () => {
 		it('should generate APIv1 pairs and strip TTF links', () => {
 			const { APIv1Variant, APIv1Result } = testData;
-			expect(pairGenerator(APIv1Variant)).toEqual(APIv1Result);
+			expect(getStaticVariantList(APIv1Variant)).toEqual(APIv1Result);
 		});
 
 		it('should generate APIv2 pairs and strip OTF links', () => {
 			const { APIv2Variant, APIv2Result } = testData;
-			expect(pairGenerator(APIv2Variant)).toEqual(APIv2Result);
+			expect(getStaticVariantList(APIv2Variant)).toEqual(APIv2Result);
 		});
 
 		it('should generate APIVariable pairs', () => {
 			const { APIVariableVariant, APIVariableResult } = testData;
-			expect(pairGenerator(APIVariableVariant)).toEqual(APIVariableResult);
+			expect(getVariableVariantList(APIVariableVariant)).toEqual(
+				APIVariableResult
+			);
 		});
 	});
 
@@ -51,7 +52,7 @@ describe('download google', () => {
 				force: false,
 				isVariable: false,
 			};
-			expect(generateLinks('abel', buildOpts)).toMatchSnapshot();
+			expect(staticLinks('abel', buildOpts)).toMatchSnapshot();
 		});
 
 		it('should generate links for unicode subset font (noto-sans-jp)', () => {
@@ -62,7 +63,7 @@ describe('download google', () => {
 				isVariable: false,
 				noSubset: false,
 			};
-			expect(generateLinks('noto-sans-jp', buildOpts)).toMatchSnapshot();
+			expect(staticLinks('noto-sans-jp', buildOpts)).toMatchSnapshot();
 		});
 
 		it('should generate links for variable fonts (cabin)', () => {
@@ -83,7 +84,7 @@ describe('download google', () => {
 				isVariable: false,
 				isIcon: true,
 			};
-			expect(iconStaticLinks('material-icons', buildOpts)).toMatchSnapshot();
+			expect(staticLinks('material-icons', buildOpts)).toMatchSnapshot();
 		});
 
 		it('should generate links for icon variable fonts (material-symbols)', () => {
@@ -95,7 +96,7 @@ describe('download google', () => {
 				isIcon: true,
 			};
 			expect(
-				iconVariableLinks('material-symbols-sharp', buildOpts)
+				variableLinks('material-symbols-sharp', buildOpts)
 			).toMatchSnapshot();
 		});
 
@@ -107,7 +108,7 @@ describe('download google', () => {
 				isVariable: false,
 				noSubset: true,
 			};
-			expect(generateLinks('noto-sans-jp', buildOpts)).toMatchSnapshot();
+			expect(staticLinks('noto-sans-jp', buildOpts)).toMatchSnapshot();
 		});
 	});
 });

--- a/packages/cli/tests/google/fixtures/download-file-data.json
+++ b/packages/cli/tests/google/fixtures/download-file-data.json
@@ -14,14 +14,22 @@
 		}
 	},
 	"APIv1Result": [
-		[
-			["400", "italic", "latin", "url", "woff2"],
-			"https://fonts.gstatic.com/s/abeezee/v14/esDT31xSG-6AGleN2tCUkp8D.woff2"
-		],
-		[
-			["400", "italic", "latin", "url", "woff"],
-			"https://fonts.gstatic.com/s/abeezee/v14/esDT31xSG-6AGleN2tCUkp8F.woff"
-		]
+		{
+			"kind": "static",
+			"weight": 400,
+			"style": "italic",
+			"subset": "latin",
+			"url": "https://fonts.gstatic.com/s/abeezee/v14/esDT31xSG-6AGleN2tCUkp8D.woff2",
+			"extension": "woff2"
+		},
+		{
+			"kind": "static",
+			"weight": 400,
+			"style": "italic",
+			"subset": "latin",
+			"url": "https://fonts.gstatic.com/s/abeezee/v14/esDT31xSG-6AGleN2tCUkp8F.woff",
+			"extension": "woff"
+		}
 	],
 
 	"APIv2Variant": {
@@ -39,14 +47,22 @@
 		}
 	},
 	"APIv2Result": [
-		[
-			["100", "normal", "[0]", "url", "woff2"],
-			"https://fonts.gstatic.com/s/notosanshk/v6/nKKO-GM_FYFRJvXzVXaAPe9ZUHp2WPP0IMAVxt9WteveoOOkzD_1Iv4Hrzhqj9DSTKYk.0.woff2"
-		],
-		[
-			["100", "normal", "[0]", "url", "woff"],
-			"https://fonts.gstatic.com/s/notosanshk/v6/nKKO-GM_FYFRJvXzVXaAPe9ZUHpw.woff"
-		]
+		{
+			"kind": "static",
+			"weight": 100,
+			"style": "normal",
+			"subset": "0",
+			"url": "https://fonts.gstatic.com/s/notosanshk/v6/nKKO-GM_FYFRJvXzVXaAPe9ZUHp2WPP0IMAVxt9WteveoOOkzD_1Iv4Hrzhqj9DSTKYk.0.woff2",
+			"extension": "woff2"
+		},
+		{
+			"kind": "static",
+			"weight": 100,
+			"style": "normal",
+			"subset": "0",
+			"url": "https://fonts.gstatic.com/s/notosanshk/v6/nKKO-GM_FYFRJvXzVXaAPe9ZUHpw.woff",
+			"extension": "woff"
+		}
 	],
 
 	"APIVariableVariant": {
@@ -58,13 +74,21 @@
 		}
 	},
 	"APIVariableResult": [
-		[
-			["full", "italic", "vietnamese"],
-			"https://fonts.gstatic.com/s/cabin/v18/u-4_0qWljRw-Pd81z_BCnhRv.woff2"
-		],
-		[
-			["full", "italic", "latin-ext"],
-			"https://fonts.gstatic.com/s/cabin/v18/u-4_0qWljRw-Pd81z_FCnhRv.woff2"
-		]
+		{
+			"kind": "variable",
+			"axes": "full",
+			"style": "italic",
+			"subset": "vietnamese",
+			"url": "https://fonts.gstatic.com/s/cabin/v18/u-4_0qWljRw-Pd81z_BCnhRv.woff2",
+			"extension": "woff2"
+		},
+		{
+			"kind": "variable",
+			"axes": "full",
+			"style": "italic",
+			"subset": "latin-ext",
+			"url": "https://fonts.gstatic.com/s/cabin/v18/u-4_0qWljRw-Pd81z_FCnhRv.woff2",
+			"extension": "woff2"
+		}
 	]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
-      flat:
-        specifier: ^5.0.2
-        version: 5.0.2
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -62,9 +59,6 @@ importers:
       '@ayuhito/eslint-config':
         specifier: ^0.2.4
         version: 0.2.4(eslint@8.40.0)(typescript@5.0.4)
-      '@types/flat':
-        specifier: ^5.0.2
-        version: 5.0.2
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.1
@@ -3609,10 +3603,6 @@ packages:
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
 
-  /@types/flat@5.0.2:
-    resolution: {integrity: sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==}
-    dev: true
-
   /@types/folder-hash@4.0.2:
     resolution: {integrity: sha512-vMVeAUKl8EmDiTLj8XJQL4gJd8UYQfxRUWiv8cZpI/iQcVkS4GHlwVdInH/4iVIzLjlc/+ejcGEhKt92bkWesQ==}
     dev: true
@@ -6720,11 +6710,6 @@ packages:
     dependencies:
       flatted: 3.2.7
       rimraf: 3.0.2
-
-  /flat@5.0.2:
-    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
-    hasBin: true
-    dev: false
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}


### PR DESCRIPTION
Fixes the bug that caused the non-variable Google fonts to be downloaded twice, to the same target file, causing indeterministic file changes and slightly broken font files. See #712 for more context.

Fixes #712.

I ran my WOFF size checking script on the output of this PR, and all the previous errors are gone (except manual fonts), so it seems to work.

There are some unexpected changes relative to [font-files@6332265](https://github.com/fontsource/font-files/tree/63322659a79e97016e971081a27d6640eb30382a):

Some fonts are completely missing, but they also don't show up on the Google Fonts website for me:
- fonts/google/arima-madurai
- fonts/google/fredoka-one
- fonts/google/gentium-book-basic
- fonts/google/kantumruy
- fonts/google/merienda-one

A subset is missing from one font, but again, it doesn't show up in the raw metadata for me either:
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-standard-italic.woff2
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-standard-normal.woff2
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-wdth-italic.woff2
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-wdth-normal.woff2
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-wght-italic.woff2
- fonts/variable/radio-canada/files/radio-canada-canadian-aboriginal-wght-normal.woff2

