### PR TITLE
fix(api): failing to generate icon css

### DIFF
--- a/.changeset/proud-rabbits-vanish.md
+++ b/.changeset/proud-rabbits-vanish.md
@@ -1,0 +1,5 @@
+---
+"cdn": patch
+---
+
+fix(api): failing to generate icon css due to typo

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -50,7 +50,7 @@ export const updateCss = async (
 ): Promise<string> => {
 	let css;
 	const { category } = metadata;
-	console.log(category);
+
 	// Icons are handled differently
 	if (category === 'icons') {
 		// Static

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -50,8 +50,9 @@ export const updateCss = async (
 ): Promise<string> => {
 	let css;
 	const { category } = metadata;
+	console.log(category);
 	// Icons are handled differently
-	if (category === 'icon') {
+	if (category === 'icons') {
 		// Static
 		const cssGenerate = generateIconStaticCSS(metadata, makeFontFilePath, tag);
 		for (const item of cssGenerate) {
@@ -112,7 +113,7 @@ export const updateVariableCSS = async (
 	const vfTag = `${id}:vf@${version}`;
 
 	// Icons are handled differently
-	if (category === 'icon') {
+	if (category === 'icons') {
 		const cssGenerate = generateIconVariableCSS(
 			variableMeta,
 			makeFontFileVariablePath,


### PR DESCRIPTION
Icon fonts such as Material Icons were failing to generate CSS due to a small typo.