### PR TITLE
feat(api): add css endpoint

### DIFF
--- a/.changeset/smooth-apples-wonder.md
+++ b/.changeset/smooth-apples-wonder.md
@@ -1,0 +1,6 @@
+---
+"cdn": patch
+"common-api": patch
+---
+
+feat(api): add css endpoint

--- a/api/README.md
+++ b/api/README.md
@@ -6,6 +6,7 @@ Learn more about the API at [fontsource.org](https://fontsource.org/docs/api/int
 
 ### Workers
 
+- [cdn](./cdn) - The worker that acts as the origin for the jsDelivr CDN proxy.
 - [common](./common) - A shared library of common functions and types used by the other workers.
 - [metadata](./metadata) - The API worker that serves the KV metadata for the fonts.
 - [upload](./upload) - A worker that uploads font files from our website VM to R2.

--- a/api/cdn/package.json
+++ b/api/cdn/package.json
@@ -20,6 +20,7 @@
 		"wrangler": "^3.7.0"
 	},
 	"dependencies": {
+		"@fontsource-utils/generate": "workspace:*",
 		"common-api": "workspace:*"
 	}
 }

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -12,22 +12,42 @@ const makeFontFilePath = (
 	return `https://r2.fontsource.org/fonts/${tag}/${subset}-${weight}-${style}.${extension}`;
 };
 
