### PR TITLE
fix(api): correct ttls to use seconds everywhere

### DIFF
--- a/.changeset/smart-emus-roll.md
+++ b/.changeset/smart-emus-roll.md
@@ -1,0 +1,6 @@
+---
+"cdn": patch
+"api": patch
+---
+
+fix(api): correct ttls to use seconds everywhere

--- a/api/cdn/src/css.ts
+++ b/api/cdn/src/css.ts
@@ -63,7 +63,7 @@ export const updateCss = async (
 				ctx.waitUntil(
 					env.CSS.put(keyGen(tag, item.filename), item.css, {
 						metadata: {
-							ttl: Date.now() + CSS_TTL,
+							ttl: Date.now() / 1000 + CSS_TTL,
 						},
 					}),
 				);
@@ -83,7 +83,7 @@ export const updateCss = async (
 				ctx.waitUntil(
 					env.CSS.put(keyGen(tag, item.filename), item.css, {
 						metadata: {
-							ttl: Date.now() + CSS_TTL,
+							ttl: Date.now() / 1000 + CSS_TTL,
 						},
 					}),
 				);
@@ -131,7 +131,7 @@ export const updateVariableCSS = async (
 				ctx.waitUntil(
 					env.CSS.put(keyGenV(tag, item.filename), item.css, {
 						metadata: {
-							ttl: Date.now() + CSS_TTL,
+							ttl: Date.now() / 1000 + CSS_TTL,
 						},
 					}),
 				);
@@ -156,7 +156,7 @@ export const updateVariableCSS = async (
 				ctx.waitUntil(
 					env.CSS.put(keyGenV(tag, item.filename), item.css, {
 						metadata: {
-							ttl: Date.now() + CSS_TTL,
+							ttl: Date.now() / 1000 + CSS_TTL,
 						},
 					}),
 				);

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -202,7 +202,7 @@ router.get('/css/:tag/:file', withParams, async (request, env, ctx) => {
 
 	// If the ttl is not set or the cache expiry is less than the current time, then return old value
 	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		// Else query metadata for existence check
 		const [staticMetadata, variableMetadata] = await Promise.all([
 			getMetadata(id, request.clone(), env),

--- a/api/metadata/src/fontlist/get.ts
+++ b/api/metadata/src/fontlist/get.ts
@@ -19,7 +19,7 @@ const getOrUpdateMetadata = async (
 
 	// If the ttl is not set or the cache expiry is less than the current time, then return old value
 	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateMetadata(env));
 	}
 
@@ -42,7 +42,7 @@ const getOrUpdateList = async (
 		return await updateList(key, env);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateList(key, env));
 	}
 

--- a/api/metadata/src/fontlist/update.ts
+++ b/api/metadata/src/fontlist/update.ts
@@ -10,7 +10,7 @@ const updateMetadata = async (env: Env) => {
 	await env.FONTLIST.put('metadata', JSON.stringify(data), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + KV_TTL,
+			ttl: Date.now() / 1000 + KV_TTL,
 		},
 	});
 
@@ -33,7 +33,7 @@ const updateList = async (key: FontlistQueries, env: Env) => {
 	// Store the list in KV
 	await env.FONTLIST.put(key, JSON.stringify(list), {
 		metadata: {
-			ttl: Date.now() + KV_TTL,
+			ttl: Date.now() / 1000 + KV_TTL,
 		},
 	});
 	return list;

--- a/api/metadata/src/fonts/get.ts
+++ b/api/metadata/src/fonts/get.ts
@@ -16,7 +16,7 @@ const getOrUpdateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 
 	// If the ttl is not set or the cache expiry is less than the current time, then return old value
 	// while revalidating the cache
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateArrayMetadata(env, ctx));
 	}
 
@@ -33,7 +33,7 @@ const getOrUpdateId = async (id: string, env: Env, ctx: ExecutionContext) => {
 		return await updateId(id, env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateId(id, env, ctx));
 	}
 

--- a/api/metadata/src/fonts/router.ts
+++ b/api/metadata/src/fonts/router.ts
@@ -116,7 +116,7 @@ router.get('/v1/fonts/:id', withParams, async (request, env, ctx) => {
 router.get('/v1/fonts/:id/:file', withParams, async (request, _env, _ctx) => {
 	const { id, file } = request;
 	const url = `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${file}`;
-	return Response.redirect(url, 302);
+	return Response.redirect(url, 301);
 });
 
 // 404 for everything else

--- a/api/metadata/src/fonts/update.ts
+++ b/api/metadata/src/fonts/update.ts
@@ -30,7 +30,7 @@ const updateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 	await env.FONTLIST.put('metadata_arr', JSON.stringify(list), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + KV_TTL,
+			ttl: Date.now() / 1000 + KV_TTL,
 		},
 	});
 	return list;
@@ -96,7 +96,7 @@ const updateId = async (
 	await env.FONTS.put(id, JSON.stringify(value), {
 		metadata: {
 			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() + KV_TTL,
+			ttl: Date.now() / 1000 + KV_TTL,
 		},
 	});
 	return value;

--- a/api/metadata/src/stats/get.ts
+++ b/api/metadata/src/stats/get.ts
@@ -22,7 +22,7 @@ export const getOrUpdateVersion = async (
 		return await updateVersion(id, isVariable, env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateVersion(id, isVariable, env, ctx));
 	}
 
@@ -46,7 +46,7 @@ export const getOrUpdatePackageStat = async (
 		return await updatePackageStat(id, env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updatePackageStat(id, env, ctx));
 	}
 

--- a/api/metadata/src/stats/update.ts
+++ b/api/metadata/src/stats/update.ts
@@ -36,7 +36,7 @@ export const updateVersion = async (
 	ctx.waitUntil(
 		env.VARIABLE.put(key, JSON.stringify(resp), {
 			metadata: {
-				ttl: Date.now() + KV_TTL,
+				ttl: Date.now() / 1000 + KV_TTL,
 			},
 		}),
 	);
@@ -154,7 +154,7 @@ export const updatePackageStat = async (
 	ctx.waitUntil(
 		env.STATS.put(key, JSON.stringify(resp), {
 			metadata: {
-				ttl: Date.now() + STAT_TTL,
+				ttl: Date.now() / 1000 + STAT_TTL,
 			},
 		}),
 	);

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -7,10 +7,10 @@ export const VARIABLE_URL =
 export const AXIS_REGISTRY_URL =
 	'https://raw.githubusercontent.com/fontsource/font-files/main/metadata/axis-registry.json';
 
-export const API_BROWSER_TTL = 60; // 1 minute
+export const API_BROWSER_TTL = 60 * 5; // 5 minutes
 
-export const CF_EDGE_TTL = 60 * 60 * 2; // 2 hours
+export const CF_EDGE_TTL = 60 * 60 * 6; // 6 hours
 
-export const KV_TTL = 60 * 60 * 6; // 6 hourS
+export const KV_TTL = 60 * 60 * 24; // 24 hours
 
 export const STAT_TTL = 60 * 60 * 24; // 24 hours

--- a/api/metadata/src/variable/get.ts
+++ b/api/metadata/src/variable/get.ts
@@ -23,7 +23,7 @@ export const getOrUpdateVariableList = async (
 		return await updateVariableList(env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateVariableList(env, ctx));
 	}
 
@@ -68,7 +68,7 @@ export const getOrUpdateAxisRegistry = async (
 		return await updateAxisRegistry(env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
+	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
 		ctx.waitUntil(updateAxisRegistry(env, ctx));
 	}
 

--- a/api/metadata/src/variable/update.ts
+++ b/api/metadata/src/variable/update.ts
@@ -30,7 +30,7 @@ export const updateVariableList = async (env: Env, ctx: ExecutionContext) => {
 		env.VARIABLE_LIST.put('metadata', JSON.stringify(noVariants), {
 			metadata: {
 				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() + KV_TTL,
+				ttl: Date.now() / 1000 + KV_TTL,
 			},
 		}),
 	);
@@ -64,7 +64,7 @@ export const updateVariable = async (
 		env.VARIABLE.put(id, JSON.stringify(dataId), {
 			metadata: {
 				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() + KV_TTL,
+				ttl: Date.now() / 1000 + KV_TTL,
 			},
 		}),
 	);
@@ -95,7 +95,7 @@ export const updateAxisRegistry = async (env: Env, ctx: ExecutionContext) => {
 		env.VARIABLE.put('axis_registry', JSON.stringify(registry), {
 			metadata: {
 				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() + KV_TTL,
+				ttl: Date.now() / 1000 + KV_TTL,
 			},
 		}),
 	);


### PR DESCRIPTION
This updates the caching TTLs for all API calls to convert `Date.now()` into seconds, fixing the stale-while-revalidate logic to actually be used instead of updating every call.

There are also a few tweaks to increase caching lengths as we get more confident with the API.