### PR TITLE
fix(cli): invalid urls generated for cdn

### DIFF
--- a/.changeset/slimy-mice-notice.md
+++ b/.changeset/slimy-mice-notice.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+fix(cli): invalid urls generated for cdn and loosen types for CSS generators

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"ci:lint": "pnpm -r run ci:lint",
 		"ci:test": "CI=true pnpm build && pnpm coverage",
 		"ci:version": "changeset version",
-		"ci:publish": "pnpm --filter \"./packages/*\" publish",
+		"ci:publish": "pnpm --filter \"./packages/*\" run build && pnpm --filter \"./packages/*\" publish",
 		"ci:publish-api": "pnpm --filter \"./packages/*\" run build && pnpm --filter \"./api/*\" run deploy"
 	},
 	"dependencies": {

--- a/packages/cli/src/google/packager-icons.ts
+++ b/packages/cli/src/google/packager-icons.ts
@@ -17,8 +17,18 @@ import {
 	makeVariableFontFilePath,
 } from '../utils';
 
+type GenerateIconStatic = Pick<
+	FontObjectV2['id'],
+	'id' | 'family' | 'styles' | 'weights' | 'subsets' | 'variants'
+>;
+
+type GenerateIconVariable = Pick<
+	FontObjectVariable['id'],
+	'id' | 'family' | 'axes' | 'variants'
+>;
+
 const generateIconStaticCSS = (
-	metadata: FontObjectV2['id'],
+	metadata: GenerateIconStatic,
 	makeFontFilePath: (
 		id: string,
 		subset: string,
@@ -133,7 +143,7 @@ const packagerIconsStatic = async (id: string, opts: BuildOptions) => {
 };
 
 const generateIconVariableCSS = (
-	metadata: FontObjectVariable['id'],
+	metadata: GenerateIconVariable,
 	makeFontFilePath: (
 		id: string,
 		subset: string,

--- a/packages/cli/src/google/packager-icons.ts
+++ b/packages/cli/src/google/packager-icons.ts
@@ -26,6 +26,7 @@ const generateIconStaticCSS = (
 		style: string,
 		extension: string,
 	) => string,
+	tag?: string,
 ): CSSGenerate => {
 	const cssGenerate: CSSGenerate = [];
 	const { id, family, styles, weights, subsets, variants } = metadata;
@@ -50,7 +51,7 @@ const generateIconStaticCSS = (
 						src: [
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -60,7 +61,7 @@ const generateIconStaticCSS = (
 							},
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -69,7 +70,7 @@ const generateIconStaticCSS = (
 								format: 'woff' as const,
 							},
 						],
-						comment: `${id}-${subset}-${weight}-${style}`,
+						comment: `${tag ?? id}-${subset}-${weight}-${style}`,
 					};
 					// This takes in a font object and returns an @font-face block
 					const css = generateFontFace(fontObj);
@@ -139,6 +140,7 @@ const generateIconVariableCSS = (
 		axesLower: string,
 		style: string,
 	) => string,
+	tag?: string,
 ): CSSGenerate => {
 	const cssGenerate: CSSGenerate = [];
 	const { id, family, variants, axes } = metadata;
@@ -175,11 +177,11 @@ const generateIconVariableCSS = (
 					variable: variableOpts,
 					src: [
 						{
-							url: makeFontFilePath(id, subset, axesLower, style),
+							url: makeFontFilePath(tag ?? id, subset, axesLower, style),
 							format: 'woff2-variations',
 						},
 					],
-					comment: `${id}-${subset}-${axesLower}-${style}`,
+					comment: `${tag ?? id}-${subset}-${axesLower}-${style}`,
 				};
 
 				// This takes in a font object and returns an @font-face block

--- a/packages/cli/src/google/packager-v1.ts
+++ b/packages/cli/src/google/packager-v1.ts
@@ -16,6 +16,7 @@ const generateV1CSS = (
 		style: string,
 		extension: string,
 	) => string,
+	tag?: string,
 ): CSSGenerate => {
 	const cssGenerate: CSSGenerate = [];
 	const { id, family, styles, weights, subsets, variants } = metadata;
@@ -37,7 +38,7 @@ const generateV1CSS = (
 						src: [
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -47,7 +48,7 @@ const generateV1CSS = (
 							},
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -56,7 +57,7 @@ const generateV1CSS = (
 								format: 'woff' as const,
 							},
 						],
-						comment: `${id}-${subset}-${weight}-${style}`,
+						comment: `${tag ?? id}-${subset}-${weight}-${style}`,
 					};
 					// This takes in a font object and returns an @font-face block
 					const css = generateFontFace(fontObj);

--- a/packages/cli/src/google/packager-v1.ts
+++ b/packages/cli/src/google/packager-v1.ts
@@ -7,8 +7,13 @@ import * as path from 'pathe';
 import type { BuildOptions, CSSGenerate } from '../types';
 import { makeFontFilePath } from '../utils';
 
+type GenerateMetadataV1 = Pick<
+	FontObjectV1['id'],
+	'id' | 'family' | 'styles' | 'weights' | 'subsets' | 'variants'
+>;
+
 const generateV1CSS = (
-	metadata: FontObjectV1['id'],
+	metadata: GenerateMetadataV1,
 	makeFontFilePath: (
 		id: string,
 		subset: string,

--- a/packages/cli/src/google/packager-v2.ts
+++ b/packages/cli/src/google/packager-v2.ts
@@ -16,6 +16,7 @@ const generateV2CSS = (
 		style: string,
 		extension: string,
 	) => string,
+	tag?: string,
 ): CSSGenerate => {
 	const cssGenerate: CSSGenerate = [];
 	const { id, family, styles, weights, variants, unicodeRange } = metadata;
@@ -42,7 +43,7 @@ const generateV2CSS = (
 						src: [
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -52,7 +53,7 @@ const generateV2CSS = (
 							},
 							{
 								url: makeFontFilePath(
-									id,
+									tag ?? id,
 									subset,
 									String(weight),
 									style,
@@ -61,7 +62,7 @@ const generateV2CSS = (
 								format: 'woff' as const,
 							},
 						],
-						comment: `${id}-${subset}-${weight}-${style}`,
+						comment: `${tag ?? id}-${subset}-${weight}-${style}`,
 					};
 					// This takes in a font object and returns an @font-face block
 					const css = generateFontFace(fontObj);

--- a/packages/cli/src/google/packager-v2.ts
+++ b/packages/cli/src/google/packager-v2.ts
@@ -7,8 +7,19 @@ import * as path from 'pathe';
 import type { BuildOptions, CSSGenerate } from '../types';
 import { findClosest, makeFontFilePath } from '../utils';
 
+type GenerateMetadataV2 = Pick<
+	FontObjectV2['id'],
+	| 'id'
+	| 'family'
+	| 'styles'
+	| 'weights'
+	| 'subsets'
+	| 'variants'
+	| 'unicodeRange'
+>;
+
 const generateV2CSS = (
-	metadata: FontObjectV2['id'],
+	metadata: GenerateMetadataV2,
 	makeFontFilePath: (
 		id: string,
 		subset: string,

--- a/packages/cli/src/google/packager-variable.ts
+++ b/packages/cli/src/google/packager-variable.ts
@@ -10,11 +10,11 @@ import {
 import * as path from 'pathe';
 
 import type { BuildOptions, CSSGenerate } from '../types';
-import { makeVariableFontFilePath } from '../utils';
+import { findClosest, makeVariableFontFilePath } from '../utils';
 
 type GenerateMetadataV2 = Pick<
 	FontObjectV2['id'],
-	'id' | 'family' | 'unicodeRange'
+	'id' | 'family' | 'unicodeRange' | 'weights'
 >;
 
 type GenerateMetadataVariable = Pick<
@@ -33,7 +33,7 @@ const generateVariableCSS = (
 	) => string,
 	tag?: string,
 ): CSSGenerate => {
-	const { id, family, unicodeRange } = metadata;
+	const { id, family, unicodeRange, weights } = metadata;
 	const { axes, variants } = variableMeta;
 	const cssGenerate: CSSGenerate = [];
 	let indexCSS = '';
@@ -62,7 +62,7 @@ const generateVariableCSS = (
 					family,
 					style,
 					display: 'swap',
-					weight: Number(axes.wght.default),
+					weight: findClosest(weights, 400),
 					unicodeRange: unicodeRange[subset],
 					variable: variableOpts,
 					src: [

--- a/packages/cli/src/google/packager-variable.ts
+++ b/packages/cli/src/google/packager-variable.ts
@@ -21,44 +21,47 @@ const generateVariableCSS = (
 		axes: string,
 		style: string,
 	) => string,
+	tag?: string,
 ): CSSGenerate => {
+	const { id, family, unicodeRange, weights } = metadata;
+	const { axes, variants } = variableMeta;
 	const cssGenerate: CSSGenerate = [];
 	let indexCSS = '';
 
-	for (const axes of Object.keys(variableMeta.variants)) {
-		const variant = variableMeta.variants[axes];
+	for (const axesKey of Object.keys(variants)) {
+		const variant = variants[axesKey];
 		const styles = Object.keys(variant);
-		const axesLower = axes.toLowerCase();
+		const axesLower = axesKey.toLowerCase();
 
 		// These are variable modifiers to change specific CSS selectors
 		// for variable fonts.
 		const variableOpts: FontObject['variable'] = {
-			wght: variableMeta.axes.wght,
+			wght: axes.wght,
 		};
-		if (axes === 'standard' || axes === 'full' || axes === 'wdth')
-			variableOpts.stretch = variableMeta.axes.wdth;
+		if (axesKey === 'standard' || axesKey === 'full' || axesKey === 'wdth')
+			variableOpts.stretch = axes.wdth;
 
-		if (axes === 'standard' || axes === 'full' || axes === 'slnt')
-			variableOpts.slnt = variableMeta.axes.slnt;
+		if (axesKey === 'standard' || axesKey === 'full' || axesKey === 'slnt')
+			variableOpts.slnt = axes.slnt;
 
 		for (const style of styles) {
 			const cssStyle: string[] = [];
 
 			for (const subset of Object.keys(variant[style])) {
 				const fontObj: FontObject = {
-					family: metadata.family,
+					family,
 					style,
 					display: 'swap',
-					weight: findClosest(metadata.weights, 400),
-					unicodeRange: metadata.unicodeRange[subset],
+					weight: findClosest(weights, 400),
+					unicodeRange: unicodeRange[subset],
 					variable: variableOpts,
 					src: [
 						{
-							url: makeFontFilePath(metadata.id, subset, axesLower, style),
+							url: makeFontFilePath(tag ?? id, subset, axesLower, style),
 							format: 'woff2-variations',
 						},
 					],
-					comment: `${metadata.id}-${subset}-${axesLower}-${style}`,
+					comment: `${tag ?? id}-${subset}-${axesLower}-${style}`,
 				};
 
 				// This takes in a font object and returns an @font-face block
@@ -77,11 +80,11 @@ const generateVariableCSS = (
 			});
 
 			// Ensure style is normal or there is only one style
-			if (axes === 'wght' && (style === 'normal' || styles.length === 1))
+			if (axesKey === 'wght' && (style === 'normal' || styles.length === 1))
 				indexCSS = css;
 
 			// Some fonts may not have a wght axis, but usually have an opsz axis to compensate
-			if (indexCSS === '' && axes === 'opsz') indexCSS = css;
+			if (indexCSS === '' && axesKey === 'opsz') indexCSS = css;
 		}
 	}
 

--- a/packages/cli/src/google/packager-variable.ts
+++ b/packages/cli/src/google/packager-variable.ts
@@ -10,11 +10,21 @@ import {
 import * as path from 'pathe';
 
 import type { BuildOptions, CSSGenerate } from '../types';
-import { findClosest, makeVariableFontFilePath } from '../utils';
+import { makeVariableFontFilePath } from '../utils';
+
+type GenerateMetadataV2 = Pick<
+	FontObjectV2['id'],
+	'id' | 'family' | 'unicodeRange'
+>;
+
+type GenerateMetadataVariable = Pick<
+	FontObjectVariable['id'],
+	'axes' | 'variants'
+>;
 
 const generateVariableCSS = (
-	metadata: FontObjectV2['id'],
-	variableMeta: FontObjectVariable['id'],
+	metadata: GenerateMetadataV2,
+	variableMeta: GenerateMetadataVariable,
 	makeFontFilePath: (
 		id: string,
 		subset: string,
@@ -23,7 +33,7 @@ const generateVariableCSS = (
 	) => string,
 	tag?: string,
 ): CSSGenerate => {
-	const { id, family, unicodeRange, weights } = metadata;
+	const { id, family, unicodeRange } = metadata;
 	const { axes, variants } = variableMeta;
 	const cssGenerate: CSSGenerate = [];
 	let indexCSS = '';
@@ -52,7 +62,7 @@ const generateVariableCSS = (
 					family,
 					style,
 					display: 'swap',
-					weight: findClosest(weights, 400),
+					weight: Number(axes.wght.default),
 					unicodeRange: unicodeRange[subset],
 					variable: variableOpts,
 					src: [


### PR DESCRIPTION
Follow up to #836. This adds an optional tag param to update the generated URLs in the CSS for the API.