### PR TITLE
feat(api): add variable metadata endpoint

### DIFF
--- a/.changeset/nervous-pots-boil.md
+++ b/.changeset/nervous-pots-boil.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+feat(api): add variable metadata endpoints

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -4,6 +4,9 @@ export const METADATA_URL =
 export const VARIABLE_URL =
 	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/variable.json';
 
+export const AXIS_REGISTRY_URL =
+	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/axis-registry.json';
+
 export const KV_TTL = 1000 * 60 * 60 * 6; // 6 hourS
 
 export const CF_EDGE_TTL = 7200; // 2 hours

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -1,6 +1,9 @@
 export const METADATA_URL =
 	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/fontsource.json';
 
+export const VARIABLE_URL =
+	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/variable.json';
+
 export const KV_TTL = 1000 * 60 * 60 * 6; // 6 hourS
 
 export const CF_EDGE_TTL = 7200; // 2 hours

--- a/api/metadata/src/variable/router.ts
+++ b/api/metadata/src/variable/router.ts
@@ -1,0 +1,74 @@
+import { error, type IRequestStrict, Router, withParams } from 'itty-router';
+
+import type { CFRouterContext, TTLMetadata } from '../types';
+import { CF_EDGE_TTL } from '../utils';
+import { type VariableList, type VariableMetadataWithVariants } from './types';
+import { updateVariable, updateVariableList } from './update';
+
+interface DownloadRequest extends IRequestStrict {
+	id: string;
+}
+
+const router = Router<DownloadRequest, CFRouterContext>();
+
+router.get('/v1/variable', async (_request, env, ctx) => {
+	const kv = await env.VARIABLE_LIST.getWithMetadata<VariableList, TTLMetadata>(
+		'metadata',
+		{
+			type: 'json',
+		},
+	);
+
+	let { value, metadata } = kv;
+	if (!value) {
+		value = await updateVariableList(env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateVariableList(env, ctx));
+	}
+
+	return new Response(JSON.stringify(value), {
+		headers: {
+			'CDN-Cache-Control': `public, max-age=${CF_EDGE_TTL}`,
+			'Content-Type': 'application/json',
+		},
+	});
+});
+
+router.get('/v1/variable/:id', withParams, async (request, env, ctx) => {
+	const { id } = request;
+
+	const kv = await env.VARIABLE.getWithMetadata<
+		VariableMetadataWithVariants,
+		TTLMetadata
+	>(id, {
+		type: 'json',
+	});
+
+	let { value, metadata } = kv;
+	if (!value) {
+		value = await updateVariable(id, env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateVariable(id, env, ctx));
+	}
+
+	return new Response(JSON.stringify(value), {
+		headers: {
+			'CDN-Cache-Control': `public, max-age=${CF_EDGE_TTL}`,
+			'Content-Type': 'application/json',
+		},
+	});
+});
+
+// 404 for everything else
+router.all('*', () =>
+	error(
+		404,
+		'Not Found. Please refer to the Fontsource API documentation: https://fontsource.org/docs/api',
+	),
+);
+
+export default router;

--- a/api/metadata/src/variable/router.ts
+++ b/api/metadata/src/variable/router.ts
@@ -2,8 +2,16 @@ import { error, type IRequestStrict, Router, withParams } from 'itty-router';
 
 import type { CFRouterContext, TTLMetadata } from '../types';
 import { CF_EDGE_TTL } from '../utils';
