### PR TITLE
fix(api): refresh sleep timer every subrequest

### DIFF
--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -1,6 +1,7 @@
 import { StatusError } from 'itty-router';
 
 import { type Manifest, type ManifestVariable } from './manifest';
+import { keepAwake, SLEEP_MINUTES } from './sleep';
 
 type R2Object = string;
 
@@ -38,6 +39,8 @@ export const bucketPathVariable = ({
 	`${id}@${version}/variable/${subset}-${axes}-${style}.woff2`;
 
 export const listBucket = async (prefix: string) => {
+	keepAwake(SLEEP_MINUTES);
+
 	const resp = await fetch(`https://upload.fontsource.org/list/${prefix}`, {
 		headers: {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -58,6 +61,8 @@ export const putBucket = async (
 	bucketPath: string,
 	body: Uint8Array | ArrayBuffer,
 ) => {
+	keepAwake(SLEEP_MINUTES);
+
 	const resp = await fetch(`https://upload.fontsource.org/put/${bucketPath}`, {
 		method: 'PUT',
 		headers: {
@@ -76,6 +81,8 @@ export const putBucket = async (
 };
 
 export const getBucket = async (bucketPath: string) => {
+	keepAwake(SLEEP_MINUTES);
+
 	const resp = await fetch(`https://upload.fontsource.org/get/${bucketPath}`, {
 		headers: {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/api/download/src/download.ts
+++ b/api/download/src/download.ts
@@ -1,3 +1,4 @@
+import { info } from 'diary';
 import { StatusError } from 'itty-router';
 import JSZip from 'jszip';
 import PQueue from 'p-queue';
@@ -22,6 +23,7 @@ export const downloadFile = async (manifest: Manifest) => {
 	const { id, subset, weight, style, extension, version, url } = manifest;
 
 	const res = await fetch(url);
+	info(`Downloading ${url}`);
 
 	if (!res.ok) {
 		throw new StatusError(500, `Could not fetch ${url}`);

--- a/api/download/src/server.ts
+++ b/api/download/src/server.ts
@@ -2,21 +2,10 @@ import { enable, error as errorDiary, info } from 'diary';
 import { error as errorRes, json, type StatusError } from 'itty-router';
 
 import router from './router';
+import { keepAwake, SLEEP_MINUTES } from './sleep';
 
 // Enable logging
 enable('*');
-
-// Have a sleep timer that kills the worker after 5 minutes
-const SLEEP_MINUTES = 2;
-let sleepTimeout: NodeJS.Timeout;
-const keepAwake = (minutes: number) => {
-	if (sleepTimeout) {
-		clearTimeout(sleepTimeout);
-	}
-
-	// eslint-disable-next-line unicorn/no-process-exit
-	sleepTimeout = setTimeout(() => process.exit(0), 1000 * 60 * minutes);
-};
 
 // Trigger the timeout on first load
 keepAwake(SLEEP_MINUTES);

--- a/api/download/src/sleep.ts
+++ b/api/download/src/sleep.ts
@@ -1,0 +1,13 @@
+// Have a sleep timer that kills the worker after 5 minutes
+export const SLEEP_MINUTES = 2;
+
+let sleepTimeout: NodeJS.Timeout;
+
+export const keepAwake = (minutes: number) => {
+	if (sleepTimeout) {
+		clearTimeout(sleepTimeout);
+	}
+
+	// eslint-disable-next-line unicorn/no-process-exit
+	sleepTimeout = setTimeout(() => process.exit(0), 1000 * 60 * minutes);
+};

--- a/api/download/src/sleep.ts
+++ b/api/download/src/sleep.ts
@@ -1,5 +1,5 @@
 // Have a sleep timer that kills the worker after 5 minutes
-export const SLEEP_MINUTES = 2;
+export const SLEEP_MINUTES = 4;
 
 let sleepTimeout: NodeJS.Timeout;
 


### PR DESCRIPTION
For large fonts, the machine would just end up sleeping mid-download since the sleep timer wasn't refreshed during downloads. This triggers the refresh when performing subrequests so the server doesn't time out.