### PR TITLE
ci(website): apply better load balancing logic and dont use update action anymore

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -18,5 +18,5 @@ jobs:
           url: "https://fontsource.org/actions/update"
           method: "POST"
           bearerToken: ${{ secrets.WEBSITE_UPDATE_TOKEN }}
-          data: '{"algolia": true, "download": true, "axisRegistry": true, "docs": true}'
+          data: '{"algolia": true}'
           timeout: 300000

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -46,15 +46,6 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_STAGING_TOKEN }}
 
-      - name: Trigger DB updates
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: "https://staging.fontsource.org/actions/update"
-          method: "POST"
-          bearerToken: ${{ secrets.WEBSITE_UPDATE_TOKEN }}
-          data: '{"download": true, "axisRegistry": true, "docs": true}'
-          timeout: 300000
-
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: "Deployed to staging: https://staging.fontsource.org/"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,12 +38,3 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_PROD_TOKEN }}
-
-      - name: Trigger DB updates
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: "https://fontsource.org/actions/update"
-          method: "POST"
-          bearerToken: ${{ secrets.WEBSITE_UPDATE_TOKEN }}
-          data: '{"algolia": true, "download": true, "axisRegistry": true, "docs": true}'
-          timeout: 300000

--- a/website/app/routes/[robots.txt].tsx
+++ b/website/app/routes/[robots.txt].tsx
@@ -6,7 +6,7 @@ Allow: /
 
 Sitemap: https://fontsource.org/sitemap.xml`;
 
-	if (process.env.NODE_ENV === 'production') {
+	if (process.env.FLY_APP_NAME === 'fontsource') {
 		return new Response(prod, {
 			headers: {
 				'Content-Type': 'text/plain',

--- a/website/app/routes/actions.update.ts
+++ b/website/app/routes/actions.update.ts
@@ -5,9 +5,6 @@ import { updateAlgoliaIndex } from '@/utils/algolia.server';
 
 interface UpdateData {
 	algolia?: boolean;
-	download?: boolean;
-	axisRegistry?: boolean;
-	docs?: boolean;
 	force?: boolean;
 }
 

--- a/website/fly.staging.toml
+++ b/website/fly.staging.toml
@@ -28,10 +28,11 @@ force_https = true
 [[services.ports]]
 port = 443
 handlers = ["tls", "http"]
+
 [services.concurrency]
-type = "connections"
-hard_limit = 60
-soft_limit = 45
+type = "requests"
+hard_limit = 100
+soft_limit = 80
 
 [[services.tcp_checks]]
 interval = "15s"

--- a/website/fly.toml
+++ b/website/fly.toml
@@ -32,9 +32,9 @@ port = 443
 handlers = ["tls", "http"]
 
 [services.concurrency]
-type = "connections"
+type = "requests"
 hard_limit = 100
-soft_limit = 50
+soft_limit = 60
 
 [[services.tcp_checks]]
 interval = "15s"


### PR DESCRIPTION
Since migrating most of the backend logic to the API, the website doesn't need to trigger any db updates on a new deploy.
There are also a few tweaks on the Fly Load Balancing numbers as we downscaled all our VMs to 256MB instances due to underutilisation.