+// Insert a weight array to find the closest number given num - used for index.css gen
+const findClosest = (arr: number[], num: number): number => {
+	// Array of absolute values showing diff from target number
+	const indexArr = arr.map((weight) => Math.abs(Number(weight) - num));
+	// Find smallest diff
+	const min = Math.min(...indexArr);
+	const closest = arr[indexArr.indexOf(min)];
+
+	return closest;
+};
+
 export const updateCss = (
 	tag: string,
 	fileName: string,
 	metadata: IDResponse,
 ) => {
-	const { family, styles, subsets, weights, unicodeRange } = metadata;
-	const [subset, weight, style] = fileName.split('-');
+	const { family, styles, subsets, weights, unicodeRange, defSubset } =
+		metadata;
+	const isIndex = fileName === 'index';
+	let [subset, weight, style] = fileName.split('-');
 	if (
-		!subset ||
-		!weight ||
-		!style ||
-		!subsets.includes(subset) ||
-		!weights.includes(Number(weight)) ||
-		!styles.includes(style)
+		!isIndex &&
+		(!subset ||
+			!weight ||
+			!style ||
+			!subsets.includes(subset) ||
+			!weights.includes(Number(weight)) ||
+			!styles.includes(style))
 	) {
 		throw new StatusError(404, 'Not Found. Invalid filename.');
+	}
+
+	if (isIndex) {
+		subset = defSubset;
+		weight = String(findClosest(weights, 400));
+		style = 'normal';
 	}
 
 	const fontObj: FontObject = {

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -1,0 +1,53 @@
+import { type FontObject, generateFontFace } from '@fontsource-utils/generate';
+import { type IDResponse } from 'common-api/types';
+import { StatusError } from 'itty-router';
+
+const makeFontFilePath = (
+	tag: string,
+	subset: string,
+	weight: string,
+	style: string,
+	extension: string,
+) => {
+	return `https://r2.fontsource.org/fonts/${tag}/${subset}-${weight}-${style}.${extension}`;
+};
+
+export const updateCss = (
+	tag: string,
+	fileName: string,
+	metadata: IDResponse,
+) => {
+	const { family, styles, subsets, weights, unicodeRange } = metadata;
+	const [subset, weight, style] = fileName.split('-');
+	if (
+		!subset ||
+		!weight ||
+		!style ||
+		!subsets.includes(subset) ||
+		!weights.includes(Number(weight)) ||
+		!styles.includes(style)
+	) {
+		throw new StatusError(404, 'Not Found. Invalid filename.');
+	}
+
+	const fontObj: FontObject = {
+		family,
+		style,
+		display: 'swap',
+		weight: Number(weight),
+		unicodeRange: unicodeRange[subset],
+		src: [
+			{
+				url: makeFontFilePath(tag, subset, weight, style, 'woff2'),
+				format: 'woff2' as const,
+			},
+			{
+				url: makeFontFilePath(tag, subset, weight, style, 'woff'),
+				format: 'woff' as const,
+			},
+		],
+		comment: `${subset}`,
+	};
+
+	return generateFontFace(fontObj);
+};

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -37,9 +37,9 @@ router.get('/fonts/:tag/:file', withParams, async (request, env, _ctx) => {
 	const isZip = extension === 'zip';
 	// If version is a specific version e.g. @3.1.1, give maximum cache, else give 1 day
 	const cacheControl =
-		version.split('.').length === 3
+		tag.split('@')[1].split('.').length === 3
 			? 'public, max-age=31536000, immutable'
-			: 'public, max-age=86400';
+			: 'public, max-age=86400, stale-while-revalidate=604800';
 
 	const headers = {
 		'Cache-Control': cacheControl,
@@ -110,7 +110,7 @@ router.get('/css/:tag/:file', withParams, async (request, env, ctx) => {
 
 	// If version is a specific version e.g. @3.1.1, give maximum cache, else give 1 day
 	const cacheControl =
-		version.split('.').length === 3
+		tag.split('@')[1].split('.').length === 3
 			? 'public, max-age=31536000, immutable'
 			: 'public, max-age=86400, stale-while-revalidate=604800';
 

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -36,8 +36,9 @@ router.get('/fonts/:tag/:file', withParams, async (request, env, _ctx) => {
 
 	const isZip = extension === 'zip';
 	// If version is a specific version e.g. @3.1.1, give maximum cache, else give 1 day
+	const tagSplit = tag.split('@')[1];
 	const cacheControl =
-		tag.split('@')[1].split('.').length === 3
+		tagSplit && tagSplit.split('.').length === 3
 			? 'public, max-age=31536000, immutable'
 			: 'public, max-age=86400, stale-while-revalidate=604800';
 
@@ -109,9 +110,11 @@ router.get('/css/:tag/:file', withParams, async (request, env, ctx) => {
 	}
 
 	// If version is a specific version e.g. @3.1.1, give maximum cache, else give 1 day
+	const tagSplit = tag.split('@')[1];
 	const cacheControl =
-		tag.split('@')[1].split('.').length === 3
-			? 'public, max-age=31536000, immutable'
+		tagSplit && tagSplit.split('.').length === 3
+			? // TODO: Replace with immutable once we migrate to jsdelivr proxy
+			  'public, max-age=86400, stale-while-revalidate=604800' // 'public, max-age=31536000, immutable'
 			: 'public, max-age=86400, stale-while-revalidate=604800';
 
 	const headers = {

--- a/api/cdn/src/util.ts
+++ b/api/cdn/src/util.ts
@@ -8,74 +8,62 @@ export const isAcceptedExtension = (
 ): extension is AcceptedExtension =>
 	ACCEPTED_EXTENSIONS.includes(extension as AcceptedExtension);
 
-const getOrUpdateZip = async (tag: string, env: Env) => {
-	// Check if download.zip exists in bucket
-	const zip = await env.BUCKET.get(`${tag}/download.zip`);
-	if (!zip) {
-		// Try calling download worker
-		const req = new Request(`https://fontsource.org/actions/download/${tag}`, {
+export const updateZip = async (tag: string, env: Env) => {
+	// Try calling download worker
+	const req = new Request(`https://fontsource.org/actions/download/${tag}`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${env.UPLOAD_KEY}`,
+		},
+	});
+
+	const resp = await fetch(req);
+	if (!resp.ok) {
+		const error = await resp.text();
+
+		if (resp.status === 524) {
+			throw new StatusError(
+				resp.status,
+				'Timeout from download worker. Please try again later as the package may be still downloading to our servers.',
+			);
+		}
+
+		throw new StatusError(
+			resp.status,
+			`Bad response from download worker. ${error}`,
+		);
+	}
+
+	// Check again if download.zip exists in bucket
+	const zip = await env.FONTS.get(`${tag}/download.zip`);
+	return zip;
+};
+
+export const updateFile = async (tag: string, file: string, env: Env) => {
+	// Try calling download worker
+	const req = new Request(
+		`https://fontsource.org/actions/download/${tag}/${file}`,
+		{
 			method: 'POST',
 			headers: {
 				Authorization: `Bearer ${env.UPLOAD_KEY}`,
 			},
-		});
+		},
+	);
 
-		const resp = await fetch(req);
-		if (!resp.ok) {
-			const error = await resp.text();
-
-			if (resp.status === 524) {
-				throw new StatusError(
-					resp.status,
-					'Timeout from download worker. Please try again later as the package may be still downloading to our servers.',
-				);
-			}
-
-			throw new StatusError(
-				resp.status,
-				`Bad response from download worker. ${error}`,
-			);
+	const resp = await fetch(req);
+	if (!resp.ok) {
+		if (resp.status === 404) {
+			throw new StatusError(resp.status, 'Not Found. File does not exist.');
 		}
+		const error = await resp.text();
 
-		// Check again if download.zip exists in bucket
-		const zip = await env.BUCKET.get(`${tag}/download.zip`);
-		return zip;
-	}
-	return zip;
-};
-
-const getOrUpdateFile = async (tag: string, file: string, env: Env) => {
-	// Check if file exists in bucket
-	const font = await env.BUCKET.get(`${tag}/${file}`);
-	if (!font) {
-		// Try calling download worker
-		const req = new Request(
-			`https://fontsource.org/actions/download/${tag}/${file}`,
-			{
-				method: 'POST',
-				headers: {
-					Authorization: `Bearer ${env.UPLOAD_KEY}`,
-				},
-			},
+		throw new StatusError(
+			resp.status,
+			`Bad response from download worker. ${error}`,
 		);
-
-		const resp = await fetch(req);
-		if (!resp.ok) {
-			if (resp.status === 404) {
-				throw new StatusError(resp.status, 'Not Found. File does not exist.');
-			}
-			const error = await resp.text();
-
-			throw new StatusError(
-				resp.status,
-				`Bad response from download worker. ${error}`,
-			);
-		}
-		// Check again if file exists in bucket
-		const font = await env.BUCKET.get(`${tag}/${file}`);
-		return font;
 	}
+	// Check again if file exists in bucket
+	const font = await env.FONTS.get(`${tag}/${file}`);
 	return font;
 };
-
-export { getOrUpdateFile, getOrUpdateZip };

--- a/api/cdn/worker-configuration.d.ts
+++ b/api/cdn/worker-configuration.d.ts
@@ -1,5 +1,6 @@
 interface Env {
-	BUCKET: R2Bucket;
+	CSS: KVNamespace;
+	FONTS: R2Bucket;
 	METADATA: Fetcher;
 
 	// Secrets

--- a/api/cdn/wrangler.toml
+++ b/api/cdn/wrangler.toml
@@ -2,8 +2,10 @@ name = "cdn"
 main = "src/worker.ts"
 compatibility_date = "2023-05-27"
 
+kv_namespaces = [{ binding = "CSS", id = "be3369d7d4c345c5bb9139f3c00f7c19" }]
+
 r2_buckets = [
-  { binding = "BUCKET", bucket_name = "fonts", preview_bucket_name = "fonts-preview" },
+  { binding = "FONTS", bucket_name = "fonts", preview_bucket_name = "fonts-preview" },
 ]
 
 services = [

--- a/api/common/util.ts
+++ b/api/common/util.ts
@@ -206,7 +206,7 @@ export const splitTag = async (tag: string): Promise<Tag> => {
 
 export const splitTagCF = async (tag: string): Promise<Tag> => {
 	// Parse tag for version e.g roboto@1.1.1
-	const [id, versionTag] = tag.split('@');
+	let [id, versionTag] = tag.split('@');
 	if (!id) {
 		throw new StatusError(
 			400,
@@ -214,10 +214,7 @@ export const splitTagCF = async (tag: string): Promise<Tag> => {
 		);
 	}
 	if (!versionTag) {
-		throw new StatusError(
-			400,
-			'Bad Request. Unable to parse version from tag.',
-		);
+		versionTag = 'latest';
 	}
 
 	// Validate version tag

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   api/cdn:
     dependencies:
+      '@fontsource-utils/generate':
+        specifier: workspace:*
+        version: link:../../packages/generate
       common-api:
         specifier: workspace:*
         version: link:../common


### PR DESCRIPTION
This is the initial development for an endpoint to generate CSS for our CDN proxy. This should be an alternative endpoint to the Google Fonts CSS API with stable versioning and SRI guarantees using the jsDelivr network to handle the serving of files.

This currently ONLY supports:
- Static fonts
- Single weight and styles

We still need to add support for merging multiple families, weights and styles together as well as variable font support.