### PR TITLE
fix(cli): handle missing license metadata gracefully

### DIFF
--- a/.changeset/rare-olives-learn.md
+++ b/.changeset/rare-olives-learn.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+Handle missing license metadata gracefully in CLI.

--- a/packages/cli/src/google/build.ts
+++ b/packages/cli/src/google/build.ts
@@ -38,7 +38,7 @@ const build = async (id: string, opts: BuildOptions) => {
 
 	// Determine license metadata
 	let fontLicense = APILicense[id];
-	if (!fontLicense) {
+	if (!fontLicense?.license) {
 		consola.warn(`No license metadata found for ${id}`);
 		fontLicense = {
 			id,

--- a/packages/cli/src/google/build.ts
+++ b/packages/cli/src/google/build.ts
@@ -1,3 +1,4 @@
+import consola from 'consola';
 import fs from 'fs-extra';
 import {
 	APIIconStatic as APIIconStaticImport,
@@ -34,7 +35,21 @@ const APIVariable = APIVariableImport;
 const build = async (id: string, opts: BuildOptions) => {
 	const font = opts.isIcon ? APIIconStatic[id] : APIv2[id];
 	const fontVariable = opts.isIcon ? APIIconVariable[id] : APIVariable[id];
-	const fontLicense = APILicense[id];
+
+	// Determine license metadata
+	let fontLicense = APILicense[id];
+	if (!fontLicense) {
+		consola.warn(`No license metadata found for ${id}`);
+		fontLicense = {
+			id,
+			authors: { copyright: 'Google Inc.' },
+			license: {
+				type: 'SIL Open Font License, 1.1',
+				url: 'http://scripts.sil.org/OFL',
+			},
+			original: 'Google Inc.',
+		};
+	}
 
 	// Set file directories
 	await fs.mkdir(opts.dir, { recursive: true });


### PR DESCRIPTION
There seems to be a font that is missing license metadata from GFM upstream. This handles the missing case with a default template while logging the error. The intended behaviour is that the build should succeed with missing license metadata since Google Fonts has a reasonable default.