### PR TITLE
feat(website): add a status page redirect

### DIFF
--- a/website/app/routes/__boundary/status.tsx
+++ b/website/app/routes/__boundary/status.tsx
@@ -1,0 +1,6 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+
+export const loader: LoaderFunction = async () => {
+	return redirect('https://status.fontsource.org');
+};


### PR DESCRIPTION
This just redirects users hitting `/status` to the actual status page at `status.fontsource.org`.