### PR TITLE
fix(api): update cache expiry rules for metadata worker

### DIFF
--- a/.changeset/nine-avocados-grow.md
+++ b/.changeset/nine-avocados-grow.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Update cache expiry rules for metadata worker to 6 hours and remove unnecessary CF Cache API references.

--- a/api/metadata/src/fontlist/get.ts
+++ b/api/metadata/src/fontlist/get.ts
@@ -17,9 +17,9 @@ const getOrUpdateMetadata = async (
 		return await updateMetadata(env);
 	}
 
-	// If the ttl is not set or the ttl is greater than the current time, then return old value
+	// If the ttl is not set or the cache expiry is less than the current time, then return old value
 	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl > Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
 		ctx.waitUntil(updateMetadata(env));
 	}
 
@@ -42,9 +42,7 @@ const getOrUpdateList = async (
 		return await updateList(key, env);
 	}
 
-	// If the ttl is not set or the ttl is greater than the current time, then return old value
-	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl > Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
 		ctx.waitUntil(updateList(key, env));
 	}
 

--- a/api/metadata/src/fontlist/router.ts
+++ b/api/metadata/src/fontlist/router.ts
@@ -7,13 +7,6 @@ import { type Fontlist, isFontlistQuery } from './types';
 const router = Router<IRequestStrict, CFRouterContext>();
 
 router.get('/fontlist', async (request, env, ctx) => {
-	// Check cf cache
-	const cacheKey = new Request(request.url, request);
-	const cache = caches.default;
-
-	const response = await cache.match(cacheKey);
-	if (response) return response;
-
 	// Get query string
 	const url = new URL(request.url);
 	const queryString = url.searchParams.toString();

--- a/api/metadata/src/fontlist/update.ts
+++ b/api/metadata/src/fontlist/update.ts
@@ -1,5 +1,5 @@
 import type { FontsourceMetadata } from '../types';
-import { METADATA_URL } from '../utils';
+import { METADATA_URL, TTL_TIME } from '../utils';
 import type { Fontlist, FontlistQueries } from './types';
 
 const updateMetadata = async (env: Env) => {
@@ -10,7 +10,7 @@ const updateMetadata = async (env: Env) => {
 	await env.FONTLIST.put('metadata', JSON.stringify(data), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + 1000 * 60 * 60, // 1 hour
+			ttl: Date.now() + TTL_TIME,
 		},
 	});
 
@@ -33,7 +33,7 @@ const updateList = async (key: FontlistQueries, env: Env) => {
 	// Store the list in KV
 	await env.FONTLIST.put(key, JSON.stringify(list), {
 		metadata: {
-			ttl: Date.now() + 1000 * 60 * 60, // 1 hour
+			ttl: Date.now() + TTL_TIME,
 		},
 	});
 	return list;

--- a/api/metadata/src/fonts/get.ts
+++ b/api/metadata/src/fonts/get.ts
@@ -14,9 +14,9 @@ const getOrUpdateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 		return await updateArrayMetadata(env, ctx);
 	}
 
-	// If the ttl is not set or the ttl is greater than the current time, then return old value
+	// If the ttl is not set or the cache expiry is less than the current time, then return old value
 	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl > Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
 		ctx.waitUntil(updateArrayMetadata(env, ctx));
 	}
 
@@ -33,7 +33,7 @@ const getOrUpdateId = async (id: string, env: Env, ctx: ExecutionContext) => {
 		return await updateId(id, env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl > Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
 		ctx.waitUntil(updateId(id, env, ctx));
 	}
 

--- a/api/metadata/src/fonts/update.ts
+++ b/api/metadata/src/fonts/update.ts
@@ -1,5 +1,6 @@
 import { getOrUpdateMetadata } from '../fontlist/get';
 import type { FontMetadata } from '../types';
+import { TTL_TIME } from '../utils';
 import type { ArrayMetadata, FontVariants, IDResponse } from './types';
 
 // This updates the main array of fonts dataset
@@ -29,7 +30,7 @@ const updateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 	await env.FONTLIST.put('metadata_arr', JSON.stringify(list), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + 1000 * 60 * 60, // 1 hour
+			ttl: Date.now() + TTL_TIME,
 		},
 	});
 	return list;
@@ -95,7 +96,7 @@ const updateId = async (
 	await env.FONTS.put(id, JSON.stringify(value), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + 1000 * 60 * 60, // 1 hour
+			ttl: Date.now() + TTL_TIME,
 		},
 	});
 	return value;

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -1,2 +1,4 @@
 export const METADATA_URL =
 	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/fontsource.json';
+
+export const TTL_TIME = 1000 * 60 * 60 * 6; // 6 hourS


### PR DESCRIPTION
This fixes a bug related to the cache being rewritten on every request instead of following the given directives, as well as removing the unnecessary Cache API implementation when a custom Edge Caching Rule on the CF dashboard could be used.