### PR TITLE
perf(website): use css api for index page

### DIFF
--- a/website/app/components/preview/TextArea.tsx
+++ b/website/app/components/preview/TextArea.tsx
@@ -158,12 +158,13 @@ const TextArea = ({ metadata }: TextAreaProps) => {
 	const isVariable = Boolean(metadata.variable);
 
 	const [loading, setLoading] = useState(true);
+
 	useLoadFont(
 		metadata.id,
 		metadata.family,
 		isVariable ? 'variable' : 'all',
 		setLoading,
-		metadata.weights
+		metadata.weights,
 	);
 
 	return (

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -16,7 +16,6 @@ import {
 } from 'react-instantsearch-hooks-web';
 
 import { useIsFontLoaded } from '@/hooks/useIsFontLoaded';
-import { useLoadFont } from '@/hooks/useLoadFont';
 import type { AlgoliaMetadata } from '@/utils/types';
 
 import { display, previewValue, size } from './observables';

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -15,6 +15,7 @@ import {
 	useInstantSearch,
 } from 'react-instantsearch-hooks-web';
 
+import { useIsFontLoaded } from '@/hooks/useIsFontLoaded';
 import { useLoadFont } from '@/hooks/useLoadFont';
 import type { AlgoliaMetadata } from '@/utils/types';
 
@@ -78,8 +79,7 @@ const HitComponent = ({ hit, fontSize }: HitComponentProps) => {
 	const { classes } = useStyles();
 	const displaySelect = useSelector(display);
 
-	const [loading, setLoading] = useState(true);
-	useLoadFont(hit.objectID, hit.family, 'index', setLoading);
+	const isFontLoaded = useIsFontLoaded(hit.family);
 
 	// Change preview text if hit.defSubset is not latin or if it's an icon
 	const previewValueSelect = useSelector(previewValue);
@@ -97,7 +97,7 @@ const HitComponent = ({ hit, fontSize }: HitComponentProps) => {
 		) {
 			previewFetcher.submit(
 				{ id: hit.objectID, subset: hit.defSubset },
-				{ method: 'POST', action: '/actions/language' }
+				{ method: 'POST', action: '/actions/language' },
 			);
 		}
 
@@ -118,7 +118,11 @@ const HitComponent = ({ hit, fontSize }: HitComponentProps) => {
 			className={classes.wrapper}
 			mih={{ base: '150px', sm: displaySelect === 'grid' ? '332px' : '150px' }}
 		>
-			<Skeleton visible={loading}>
+			<link
+				rel="stylesheet"
+				href={`https://r2.fontsource.org/css/${hit.objectID}@latest/index.css`}
+			/>
+			<Skeleton visible={!isFontLoaded}>
 				<Text size={fontSize} style={{ fontFamily: `"${hit.family}"` }}>
 					{currentPreview}
 				</Text>

--- a/website/app/hooks/useLoadFont.ts
+++ b/website/app/hooks/useLoadFont.ts
@@ -10,13 +10,13 @@ export const useLoadFont = (
 	family: string,
 	type: LoadType,
 	setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-	weights?: number[]
+	weights?: number[],
 ) => {
 	const fontCss = useFetcher();
 	// useFetcher only knows when the CSS is loaded, but not the font files themselves
 	const isFontLoaded = useIsFontLoaded(
 		type === 'variable' ? `${family} Variable` : family,
-		weights
+		weights,
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
This migrates the initial CSS endpoint from #822 into the website for the homepage, leading to a much snappier page that is much much faster than the previous iteration. It also greatly reduces the load on the website VMs. 

Eventually, we'll want to migrate everything onto the Fontsource API once it has that capability.