-import { type VariableList, type VariableMetadataWithVariants } from './types';
-import { updateVariable, updateVariableList } from './update';
+import {
+	type AxisRegistry,
+	type VariableList,
+	type VariableMetadataWithVariants,
+} from './types';
+import {
+	updateAxisRegistry,
+	updateVariable,
+	updateVariableList,
+} from './update';
 
 interface DownloadRequest extends IRequestStrict {
 	id: string;
@@ -53,6 +61,31 @@ router.get('/v1/variable/:id', withParams, async (request, env, ctx) => {
 
 	if (!metadata?.ttl || metadata.ttl < Date.now()) {
 		ctx.waitUntil(updateVariable(id, env, ctx));
+	}
+
+	return new Response(JSON.stringify(value), {
+		headers: {
+			'CDN-Cache-Control': `public, max-age=${CF_EDGE_TTL}`,
+			'Content-Type': 'application/json',
+		},
+	});
+});
+
+router.get('/v1/axis-registry', async (_request, env, ctx) => {
+	const kv = await env.VARIABLE_LIST.getWithMetadata<AxisRegistry, TTLMetadata>(
+		'axis_registry',
+		{
+			type: 'json',
+		},
+	);
+
+	let { value, metadata } = kv;
+	if (!value) {
+		value = await updateAxisRegistry(env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateAxisRegistry(env, ctx));
 	}
 
 	return new Response(JSON.stringify(value), {

--- a/api/metadata/src/variable/types.ts
+++ b/api/metadata/src/variable/types.ts
@@ -1,0 +1,23 @@
+interface AxesData {
+	default: string;
+	min: string;
+	max: string;
+	step: string;
+}
+
+// axes: italic: link
+type VariableVariants = Record<string, Record<string, string>>;
+
+interface VariableMetadata {
+	family: string;
+	id: string;
+	axes: Record<string, AxesData>;
+}
+
+interface VariableMetadataWithVariants extends VariableMetadata {
+	variants: VariableVariants;
+}
+
+type VariableList = Record<string, VariableMetadata>;
+
+export type { VariableList, VariableMetadata, VariableMetadataWithVariants };

--- a/api/metadata/src/variable/types.ts
+++ b/api/metadata/src/variable/types.ts
@@ -20,4 +20,21 @@ interface VariableMetadataWithVariants extends VariableMetadata {
 
 type VariableList = Record<string, VariableMetadata>;
 
-export type { VariableList, VariableMetadata, VariableMetadataWithVariants };
+interface AxisRegistryItem {
+	name: string;
+	tag: string;
+	description: string;
+	min: number;
+	max: number;
+	default: number;
+	precision: number;
+}
+
+type AxisRegistry = AxisRegistryItem[];
+
+export type {
+	AxisRegistry,
+	VariableList,
+	VariableMetadata,
+	VariableMetadataWithVariants,
+};

--- a/api/metadata/src/variable/update.ts
+++ b/api/metadata/src/variable/update.ts
@@ -1,0 +1,66 @@
+import { StatusError } from 'itty-router';
+
+import { KV_TTL, VARIABLE_URL } from '../utils';
+import {
+	type VariableMetadata,
+	type VariableMetadataWithVariants,
+} from './types';
+
+export const updateVariableList = async (env: Env, ctx: ExecutionContext) => {
+	const resp = await fetch(VARIABLE_URL);
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new StatusError(
+			resp.status,
+			`Failed to fetch variable metadata. ${text}`,
+		);
+	}
+	const data = await resp.json<Record<string, VariableMetadataWithVariants>>();
+
+	// Remove variants property from all fonts
+	const noVariants: Record<string, VariableMetadata> = {};
+	for (const [key, value] of Object.entries(data)) {
+		const { variants, ...rest } = value;
+		noVariants[key] = rest;
+	}
+
+	// Save entire metadata into KV first
+	ctx.waitUntil(
+		env.VARIABLE_LIST.put('metadata', JSON.stringify(noVariants), {
+			metadata: {
+				// We need to set a custom ttl for a stale-while-revalidate strategy
+				ttl: Date.now() + KV_TTL,
+			},
+		}),
+	);
+
+	return data;
+};
+
+export const updateVariable = async (
+	id: string,
+	env: Env,
+	ctx: ExecutionContext,
+) => {
+	const response = await fetch(VARIABLE_URL);
+	const data =
+		await response.json<Record<string, VariableMetadataWithVariants>>();
+	const dataId = data[id];
+
+	if (!dataId) {
+		// eslint-disable-next-line unicorn/no-null
+		return null;
+	}
+
+	// Save entire metadata into KV first
+	ctx.waitUntil(
+		env.VARIABLE.put(id, JSON.stringify(dataId), {
+			metadata: {
+				// We need to set a custom ttl for a stale-while-revalidate strategy
+				ttl: Date.now() + KV_TTL,
+			},
+		}),
+	);
+
+	return dataId;
+};

--- a/api/metadata/worker-configuration.d.ts
+++ b/api/metadata/worker-configuration.d.ts
@@ -1,6 +1,11 @@
 interface Env {
 	FONTLIST: KVNamespace;
 	FONTS: KVNamespace;
+	VARIABLE: KVNamespace;
+	VARIABLE_LIST: KVNamespace;
+
 	BUCKET: R2Bucket;
+
+	// Secrets
 	UPLOAD_KEY: string;
 }

--- a/api/metadata/wrangler.toml
+++ b/api/metadata/wrangler.toml
@@ -5,6 +5,8 @@ compatibility_date = "2023-05-27"
 kv_namespaces = [
   { binding = "FONTLIST", id = "ef03b5ef10034282a8e6220b9a5258c1", preview_id = "8786b20cf84b4b62ba88505d8cd8caaf" },
   { binding = "FONTS", id = "3dfa82ada2204c49b2f317a63b72d93c", preview_id = "fe8764b094ec4524ba50631ecc24f177" },
+  { binding = "VARIABLE_LIST", id = "669f1133f5144ab0822980b3d7e18559" },
+  { binding = "VARIABLE", id = "592f7cf6d10f4086ae421d538e3f9bfc" },
 ]
 
 r2_buckets = [


### PR DESCRIPTION
This adds a new variable endpoint to fetch variable font metadata for individual fonts. I won't be adding docs for the endpoint anytime soon until I've dogfooded it to the Fontsource website and have ironed it all out.

Endpoints added: 
- `/v1/variable`
- `/v1/variable/{id}`
- `/v1/axis-registry`