### PR TITLE
refactor(cli): expose css generation for each package

### DIFF
--- a/.changeset/weak-queens-eat.md
+++ b/.changeset/weak-queens-eat.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+refactor(cli): expose css generation for each package

--- a/packages/cli/src/google/packager-icons.ts
+++ b/packages/cli/src/google/packager-icons.ts
@@ -5,18 +5,30 @@ import {
 	type APIIconResponse,
 	APIIconStatic,
 	APIIconVariable,
+	type FontObjectV2,
+	type FontObjectVariable,
 } from 'google-font-metadata';
 import * as path from 'pathe';
 
-import type { BuildOptions } from '../types';
+import type { BuildOptions, CSSGenerate } from '../types';
 import {
 	findClosest,
 	makeFontFilePath,
 	makeVariableFontFilePath,
 } from '../utils';
 
-const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
-	const { family, styles, weights, subsets, variants } = APIIconStatic[id];
+const generateIconStaticCSS = (
+	metadata: FontObjectV2['id'],
+	makeFontFilePath: (
+		id: string,
+		subset: string,
+		weight: string,
+		style: string,
+		extension: string,
+	) => string,
+): CSSGenerate => {
+	const cssGenerate: CSSGenerate = [];
+	const { id, family, styles, weights, subsets, variants } = metadata;
 
 	// Find the weight for index.css in the case weight 400 does not exist.
 	const indexWeight = findClosest(weights, 400);
@@ -37,11 +49,23 @@ const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
 						weight,
 						src: [
 							{
-								url: makeFontFilePath(id, subset, weight, style, 'woff2'),
+								url: makeFontFilePath(
+									id,
+									subset,
+									String(weight),
+									style,
+									'woff2',
+								),
 								format: 'woff2' as const,
 							},
 							{
-								url: makeFontFilePath(id, subset, weight, style, 'woff'),
+								url: makeFontFilePath(
+									id,
+									subset,
+									String(weight),
+									style,
+									'woff',
+								),
 								format: 'woff' as const,
 							},
 						],
@@ -51,17 +75,27 @@ const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
 					const css = generateFontFace(fontObj);
 
 					if (style === 'normal') {
-						let cssPath = path.join(opts.dir, `${weight}.css`);
-						await fs.writeFile(cssPath, css);
-
-						cssPath = path.join(opts.dir, `${subset}-${weight}.css`);
-						await fs.writeFile(cssPath, css);
+						cssGenerate.push(
+							{
+								filename: `$${weight}.css`,
+								css,
+							},
+							{
+								filename: `${subset}-${weight}.css`,
+								css,
+							},
+						);
 					} else {
-						let cssPath = path.join(opts.dir, `${weight}-italic.css`);
-						await fs.writeFile(cssPath, css);
-
-						cssPath = path.join(opts.dir, `${subset}-${weight}-italic.css`);
-						await fs.writeFile(cssPath, css);
+						cssGenerate.push(
+							{
+								filename: `${weight}-italic.css`,
+								css,
+							},
+							{
+								filename: `${subset}-${weight}-italic.css`,
+								css,
+							},
+						);
 					}
 					cssSubset.push(css);
 				}
@@ -69,37 +103,64 @@ const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
 
 			// If the weight is index, generate index.css
 			if (weight === indexWeight) {
-				const cssIndexPath = path.join(opts.dir, 'index.css');
-				await fs.writeFile(cssIndexPath, cssSubset.join('\n\n'));
+				cssGenerate.push({
+					filename: 'index.css',
+					css: cssSubset.join('\n\n'),
+				});
 			}
 
-			const cssSubsetPath = path.join(opts.dir, `${subset}.css`);
-			await fs.writeFile(cssSubsetPath, cssSubset.join('\n\n'));
+			cssGenerate.push({
+				filename: `${subset}.css`,
+				css: cssSubset.join('\n\n'),
+			});
 		}
