### PR TITLE
fix: update download link to use new download url

### DIFF
--- a/website/app/components/preview/Tabs.tsx
+++ b/website/app/components/preview/Tabs.tsx
@@ -137,7 +137,7 @@ export const TabsWrapper = ({
 						Install
 					</Tabs.Tab>
 					<a
-						href={`https://api.fontsource.org/v1/fonts/${metadata.id}/download`}
+						href={`https://api.fontsource.org/v1/download/${metadata.id}`}
 						className={classes.downloadButton}
 						ref={ref}
 					>


### PR DESCRIPTION
As the API has updated, this URL should be fine to change as it was undocumented.