### PR TITLE
fix(api): invalid version sorting

### DIFF
--- a/.changeset/spicy-donuts-call.md
+++ b/.changeset/spicy-donuts-call.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix(api): invalid version sorting

--- a/api/metadata/src/stats/util.ts
+++ b/api/metadata/src/stats/util.ts
@@ -10,12 +10,15 @@ interface JSDelivrAPIVersion {
 
 export const sortSemverList = (list: string[]): string[] => {
 	return list.sort((a, b) => {
-		const aMajor = a.split('.')[0];
-		const bMajor = b.split('.')[0];
-		const aMinor = a.split('.')[1];
-		const bMinor = b.split('.')[1];
-		const aPatch = a.split('.')[2];
-		const bPatch = b.split('.')[2];
+		const aSplit = a.split('.');
+		const bSplit = b.split('.');
+
+		const aMajor = Number(aSplit[0]);
+		const bMajor = Number(bSplit[0]);
+		const aMinor = Number(aSplit[1]);
+		const bMinor = Number(bSplit[1]);
+		const aPatch = Number(aSplit[2]);
+		const bPatch = Number(bSplit[2]);
 		if (aMajor > bMajor) return -1;
 		if (aMajor < bMajor) return 1;
 		if (aMinor > bMinor) return -1;


### PR DESCRIPTION
Our version API was incorrectly sorting any semver versions that had multiple digits per section e.g. `5.0.18` will sort after `5.0.1`.

This issue cascades down to our CSS API that relies on the latest version value for outputting up to date artifacts.