### PR TITLE
feat(api): add axis registry queries

### DIFF
--- a/.changeset/small-apes-smell.md
+++ b/.changeset/small-apes-smell.md
@@ -1,0 +1,5 @@
+---
+"api": minor
+---
+
+feat(api): add axis registry queries

--- a/api/metadata/src/variable/get.ts
+++ b/api/metadata/src/variable/get.ts
@@ -1,0 +1,78 @@
+import { type TTLMetadata } from '../types';
+import {
+	type AxisRegistry,
+	type VariableList,
+	type VariableMetadataWithVariants,
+} from './types';
+import {
+	updateAxisRegistry,
+	updateVariable,
+	updateVariableList,
+} from './update';
+
+export const getOrUpdateVariableList = async (
+	env: Env,
+	ctx: ExecutionContext,
+) => {
+	const { value, metadata } = await env.VARIABLE_LIST.getWithMetadata<
+		VariableList,
+		TTLMetadata
+	>('variable_list', {
+		type: 'json',
+	});
+
+	if (!value) {
+		return await updateVariableList(env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateVariableList(env, ctx));
+	}
+
+	return value;
+};
+
+export const getOrUpdateVariableId = async (
+	id: string,
+	env: Env,
+	ctx: ExecutionContext,
+) => {
+	const { value, metadata } = await env.VARIABLE.getWithMetadata<
+		VariableMetadataWithVariants,
+		TTLMetadata
+	>(id, {
+		type: 'json',
+	});
+
+	if (!value) {
+		return await updateVariable(id, env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateVariable(id, env, ctx));
+	}
+
+	return value;
+};
+
+export const getOrUpdateAxisRegistry = async (
+	env: Env,
+	ctx: ExecutionContext,
+) => {
+	const { value, metadata } = await env.VARIABLE_LIST.getWithMetadata<
+		AxisRegistry,
+		TTLMetadata
+	>('axis_registry', {
+		type: 'json',
+	});
+
+	if (!value) {
+		return await updateAxisRegistry(env, ctx);
+	}
+
+	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+		ctx.waitUntil(updateAxisRegistry(env, ctx));
+	}
+
+	return value;
+};

--- a/api/metadata/src/variable/types.ts
+++ b/api/metadata/src/variable/types.ts
@@ -32,9 +32,16 @@ interface AxisRegistryItem {
 
 type AxisRegistry = AxisRegistryItem[];
 
+const axisRegistryQueries = ['name', 'tag'] as const;
+type AxisRegistryQueries = (typeof axisRegistryQueries)[number];
+const isAxisRegistryQuery = (x: string): x is AxisRegistryQueries =>
+	axisRegistryQueries.includes(x as AxisRegistryQueries);
+
 export type {
 	AxisRegistry,
 	VariableList,
 	VariableMetadata,
 	VariableMetadataWithVariants,
 };
+
+export { isAxisRegistryQuery };


### PR DESCRIPTION
This adds query parameters for the axis registry for `name` and `tag`  properties to let users filter out unnecessary data when querying multiple axes.

Also minor refactor to split get and update functionality into separate files for the variable API.