### PR TITLE
fix(api): fallback missing unicode range keys to subsets

### DIFF
--- a/.changeset/tall-planes-deny.md
+++ b/.changeset/tall-planes-deny.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+fix(api): fallback missing unicode range keys to subsets

--- a/packages/cli/src/google/css.ts
+++ b/packages/cli/src/google/css.ts
@@ -151,13 +151,15 @@ export const generateV2CSS = (
 	tag?: string,
 ): CSSGenerate => {
 	const cssGenerate: CSSGenerate = [];
-	const { id, family, styles, weights, variants, unicodeRange } = metadata;
+	const { id, family, styles, weights, variants, unicodeRange, subsets } =
+		metadata;
 
 	// Find the weight for index.css in the case weight 400 does not exist.
 	const indexWeight = findClosest(weights, 400);
 
 	// Generate CSS
-	const unicodeKeys = Object.keys(unicodeRange);
+	const hasUnicode = Object.keys(unicodeRange).length > 0;
+	const unicodeKeys = hasUnicode ? Object.keys(unicodeRange) : subsets;
 
 	for (const weight of weights) {
 		for (const style of styles) {
@@ -171,7 +173,7 @@ export const generateV2CSS = (
 						style,
 						display: 'swap',
 						weight,
-						unicodeRange: unicodeRange[subset],
+						unicodeRange: hasUnicode ? unicodeRange[subset] : undefined,
 						src: [
 							{
 								url: makeFontFilePath(


### PR DESCRIPTION
Closes #799 and #856.

User submitted fonts don't include `unicode-range` keys, thus the generated CSS for non-Google fonts was often missing failing website previews.