### PR TITLE
perf(website): use jsdelivr cdn instead of r2 origin for css

### DIFF
--- a/website/app/components/preview/TextArea.tsx
+++ b/website/app/components/preview/TextArea.tsx
@@ -117,7 +117,7 @@ const TextArea = ({ metadata, variableCssKey }: TextAreaProps) => {
 					<Fragment key={`s-${weight}`}>
 						<link
 							rel="stylesheet"
-							href={`https://r2.fontsource.org/css/${id}@latest/${weight}.css`}
+							href={`https://cdn.jsdelivr.net/fontsource/css/${id}@latest/${weight}.css`}
 						/>
 						<TextBox weight={weight} family={family} loaded={!isFontLoaded} />
 					</Fragment>
@@ -125,7 +125,7 @@ const TextArea = ({ metadata, variableCssKey }: TextAreaProps) => {
 			{isVariable && (
 				<link
 					rel="stylesheet"
-					href={`https://r2.fontsource.org/css/${id}:vf@latest/${
+					href={`https://cdn.jsdelivr.net/fontsource/css/${id}:vf@latest/${
 						variableCssKey ?? 'wght'
 					}.css`}
 				/>

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -54,7 +54,7 @@ const HitComponent = ({ hit, fontSize }: HitComponentProps) => {
 		>
 			<link
 				rel="stylesheet"
-				href={`https://r2.fontsource.org/css/${hit.objectID}@latest/index.css`}
+				href={`https://cdn.jsdelivr.net/fontsource/css/${hit.objectID}@latest/index.css`}
 			/>
 			<Skeleton visible={!isFontLoaded}>
 				<Text fz={fontSize} style={{ fontFamily: `"${hit.family}"` }}>


### PR DESCRIPTION
We were still using the R2 origin API for our CSS instead of the CDN for the website. This changes it to use the CDN since it has become more stable.