### PR TITLE
fix(website): sitemap generation

### DIFF
--- a/website/app/routes/[sitemap.xml].tsx
+++ b/website/app/routes/[sitemap.xml].tsx
@@ -1,5 +1,3 @@
-
-
 import type { LoaderFunction } from '@remix-run/node';
 import path from 'pathe';
 import { SitemapStream, streamToPromise } from 'sitemap';
@@ -14,7 +12,7 @@ export const loader: LoaderFunction = async () => {
 
 	// Pipe each font to stream
 	const fontlist: Record<string, string> = await kya(
-		'https://api.fontsource.org/fontlist?family'
+		'https://api.fontsource.org/fontlist?family',
 	);
 
 	for (const id of Object.keys(fontlist)) {
@@ -26,8 +24,7 @@ export const loader: LoaderFunction = async () => {
 	}
 
 	// Pipe all docs to stream
-	// eslint-disable-next-line unicorn/prefer-module
-	const slugs = await getAllSlugsInDir(path.join(__dirname+ '../docs'));
+	const slugs = await getAllSlugsInDir(path.join(process.cwd(), 'docs'));
 
 	for (const slug of slugs) {
 		smStream.write({


### PR DESCRIPTION
Sitemaps were not generating correctly after the Remix v2 migration which may have changed how `__dirname` works. This switches the docs slug scraper to use absolute paths from `process.cwd()` instead.