+	}
+
+	return cssGenerate;
+};
+
+const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
+	const cssGenerate = generateIconStaticCSS(
+		APIIconStatic[id],
+		makeFontFilePath,
+	);
+
+	for (const item of cssGenerate) {
+		const cssPath = path.join(opts.dir, item.filename);
+		await fs.writeFile(cssPath, item.css);
 	}
 };
 
-const packagerIconsVariable = async (id: string, opts: BuildOptions) => {
-	const icon = APIIconVariable[id];
+const generateIconVariableCSS = (
+	metadata: FontObjectVariable['id'],
+	makeFontFilePath: (
+		id: string,
+		subset: string,
+		axesLower: string,
+		style: string,
+	) => string,
+): CSSGenerate => {
+	const cssGenerate: CSSGenerate = [];
+	const { id, family, variants, axes } = metadata;
 
 	// Generate CSS
 	let indexCSS = '';
 
-	for (const axes of Object.keys(icon.variants)) {
-		const variant = icon.variants[axes];
+	for (const axesKey of Object.keys(variants)) {
+		const variant = variants[axesKey];
 		const styles = Object.keys(variant);
-		const axesLower = axes.toLowerCase();
+		const axesLower = axesKey.toLowerCase();
 
 		// These are variable modifiers to change specific CSS selectors
 		// for variable fonts.
 		const variableOpts: APIIconResponse['axes'] = {
-			wght: icon.axes.wght,
+			wght: axes.wght,
 		};
-		if (axes === 'standard' || axes === 'full' || axes === 'wdth')
-			variableOpts.stretch = icon.axes.wdth;
+		if (axesKey === 'standard' || axesKey === 'full' || axesKey === 'wdth')
+			variableOpts.stretch = axes.wdth;
 
-		if (axes === 'standard' || axes === 'full' || axes === 'slnt')
-			variableOpts.slnt = icon.axes.slnt;
+		if (axesKey === 'standard' || axesKey === 'full' || axesKey === 'slnt')
+			variableOpts.slnt = axes.slnt;
 
 		// Generate variable CSS
 		for (const style of styles) {
@@ -107,14 +168,14 @@ const packagerIconsVariable = async (id: string, opts: BuildOptions) => {
 
 			for (const subset of Object.keys(variant[style])) {
 				const fontObj: FontObject = {
-					family: icon.family,
+					family,
 					style,
 					display: 'swap',
-					weight: Number(icon.axes.wght.default),
+					weight: Number(axes.wght.default),
 					variable: variableOpts,
 					src: [
 						{
-							url: makeVariableFontFilePath(id, subset, axesLower, style),
+							url: makeFontFilePath(id, subset, axesLower, style),
 							format: 'woff2-variations',
 						},
 					],
@@ -129,18 +190,40 @@ const packagerIconsVariable = async (id: string, opts: BuildOptions) => {
 			// Write down CSS
 			const filename =
 				style === 'normal' ? `${axesLower}.css` : `${axesLower}-${style}.css`;
-			const cssPath = path.join(opts.dir, filename);
 			const css = cssStyle.join('\n\n');
-			await fs.writeFile(cssPath, css);
+			cssGenerate.push({
+				filename,
+				css,
+			});
 
 			// Some fonts may not have a wght axis, but usually have an opsz axis to compensate
-			if (axes === 'wght') indexCSS = css;
-			if (!indexCSS && axes === 'opsz') indexCSS = css;
+			if (axesKey === 'wght') indexCSS = css;
+			if (!indexCSS && axesKey === 'opsz') indexCSS = css;
 		}
 	}
 
 	// Write down index.css for variable package
-	await fs.writeFile(path.join(opts.dir, 'index.css'), indexCSS);
+	cssGenerate.push({
+		filename: 'index.css',
+		css: indexCSS,
+	});
+
+	return cssGenerate;
 };
 
-export { packagerIconsStatic, packagerIconsVariable };
+const packagerIconsVariable = async (id: string, opts: BuildOptions) => {
+	const icon = APIIconVariable[id];
+	const cssGenerate = generateIconVariableCSS(icon, makeVariableFontFilePath);
+
+	for (const item of cssGenerate) {
+		const cssPath = path.join(opts.dir, item.filename);
+		await fs.writeFile(cssPath, item.css);
+	}
+};
+
+export {
+	generateIconStaticCSS,
+	generateIconVariableCSS,
+	packagerIconsStatic,
+	packagerIconsVariable,
+};

--- a/packages/cli/src/google/packager-icons.ts
+++ b/packages/cli/src/google/packager-icons.ts
@@ -77,7 +77,7 @@ const generateIconStaticCSS = (
 					if (style === 'normal') {
 						cssGenerate.push(
 							{
-								filename: `$${weight}.css`,
+								filename: `${weight}.css`,
 								css,
 							},
 							{

--- a/packages/cli/src/google/packager-v2.ts
+++ b/packages/cli/src/google/packager-v2.ts
@@ -1,14 +1,24 @@
 /* eslint-disable no-await-in-loop */
 import { generateFontFace } from '@fontsource-utils/generate';
 import fs from 'fs-extra';
-import { APIv2 } from 'google-font-metadata';
+import { APIv2, type FontObjectV2 } from 'google-font-metadata';
 import * as path from 'pathe';
 
-import type { BuildOptions } from '../types';
+import type { BuildOptions, CSSGenerate } from '../types';
 import { findClosest, makeFontFilePath } from '../utils';
 
-const packagerV2 = async (id: string, opts: BuildOptions) => {
-	const { family, styles, weights, variants, unicodeRange } = APIv2[id];
+const generateV2CSS = (
+	metadata: FontObjectV2['id'],
+	makeFontFilePath: (
+		id: string,
+		subset: string,
+		weight: string,
+		style: string,
+		extension: string,
+	) => string,
+): CSSGenerate => {
+	const cssGenerate: CSSGenerate = [];
+	const { id, family, styles, weights, variants, unicodeRange } = metadata;
 
 	// Find the weight for index.css in the case weight 400 does not exist.
 	const indexWeight = findClosest(weights, 400);
@@ -31,11 +41,23 @@ const packagerV2 = async (id: string, opts: BuildOptions) => {
 						unicodeRange: unicodeRange[subset],
 						src: [
 							{
-								url: makeFontFilePath(id, subset, weight, style, 'woff2'),
+								url: makeFontFilePath(
+									id,
+									subset,
+									String(weight),
+									style,
+									'woff2',
+								),
 								format: 'woff2' as const,
 							},
 							{
-								url: makeFontFilePath(id, subset, weight, style, 'woff'),
+								url: makeFontFilePath(
+									id,
+									subset,
+									String(weight),
+									style,
+									'woff',
+								),
 								format: 'woff' as const,
 							},
 						],
@@ -50,24 +72,40 @@ const packagerV2 = async (id: string, opts: BuildOptions) => {
 			// Write down CSS
 			if (style in variants[weight]) {
 				if (style === 'normal') {
-					const cssPath = path.join(opts.dir, `${weight}.css`);
-					await fs.writeFile(cssPath, cssStyle.join('\n\n'));
+					cssGenerate.push({
+						filename: `${weight}.css`,
+						css: cssStyle.join('\n\n'),
+					});
 
 					// Generate index CSS
 					if (weight === indexWeight) {
-						await fs.writeFile(
-							path.join(opts.dir, 'index.css'),
-							cssStyle.join('\n\n')
-						);
+						cssGenerate.push({
+							filename: 'index.css',
+							css: cssStyle.join('\n\n'),
+						});
 					}
 				} else {
 					// If italic or else, define specific style CSS file
-					const cssStylePath = path.join(opts.dir, `${weight}-${style}.css`);
-					await fs.writeFile(cssStylePath, cssStyle.join('\n\n'));
+					cssGenerate.push({
+						filename: `${weight}-${style}.css`,
+						css: cssStyle.join('\n\n'),
+					});
 				}
 			}
 		}
 	}
+
+	return cssGenerate;
 };
 
-export { packagerV2 };
+const packagerV2 = async (id: string, opts: BuildOptions) => {
+	const metadata = APIv2[id];
+	const cssGenerate = generateV2CSS(metadata, makeFontFilePath);
+
+	for (const item of cssGenerate) {
+		const cssPath = path.join(opts.dir, item.filename);
+		await fs.writeFile(cssPath, item.css);
+	}
+};
+
+export { generateV2CSS, packagerV2 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,17 @@
 export { create } from './custom/create';
 export { verify } from './custom/verify';
+export {
+	generateIconStaticCSS,
+	generateIconVariableCSS,
+	packagerIconsStatic,
+	packagerIconsVariable,
+} from './google/packager-icons';
+export { generateV1CSS, packagerV1 } from './google/packager-v1';
+export { generateV2CSS, packagerV2 } from './google/packager-v2';
+export {
+	generateVariableCSS,
+	packagerVariable,
+} from './google/packager-variable';
 export { processGoogle } from './google/queue';
 export {
 	APIIconStatic,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -36,7 +36,7 @@ const CATEGORY_NAMES = [
 	'icons',
 	'other',
 ] as const;
-export type CategoryNames = typeof CATEGORY_NAMES[number];
+export type CategoryNames = (typeof CATEGORY_NAMES)[number];
 export const isCategoryName = (value: string): value is CategoryNames =>
 	CATEGORY_NAMES.includes(value as CategoryNames);
 
@@ -61,5 +61,11 @@ export interface Metadata {
 	source: string;
 	type: TypeNames;
 }
+interface CSSGenerateItem {
+	filename: string;
+	css: string;
+}
+
+export type CSSGenerate = CSSGenerateItem[];
 
 export type UnicodeRange = Record<string, string>;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -8,10 +8,10 @@ const makeFontDownloadPath = (
 	subset: string,
 	weight: number,
 	style: string,
-	extension: string
+	extension: string,
 ): string =>
 	cleanPaths(
-		`${fontDir}/files/${fontId}-${subset}-${weight}-${style}.${extension}`
+		`${fontDir}/files/${fontId}-${subset}-${weight}-${style}.${extension}`,
 	);
 
 // Some axes are all uppercase making packages inconsistent
@@ -20,19 +20,19 @@ const makeVariableFontDownloadPath = (
 	fontId: string,
 	subset: string,
 	axes: string,
-	style: string
+	style: string,
 ): string =>
 	cleanPaths(
-		`${fontDir}/files/${fontId}-${subset}-${axes.toLowerCase()}-${style}.woff2`
+		`${fontDir}/files/${fontId}-${subset}-${axes.toLowerCase()}-${style}.woff2`,
 	);
 
 // Used for the src urls in CSS files
 const makeFontFilePath = (
 	fontId: string,
 	subset: string,
-	weight: number,
+	weight: string,
 	style: string,
-	extension: string
+	extension: string,
 ): string =>
 	cleanPaths(`./files/${fontId}-${subset}-${weight}-${style}.${extension}`);
 
@@ -40,7 +40,7 @@ const makeVariableFontFilePath = (
 	fontId: string,
 	subset: string,
 	axes: string,
-	style: string
+	style: string,
 ): string => cleanPaths(`./files/${fontId}-${subset}-${axes}-${style}.woff2`);
 
 // Insert a weight array to find the closest number given num - used for index.css gen


### PR DESCRIPTION
This separates the CSS generation and writing to disk functionality into two separate functions which are now exposed in the programmatic API. The usage is meant for the API which needs to generate equivalent CSS for the CDN.