### PR TITLE
fix(api): remove variable variants

### DIFF
--- a/.changeset/tricky-dots-travel.md
+++ b/.changeset/tricky-dots-travel.md
@@ -1,0 +1,7 @@
+---
+"cdn": patch
+"common-api": patch
+"api": patch
+---
+
+fix(api): remove variable variants

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -24,8 +24,7 @@ interface CDNRequest extends IRequestStrict {
 	file: string;
 }
 
-// TODO: Replace with immutable once we migrate to jsdelivr proxy
-const IMMUTABLE_CACHE = 'public, max-age=86400, stale-while-revalidate=604800'; // 'public, max-age=31536000, immutable'
+const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable';
 const STALE_CACHE = 'public, max-age=86400, stale-while-revalidate=604800';
 
 export const { preflight, corsify } = createCors();

--- a/api/common/types.ts
+++ b/api/common/types.ts
@@ -45,10 +45,10 @@ interface VersionResponse {
 }
 
 interface AxesData {
-	default: string;
-	min: string;
-	max: string;
-	step: string;
+	default: number;
+	min: number;
+	max: number;
+	step: number;
 }
 
 // axes: italic: link
@@ -62,7 +62,6 @@ interface VariableVariants {
 
 interface VariableMetadata {
 	family: string;
-	id: string;
 	axes: Record<string, AxesData>;
 }
 

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -13,4 +13,4 @@ export const CF_EDGE_TTL = 60 * 60 * 6; // 6 hours
 
 export const KV_TTL = 60 * 60 * 24; // 24 hours
 
-export const STAT_TTL = 60 * 60 * 24; // 24 hours
+export const STAT_TTL = 60 * 60 * 6; // 6 hours

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -9,8 +9,8 @@ export const AXIS_REGISTRY_URL =
 
 export const API_BROWSER_TTL = 60 * 5; // 5 minutes
 
-export const CF_EDGE_TTL = 60 * 60 * 6; // 6 hours
+export const CF_EDGE_TTL = 60 * 60 * 24; // 24 hours
 
-export const KV_TTL = 60 * 60 * 24; // 24 hours
+export const KV_TTL = 60 * 60 * 12; // 12 hours
 
 export const STAT_TTL = 60 * 60 * 6; // 6 hours

--- a/api/metadata/src/variable/get.ts
+++ b/api/metadata/src/variable/get.ts
@@ -1,4 +1,4 @@
-import { type VariableMetadataWithVariants } from 'common-api/types';
+import { type VariableMetadata } from 'common-api/types';
 
 import { type TTLMetadata } from '../types';
 import { type AxisRegistry, type VariableList } from './types';
@@ -36,7 +36,7 @@ export const getOrUpdateVariableId = async (
 	ctx: ExecutionContext,
 ) => {
 	const { value, metadata } = await env.VARIABLE.getWithMetadata<
-		VariableMetadataWithVariants,
+		VariableMetadata,
 		TTLMetadata
 	>(id, {
 		type: 'json',

--- a/api/metadata/src/variable/update.ts
+++ b/api/metadata/src/variable/update.ts
@@ -21,8 +21,8 @@ export const updateVariableList = async (env: Env, ctx: ExecutionContext) => {
 	// Remove variants property from all fonts
 	const noVariants: Record<string, VariableMetadata> = {};
 	for (const [key, value] of Object.entries(data)) {
-		const { variants, ...rest } = value;
-		noVariants[key] = rest;
+		const { axes, family } = value;
+		noVariants[key] = { axes, family };
 	}
 
 	// Save entire metadata into KV first
@@ -59,9 +59,14 @@ export const updateVariable = async (
 		return null;
 	}
 
+	const noVariants: VariableMetadata = {
+		family: dataId.family,
+		axes: dataId.axes,
+	};
+
 	// Save entire metadata into KV first
 	ctx.waitUntil(
-		env.VARIABLE.put(id, JSON.stringify(dataId), {
+		env.VARIABLE.put(id, JSON.stringify(noVariants), {
 			metadata: {
 				// We need to set a custom ttl for a stale-while-revalidate strategy
 				ttl: Date.now() / 1000 + KV_TTL,
@@ -69,7 +74,7 @@ export const updateVariable = async (
 		}),
 	);
 
-	return dataId;
+	return noVariants;
 };
 
 export const updateAxisRegistry = async (env: Env, ctx: ExecutionContext) => {


### PR DESCRIPTION
As the variable API is still in an experimental phase and is undocumented while it is being tested, it should be fine to remove the `variants` property since it isn't very useful while taking up a lot of the object's size.