### PR TITLE
perf(api): use jsdelivr cdn for font files in css

### DIFF
--- a/.changeset/slow-days-itch.md
+++ b/.changeset/slow-days-itch.md
@@ -1,0 +1,7 @@
+---
+"cdn": patch
+"api": patch
+"upload": patch
+---
+
+perf(api): use jsdelivr cdn for font files in css

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -21,7 +21,7 @@ const makeFontFilePath = (
 	extension: string,
 ) => {
 	// We need to replace square brackets with empty spaces
-	return `https://r2.fontsource.org/fonts/${tag}/${subset}-${weight}-${style}.${extension}`
+	return `https://cdn.jsdelivr.net/fontsource/fonts/${tag}/${subset}-${weight}-${style}.${extension}`
 		.replace('[', '')
 		.replace(']', '');
 };
@@ -32,7 +32,7 @@ const makeFontFileVariablePath = (
 	axes: string,
 	style: string,
 ) => {
-	return `https://r2.fontsource.org/fonts/${tag}/${subset}-${axes}-${style}.woff2`
+	return `https://cdn.jsdelivr.net/fontsource/fonts/${tag}/${subset}-${axes}-${style}.woff2`
 		.replace('[', '')
 		.replace(']', '');
 };

--- a/api/metadata/package.json
+++ b/api/metadata/package.json
@@ -16,6 +16,7 @@
 		"eslint": "^8.50.0",
 		"itty-router": "^4.0.23",
 		"typescript": "^5.2.2",
+		"vitest": "^0.34.4",
 		"vitest-environment-miniflare": "^2.14.1",
 		"wrangler": "^3.8.0"
 	},

--- a/api/upload/package.json
+++ b/api/upload/package.json
@@ -16,6 +16,7 @@
 		"eslint": "^8.50.0",
 		"itty-router": "^4.0.23",
 		"typescript": "^5.0.4",
+		"vitest": "^0.34.4",
 		"vitest-environment-miniflare": "^2.14.1",
 		"wrangler": "^3.8.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      vitest:
+        specifier: ^0.34.4
+        version: 0.34.6(sass@1.62.1)
       vitest-environment-miniflare:
         specifier: ^2.14.1
         version: 2.14.1(vitest@0.34.6)
@@ -143,6 +146,9 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.2.2
+      vitest:
+        specifier: ^0.34.4
+        version: 0.34.6(sass@1.62.1)
       vitest-environment-miniflare:
         specifier: ^2.14.1
         version: 2.14.1(vitest@0.34.6)
@@ -3119,6 +3125,7 @@ packages:
 
   /@types/node@20.7.1:
     resolution: {integrity: sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==}
+    dev: true
 
   /@types/node@20.8.0:
     resolution: {integrity: sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ==}
@@ -3200,7 +3207,7 @@ packages:
     resolution: {integrity: sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.7.1
+      '@types/node': 20.8.2
     dev: false
     optional: true
 
@@ -3373,7 +3380,7 @@ packages:
       lodash: 4.17.21
       mlly: 1.4.2
       outdent: 0.8.0
-      vite: 4.4.9(@types/node@20.8.2)
+      vite: 4.4.9(@types/node@20.8.2)(sass@1.62.1)
       vite-node: 0.28.5(@types/node@20.8.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -5177,7 +5184,7 @@ packages:
       '@typescript-eslint/utils': 6.7.3(eslint@8.50.0)(typescript@5.2.2)
       eslint: 8.50.0
       typescript: 5.2.2
-      vitest: 0.34.6
+      vitest: 0.34.6(sass@1.62.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10291,7 +10298,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.4.9(@types/node@20.8.2)
+      vite: 4.4.9(@types/node@20.8.2)(sass@1.62.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10325,28 +10332,6 @@ packages:
       - terser
     dev: false
 
-  /vite-node@0.34.6(@types/node@20.8.2):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      mlly: 1.4.2
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@0.34.6(@types/node@20.8.2)(sass@1.62.1):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -10367,42 +10352,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite@4.4.9(@types/node@20.8.2):
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.8.2
-      esbuild: 0.18.20
-      postcss: 8.4.31
-      rollup: 3.29.4
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /vite@4.4.9(@types/node@20.8.2)(sass@1.62.1):
@@ -10522,71 +10471,6 @@ packages:
       - supports-color
       - terser
     dev: false
-
-  /vitest@0.34.6:
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.6
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.8.2
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.10
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.4
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.4.3
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.7.0
-      vite: 4.4.9(@types/node@20.8.2)
-      vite-node: 0.34.6(@types/node@20.8.2)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@0.34.6(sass@1.62.1):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,4 +1,4 @@
 import { defineWorkspace } from 'vitest/config';
 
 // api is not included in workspace because Miniflare breaks
-export default defineWorkspace(['packages/*']);
+export default defineWorkspace(['packages/*', 'api/*']);


### PR DESCRIPTION
I think the font file CDN is stable enough to use on the website. Eventually, we'll be able to use the proxy for the CSS API once I think that's stable enough too.