### PR TITLE
fix(api): should 404 unknown id for stats

### DIFF
--- a/.changeset/funny-eagles-exercise.md
+++ b/.changeset/funny-eagles-exercise.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix(api): should 404 unknown id for stats

--- a/api/metadata/src/stats/router.ts
+++ b/api/metadata/src/stats/router.ts
@@ -63,6 +63,12 @@ router.get('/v1/stats/:id', withParams, async (request, env, ctx) => {
 		return response;
 	}
 
+	// Check if font exists
+	const metadata = await getOrUpdateId(id, env, ctx);
+	if (!metadata) {
+		throw new StatusError(404, 'Not found. Font does not exist.');
+	}
+
 	const stats = await getOrUpdatePackageStat(id, env, ctx);
 	if (!stats) {
 		throw new StatusError(500, 'Internal Server Error. Stats list empty.');


### PR DESCRIPTION
The current stats API will return a 500 instead of a 404 if the font ID is unknown. This adds an existence check before trying to update the stats KV.