### PR TITLE
fix(api): update cf version funcs to throw statuserrors

### DIFF
--- a/.changeset/soft-buttons-repeat.md
+++ b/.changeset/soft-buttons-repeat.md
@@ -1,0 +1,5 @@
+---
+"common-api": patch
+---
+
+fix(api): update cf version funcs to throw statuserrors


### PR DESCRIPTION
The common API package should never throw Responses, just StatusErrors else a worker exception would occur. This corrects the thrown errors to the correct type.