### PR TITLE
fix(api): id query not allowed in fonts route

### DIFF
--- a/.changeset/polite-birds-eat.md
+++ b/.changeset/polite-birds-eat.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Fix id query not allowed in API fonts route

--- a/api/metadata/src/fonts/types.ts
+++ b/api/metadata/src/fonts/types.ts
@@ -16,6 +16,7 @@ interface ArrayMetadataItem {
 type ArrayMetadata = ArrayMetadataItem[];
 
 const fontsQueries = [
+	'id',
 	'family',
 	'subsets',
 	'weights',


### PR DESCRIPTION
Wasen't able to test this, but I think this is why `https://api.fontsource.org/v1/fonts?id=roboto` no longer works.