### PR TITLE
fix(publish): write npmrc inside each package

### DIFF
--- a/.changeset/slimy-buses-flow.md
+++ b/.changeset/slimy-buses-flow.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/publish": patch
+---
+
+Write `.npmrc` inside each package for authentication.


### PR DESCRIPTION
The publish CLI encounters auth errors as apparently writing `.npmrc` is not sufficient in the root of a monorepo. It must be written individually in each package.