### PR TITLE
perf(website): increase concurrency for download worker

### DIFF
--- a/.changeset/dry-chairs-speak.md
+++ b/.changeset/dry-chairs-speak.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+perf(website): increase concurrency for download worker

--- a/api/metadata/src/download/get.ts
+++ b/api/metadata/src/download/get.ts
@@ -16,6 +16,13 @@ const getOrUpdateZip = async (tag: string, env: Env) => {
 		if (!resp.ok) {
 			const error = await resp.text();
 
+			if (resp.status === 524) {
+				throw new StatusError(
+					resp.status,
+					'Timeout from download worker. Please try again later as the package may be still downloading to our servers.',
+				);
+			}
+
 			throw new StatusError(
 				resp.status,
 				`Bad response from download worker. ${error}`,

--- a/website/app/utils/download/download.ts
+++ b/website/app/utils/download/download.ts
@@ -52,7 +52,7 @@ export const downloadFile = async (manifest: Manifest) => {
 
 export const downloadManifest = async (manifest: Manifest[]) => {
 	// Create a queue
-	const queue = new PQueue({ concurrency: 12 });
+	const queue = new PQueue({ concurrency: 24 });
 	let hasError: Error | undefined;
 
 	// Download all files


### PR DESCRIPTION
The concurrency can be increased as our VMs can handle it.