### PR TITLE
fix(cli): undo custom package verifier changes

### DIFF
--- a/.changeset/weak-balloons-listen.md
+++ b/.changeset/weak-balloons-listen.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+Undo custom package verifier changes from [#737](https://github.com/fontsource/fontsource/pull/737). 

--- a/packages/cli/src/custom/verify.ts
+++ b/packages/cli/src/custom/verify.ts
@@ -37,10 +37,7 @@ export const verifyFilenames = async (metadata: Metadata, dir: string) => {
 
 	// Check if all expected filenames are present and show all missing or non-matching filenames
 	const missingFilenames = expectedFilenames.filter(
-		(filename) =>
-			!filenames.includes(filename) ||
-			!filename.endsWith('.ttf') ||
-			!filename.endsWith('.otf')
+		(filename) => !filenames.includes(filename)
 	);
 	if (missingFilenames.length > 0) {
 		throw new Error(


### PR DESCRIPTION
Partially undoes #737 changes to the package verifier as that seems to have broken verification tests.