### PR TITLE
fix(publish): add error count limit before throwing

### DIFF
--- a/.changeset/unlucky-insects-heal.md
+++ b/.changeset/unlucky-insects-heal.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/publish": patch
+---
+
+Add a counter for the maximum number of errors to occur before throwing the whole queue.


### PR DESCRIPTION
Track the number of non-429 errors and only throw the queue after it exceeds 5 rejections. This allows single error failures to not stop the whole publish cycle but also catches when a macro issue is occurring.