### PR TITLE
fix(api): only use icon generators for google icons

### DIFF
--- a/.changeset/mean-hotels-laugh.md
+++ b/.changeset/mean-hotels-laugh.md
@@ -1,0 +1,5 @@
+---
+"cdn": patch
+---
+
+fix(api): only use icon generators for google icons

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -49,10 +49,10 @@ export const updateCss = async (
 	ctx: ExecutionContext,
 ): Promise<string> => {
 	let css;
-	const { category } = metadata;
+	const { category, type } = metadata;
 
 	// Icons are handled differently
-	if (category === 'icons') {
+	if (category === 'icons' && type === 'google') {
 		// Static
 		const cssGenerate = generateIconStaticCSS(metadata, makeFontFilePath, tag);
 		for (const item of cssGenerate) {
@@ -108,12 +108,12 @@ export const updateVariableCSS = async (
 	ctx: ExecutionContext,
 ): Promise<string> => {
 	let css;
-	const { category } = metadata;
+	const { category, type } = metadata;
 	const tag = `${id}@${version}`;
 	const vfTag = `${id}:vf@${version}`;
 
 	// Icons are handled differently
-	if (category === 'icons') {
+	if (category === 'icons' && type === 'google') {
 		const cssGenerate = generateIconVariableCSS(
 			variableMeta,
 			makeFontFileVariablePath,


### PR DESCRIPTION
Technically the custom CSS generation for icons should only apply to Google Icons, such as Material Icons. This narrows the possibilities this custom CSS generation runs in.