### PR TITLE
perf(api): cache metadata on edge

### DIFF
--- a/.changeset/angry-onions-check.md
+++ b/.changeset/angry-onions-check.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+perf(api): cache metadata on edge

--- a/api/metadata/src/download/router.ts
+++ b/api/metadata/src/download/router.ts
@@ -2,6 +2,7 @@ import { getVersion } from 'common-api/util';
 import { error, type IRequestStrict, Router, withParams } from 'itty-router';
 
 import type { CFRouterContext } from '../types';
+import { CF_EDGE_TTL } from '../utils';
 import { getOrUpdateZip } from './get';
 
 interface DownloadRequest extends IRequestStrict {
@@ -24,7 +25,8 @@ router.get('/v1/download/:id', withParams, async (request, env, ctx) => {
 	return new Response(zip.body, {
 		headers: {
 			'Content-Type': 'application/zip',
-			'Content-Disposition': `attachment; filename="${id}.zip"`,
+			'Content-Disposition': `attachment; filename="${tag}.zip"`,
+			'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 		},
 	});
 });

--- a/api/metadata/src/fontlist/router.ts
+++ b/api/metadata/src/fontlist/router.ts
@@ -1,6 +1,7 @@
 import { error, type IRequestStrict, json, Router } from 'itty-router';
 
 import type { CFRouterContext } from '../types';
+import { CF_EDGE_TTL } from '../utils';
 import { getOrUpdateList } from './get';
 import { type Fontlist, isFontlistQuery } from './types';
 
@@ -40,7 +41,11 @@ router.get('/fontlist', async (request, env, ctx) => {
 		return error(500, 'Internal server error.');
 	}
 
-	return json(list);
+	return json(list, {
+		headers: {
+			'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
+		},
+	});
 });
 
 // 404 for everything else

--- a/api/metadata/src/fontlist/update.ts
+++ b/api/metadata/src/fontlist/update.ts
@@ -1,5 +1,5 @@
 import type { FontsourceMetadata } from '../types';
-import { METADATA_URL, TTL_TIME } from '../utils';
+import { KV_TTL, METADATA_URL } from '../utils';
 import type { Fontlist, FontlistQueries } from './types';
 
 const updateMetadata = async (env: Env) => {
@@ -10,7 +10,7 @@ const updateMetadata = async (env: Env) => {
 	await env.FONTLIST.put('metadata', JSON.stringify(data), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + TTL_TIME,
+			ttl: Date.now() + KV_TTL,
 		},
 	});
 
@@ -33,7 +33,7 @@ const updateList = async (key: FontlistQueries, env: Env) => {
 	// Store the list in KV
 	await env.FONTLIST.put(key, JSON.stringify(list), {
 		metadata: {
-			ttl: Date.now() + TTL_TIME,
+			ttl: Date.now() + KV_TTL,
 		},
 	});
 	return list;

--- a/api/metadata/src/fonts/router.ts
+++ b/api/metadata/src/fonts/router.ts
@@ -10,6 +10,7 @@ import {
 
 import { getOrUpdateFile } from '../download/get';
 import { type CFRouterContext } from '../types';
+import { CF_EDGE_TTL } from '../utils';
 import { getOrUpdateArrayMetadata, getOrUpdateId } from './get';
 import { isFontsQueries } from './types';
 
@@ -58,7 +59,11 @@ router.get('/v1/fonts', async (request, env, ctx) => {
 	}
 
 	// Return the filtered results
-	return json(filtered);
+	return json(filtered, {
+		headers: {
+			'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
+		},
+	});
 });
 
 router.get('/v1/fonts/:id', withParams, async (request, env, ctx) => {
@@ -69,7 +74,11 @@ router.get('/v1/fonts/:id', withParams, async (request, env, ctx) => {
 		return error(404, 'Not Found. Font does not exist.');
 	}
 
-	return json(data);
+	return json(data, {
+		headers: {
+			'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
+		},
+	});
 });
 
 // This is a deprecated route, but we need to keep it for backwards compatibility
@@ -90,6 +99,7 @@ router.get('/v1/fonts/:id/:file', withParams, async (request, env, _ctx) => {
 		return new Response(font.body, {
 			headers: {
 				'Content-Type': 'font/woff2',
+				'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 			},
 		});
 	}
@@ -98,6 +108,7 @@ router.get('/v1/fonts/:id/:file', withParams, async (request, env, _ctx) => {
 		return new Response(font.body, {
 			headers: {
 				'Content-Type': 'font/woff',
+				'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 			},
 		});
 	}
@@ -106,6 +117,7 @@ router.get('/v1/fonts/:id/:file', withParams, async (request, env, _ctx) => {
 		return new Response(font.body, {
 			headers: {
 				'Content-Type': 'font/ttf',
+				'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 			},
 		});
 	}
@@ -114,6 +126,7 @@ router.get('/v1/fonts/:id/:file', withParams, async (request, env, _ctx) => {
 		return new Response(font.body, {
 			headers: {
 				'Content-Type': 'font/otf',
+				'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 			},
 		});
 	}

--- a/api/metadata/src/fonts/update.ts
+++ b/api/metadata/src/fonts/update.ts
@@ -1,6 +1,6 @@
 import { getOrUpdateMetadata } from '../fontlist/get';
 import type { FontMetadata } from '../types';
-import { TTL_TIME } from '../utils';
+import { KV_TTL } from '../utils';
 import type { ArrayMetadata, FontVariants, IDResponse } from './types';
 
 // This updates the main array of fonts dataset
@@ -30,7 +30,7 @@ const updateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 	await env.FONTLIST.put('metadata_arr', JSON.stringify(list), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + TTL_TIME,
+			ttl: Date.now() + KV_TTL,
 		},
 	});
 	return list;
@@ -96,7 +96,7 @@ const updateId = async (
 	await env.FONTS.put(id, JSON.stringify(value), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + TTL_TIME,
+			ttl: Date.now() + KV_TTL,
 		},
 	});
 	return value;

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -1,4 +1,6 @@
 export const METADATA_URL =
 	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/fontsource.json';
 
-export const TTL_TIME = 1000 * 60 * 60 * 6; // 6 hourS
+export const KV_TTL = 1000 * 60 * 60 * 6; // 6 hourS
+
+export const CF_EDGE_TTL = 7200; // 2 hours


### PR DESCRIPTION
This uses the `CDN-Cache-Control` header to cache all requests on the Cloudflare CDN without using the browser cache.