### PR TITLE
Fix links in sass-import.mdx

### DIFF
--- a/website/docs/getting-started/sass-import.mdx
+++ b/website/docs/getting-started/sass-import.mdx
@@ -40,5 +40,5 @@ body {
 
 For more advanced usage, you can use the Fontsource Sass mixins to generate a highly customizable CSS file for your font.
 
-- [Faces Mixin](/getting-started/faces-mixin)
-- [Generator Mixin](/getting-started/generator-mixin)
+- [Faces Mixin](/docs/getting-started/faces-mixin)
+- [Generator Mixin](/docs/getting-started/generator-mixin)


### PR DESCRIPTION
Both links at the end here don't work: https://fontsource.org/docs/getting-started/sass-import