### PR TITLE
feat(api): add variable data to stats api

### DIFF
--- a/.changeset/rotten-hairs-smoke.md
+++ b/.changeset/rotten-hairs-smoke.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+feat(api): add variable data to stats api


### PR DESCRIPTION
Variable metadata wasn't included in the first iteration of the stats API. This should now include any NPM or jsDelivr related information for download statistics.