### PR TITLE
docs: update readme of material symbols

### DIFF
--- a/website/docs/getting-started/material-symbols.mdx
+++ b/website/docs/getting-started/material-symbols.mdx
@@ -49,7 +49,7 @@ import "@fontsource/material-symbols-sharp";
 
 ### 3. Apply CSS class
 
-To ensure proper rendering of the icons, include the following CSS class in your HTML file. You can use the same class or create different classes for each sy,b set:
+To ensure proper rendering of the icons, include the following CSS class in your HTML file. You can use the same class or create different classes for each icon set:
 
 ```css
 .material-symbols-outlined {

--- a/website/docs/getting-started/material-symbols.mdx
+++ b/website/docs/getting-started/material-symbols.mdx
@@ -17,24 +17,24 @@ To install Material Symbols from Fontsource, follow the steps below:
 
 ### 1. Install Icon Set
 
-Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Icons Round icon set, you would install the `@fontsource/material-icons-round` package.
+Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Symbols Round icon set, you would install the `@fontsource/material-symbols-round` package.
 
 ### 2. Import Icon Set
 
 In your application's entry file or component, import the font variation you installed. For example:
 
 ```jsx
-import "@fontsource-variable/material-icons-outlined";
-import "@fontsource-variable/material-icons-rounded";
-import "@fontsource-variable/material-icons-sharp";
+import "@fontsource-variable/material-symbols-outlined";
+import "@fontsource-variable/material-symbols-rounded";
+import "@fontsource-variable/material-symbols-sharp";
 ```
 
 You can import individual axes or the whole set with these examples:
 
 ```jsx
-import "@fontsource-variable/material-icons-outlined/fill.css";
-import "@fontsource-variable/material-icons-rounded/opsz.css";
-import "@fontsource-variable/material-icons-sharp/full.css";
+import "@fontsource-variable/material-symbols-outlined/fill.css";
+import "@fontsource-variable/material-symbols-rounded/opsz.css";
+import "@fontsource-variable/material-symbols-sharp/full.css";
 ```
 
 Please refer to the [Variable Fonts](/docs/getting-started/variable) guide for more information on using variable fonts.
@@ -42,31 +42,31 @@ Please refer to the [Variable Fonts](/docs/getting-started/variable) guide for m
 If you do not need the variable font support, you can import the standard font variation instead:
 
 ```jsx
-import "@fontsource/material-icons-outlined";
-import "@fontsource/material-icons-rounded";
-import "@fontsource/material-icons-sharp";
+import "@fontsource/material-symbols-outlined";
+import "@fontsource/material-symbols-rounded";
+import "@fontsource/material-symbols-sharp";
 ```
 
 ### 3. Apply CSS class
 
-To ensure proper rendering of the icons, include the following CSS class in your HTML file. You can use the same class or create different classes for each icon set:
+To ensure proper rendering of the icons, include the following CSS class in your HTML file. You can use the same class or create different classes for each sy,b set:
 
 ```css
 .material-symbols-outlined {
-  font-family: 'Material Symbols Outlined';
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;  /* Preferred icon size */
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
+	font-family: "Material Symbols Outlined";
+	font-weight: normal;
+	font-style: normal;
+	font-size: 24px; /* Preferred icon size */
+	display: inline-block;
+	line-height: 1;
+	text-transform: none;
+	letter-spacing: normal;
+	word-wrap: normal;
+	white-space: nowrap;
+	direction: ltr;
 }
 ```
 
 By applying the `.material-symbols-outlined` class to the relevant elements, you can utilize the Material Symbols Outlined font in your application.
 
-You can learn more about styling Material Icons [here](https://developers.google.com/fonts/docs/material_symbols).
+You can learn more about styling Material Symbols [here](https://developers.google.com/fonts/docs/material_symbols).

--- a/website/docs/getting-started/material-symbols.mdx
+++ b/website/docs/getting-started/material-symbols.mdx
@@ -17,7 +17,7 @@ To install Material Symbols from Fontsource, follow the steps below:
 
 ### 1. Install Icon Set
 
-Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Symbols Round icon set, you would install the `@fontsource-variable/material-symbols-round` package.
+Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Symbols Round icon set, you would install the `@fontsource-variable/material-symbols-rounded` package.
 
 ### 2. Import Icon Set
 

--- a/website/docs/getting-started/material-symbols.mdx
+++ b/website/docs/getting-started/material-symbols.mdx
@@ -17,7 +17,7 @@ To install Material Symbols from Fontsource, follow the steps below:
 
 ### 1. Install Icon Set
 
-Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Symbols Round icon set, you would install the `@fontsource/material-symbols-round` package.
+Install the desired icon set from Fontsource using your package manager of choice. For example, if you want to use the Material Symbols Round icon set, you would install the `@fontsource-variable/material-symbols-round` package.
 
 ### 2. Import Icon Set
 


### PR DESCRIPTION
This PR fixes wrong package names in the documentation for Material Symbols. It linked to packages that don't exist.


I also noticed that there isn't any prettier config in this project, as my prettier turned single quotes into double quotes and spaces into tabs. Also in different parts of the docs, there is no consistent formatting.

Maybe one can include a global prettier config to enforce global formatting guidelines?