### PR TITLE
fix(api): store version stats in correct kv cache

### DIFF
--- a/.changeset/chatty-bees-watch.md
+++ b/.changeset/chatty-bees-watch.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix(api): store version stats in correct kv cache

--- a/api/metadata/src/stats/update.ts
+++ b/api/metadata/src/stats/update.ts
@@ -35,7 +35,7 @@ export const updateVersion = async (
 
 	// Add to KV cache
 	ctx.waitUntil(
-		env.VARIABLE.put(key, JSON.stringify(resp), {
+		env.STATS.put(key, JSON.stringify(resp), {
 			metadata: {
 				ttl: Date.now() / 1000 + KV_TTL,
 			},


### PR DESCRIPTION
Turns out we were never storing the version metadata in the correct KV cache leading to a short outage on our end when our upstream provider for version metadata also went down.

This should store metadata in the correct KV namespace and should also lead to faster response times across the board.