### PR TITLE
fix(website): update algolia index using api

### DIFF
--- a/website/app/utils/metadata/metadata.server.ts
+++ b/website/app/utils/metadata/metadata.server.ts
@@ -3,6 +3,7 @@ import { kya } from '@/utils/utils.server';
 
 const FONTLIST_URL = 'https://api.fontsource.org/fontlist';
 const METADATA_URL = 'https://api.fontsource.org/v1/fonts/';
+const FULL_METADATA_URL = 'https://api.fontsource.org/v1/fonts';
 
 const getFontlist = async (): Promise<Record<string, string>> => {
 	const fontlist = await kya(FONTLIST_URL);
@@ -12,8 +13,18 @@ const getFontlist = async (): Promise<Record<string, string>> => {
 
 const getMetadata = async (id: string): Promise<Metadata> => {
 	const metadata: Metadata = await kya(METADATA_URL + id);
+	return metadata;
+};
+
+const getFullMetadata = async (): Promise<Record<string, Metadata>> => {
+	const metadataArr: Metadata[] = await kya(FULL_METADATA_URL);
+	const metadata: Record<string, Metadata> = {};
+
+	for (const item of metadataArr) {
+		metadata[item.id] = item;
+	}
 
 	return metadata;
 };
 
-export { getFontlist, getMetadata };
+export { getFontlist, getFullMetadata, getMetadata };


### PR DESCRIPTION
This should reduce the unnecessary HTTP requests to the API by using the main API list metadata instead when updating the Algolia index.