### PR TITLE
fix(api): use multipart for uploads

### DIFF
--- a/.changeset/grumpy-years-judge.md
+++ b/.changeset/grumpy-years-judge.md
@@ -1,6 +1,6 @@
 ---
-"download": patch
-"upload": patch
+"download": minor
+"upload": minor
 ---
 
 fix(api): use multipart for uploads

--- a/.changeset/grumpy-years-judge.md
+++ b/.changeset/grumpy-years-judge.md
@@ -1,0 +1,6 @@
+---
+"download": patch
+"upload": patch
+---
+
+fix(api): use multipart for uploads

--- a/.changeset/grumpy-years-judge.md
+++ b/.changeset/grumpy-years-judge.md
@@ -3,4 +3,4 @@
 "upload": minor
 ---
 
-fix(api): use multipart for uploads
+feat(api): use multipart for uploads

--- a/.changeset/large-tomatoes-cover.md
+++ b/.changeset/large-tomatoes-cover.md
@@ -1,0 +1,6 @@
+---
+"cdn": patch
+"upload": patch
+---
+
+perf(api): stream responses instead of buffering

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -70,7 +70,9 @@ router.get('/fonts/:tag/:file', withParams, async (request, env, ctx) => {
 	headers.set('Content-Type', isZip ? 'application/zip' : `font/${extension}`);
 	headers.set(
 		'Content-Disposition',
-		isZip ? `${id}_${version}.zip` : `${id}_${version}_${file}`,
+		`attachment; filename="${
+			isZip ? `${id}_${version}.zip` : `${id}_${version}_${file}`
+		}"`,
 	);
 
 	// Check R2 bucket for file

--- a/api/download/package.json
+++ b/api/download/package.json
@@ -21,7 +21,6 @@
 	"dependencies": {
 		"diary": "^0.4.4",
 		"itty-router": "^4.0.23",
-		"jszip": "^3.10.1",
 		"p-queue": "^7.4.1",
 		"woff2sfnt-sfnt2woff": "^1.0.0"
 	}

--- a/api/download/package.json
+++ b/api/download/package.json
@@ -20,6 +20,7 @@
 	},
 	"dependencies": {
 		"diary": "^0.4.4",
+		"fflate": "^0.8.1",
 		"itty-router": "^4.0.23",
 		"p-queue": "^7.4.1",
 		"woff2sfnt-sfnt2woff": "^1.0.0"

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -61,7 +61,7 @@ const abortMultiPartUpload = async (bucketPath: string, uploadId: string) => {
 	const resp = await fetch(
 		`https://upload.fontsource.org/multipart/${bucketPath}?action=mpu-abort`,
 		{
-			method: 'POST',
+			method: 'DELETE',
 			headers: {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				Authorization: `Bearer ${process.env.UPLOAD_KEY!}`,
@@ -119,7 +119,7 @@ const uploadPart = async (
 	const resp = await fetch(
 		`https://upload.fontsource.org/multipart/${bucketPath}?action=mpu-uploadpart`,
 		{
-			method: 'POST',
+			method: 'PUT',
 			headers: {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				Authorization: `Bearer ${process.env.UPLOAD_KEY!}`,

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -203,9 +203,9 @@ export const putBucket = async (
 	bucketPath: string,
 	body: Uint8Array | ArrayBuffer,
 ) => {
-	// We only use multipart uploads for files larger than 20MB since Cloudflare
+	// We only use multipart uploads for files larger than 80MB since Cloudflare
 	// limits the maximum request size to 100MB
-	const partSize = 20 * 1024 * 1024;
+	const partSize = 80 * 1024 * 1024;
 	if (body.byteLength < partSize) {
 		keepAwake(SLEEP_MINUTES);
 		const resp = await fetch(

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -192,7 +192,7 @@ export const putBucket = async (
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					Authorization: `Bearer ${process.env.UPLOAD_KEY!}`,
 				},
-				body: new Blob([body]),
+				body,
 			},
 		);
 

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -134,7 +134,10 @@ const uploadPart = async (
 	const formData = new FormData();
 	formData.append('partNumber', String(partNumber));
 	formData.append('uploadId', uploadId);
-	formData.append('file', new Blob([partData]));
+
+	const blob = new Blob([partData]);
+	const filename = `${bucketPath}-${partNumber}`;
+	formData.append('file', blob, filename);
 
 	const resp = await fetch(
 		`https://upload.fontsource.org/multipart/${bucketPath}?action=mpu-uploadpart`,
@@ -237,6 +240,7 @@ export const putBucket = async (
 	while (offset < body.byteLength) {
 		const end = Math.min(offset + partSize, body.byteLength);
 		const partData = body.slice(offset, end);
+		info(`Uploading part ${partNumber} with size ${partData.byteLength}`);
 
 		const etag = await uploadPart(bucketPath, uploadId, partNumber, partData);
 

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -111,6 +111,7 @@ const uploadPart = async (
 	partNumber: number,
 	partData: Uint8Array | ArrayBuffer,
 ) => {
+	keepAwake(SLEEP_MINUTES);
 	const formData = new FormData();
 	formData.append('partNumber', partNumber.toString());
 	formData.append('uploadId', uploadId);

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -173,12 +173,11 @@ export const putBucket = async (
 	bucketPath: string,
 	body: Uint8Array | ArrayBuffer,
 ) => {
-	keepAwake(SLEEP_MINUTES);
-
-	// We only use multipart uploads for files larger than 50MB since Cloudflare
+	// We only use multipart uploads for files larger than 20MB since Cloudflare
 	// limits the maximum request size to 100MB
-	const partSize = 50 * 1024 * 1024;
+	const partSize = 20 * 1024 * 1024;
 	if (body.byteLength < partSize) {
+		keepAwake(SLEEP_MINUTES);
 		const resp = await fetch(
 			`https://upload.fontsource.org/put/${bucketPath}`,
 			{
@@ -193,7 +192,7 @@ export const putBucket = async (
 
 		if (!resp.ok) {
 			const error = await resp.text();
-			handleBucketError(resp, `Unable to upload file. ${error}`);
+			handleBucketError(resp, `Unable to upload file ${bucketPath}. ${error}`);
 		}
 
 		return;

--- a/api/download/src/bucket.ts
+++ b/api/download/src/bucket.ts
@@ -1,3 +1,4 @@
+import { info } from 'diary';
 import { StatusError } from 'itty-router';
 
 import { type Manifest, type ManifestVariable } from './manifest';
@@ -206,6 +207,8 @@ export const putBucket = async (
 
 		return;
 	}
+
+	info(`Uploading ${bucketPath} in parts with size ${body.byteLength}`);
 
 	const uploadId = await initiateMultipartUpload(bucketPath);
 

--- a/api/download/src/download.ts
+++ b/api/download/src/download.ts
@@ -167,6 +167,9 @@ export const generateZip = async (
 			});
 	}
 
+	// Wait for all files to be downloaded
+	await zipQueue.onIdle();
+
 	// Add LICENSE file
 	const license = await fetch(
 		`https://cdn.jsdelivr.net/npm/@fontsource/${id}@${version}/LICENSE`,

--- a/api/download/src/manifest.ts
+++ b/api/download/src/manifest.ts
@@ -3,6 +3,7 @@ import { StatusError } from 'itty-router';
 import { bucketPath, listBucket } from './bucket';
 import { type IDResponse } from './types';
 import { splitTag } from './util';
+import { info } from 'diary';
 
 export interface Manifest {
 	id: string;
@@ -165,13 +166,17 @@ export const pruneManifest = async (
 		: `${id}@${version}/`;
 	const existingFiles = await listBucket(prefix);
 
-	const manifest = baseManifest.filter((file) => {
-		const existingFile = existingFiles.objects.find((existingFile) => {
-			return existingFile === bucketPath(file);
-		});
+	// Filter out existing files
+	const manifest = [];
+	const existingSet = new Set(existingFiles.objects);
+	for (const file of baseManifest) {
+		if (!existingSet.has(bucketPath(file))) {
+			manifest.push(file);
+		}
+	}
 
-		return !existingFile;
-	});
-
+	info(
+		`Found ${manifest.length} new files to download out of ${baseManifest.length} from original manifest.`,
+	);
 	return manifest;
 };

--- a/api/download/src/server.ts
+++ b/api/download/src/server.ts
@@ -23,7 +23,7 @@ export default {
 			})
 			.catch((error_: StatusError) => {
 				const path = new URL(req.url).pathname;
-				if (error_.status >= 500) {
+				if (!error_.status || error_.status >= 500) {
 					errorDiary(
 						`${req.method} ${path} ${error_.status} ${error_.message}`,
 					);

--- a/api/download/src/sleep.ts
+++ b/api/download/src/sleep.ts
@@ -1,5 +1,5 @@
-// Have a sleep timer that kills the worker after 3 minutes
-export const SLEEP_MINUTES = 3;
+// Have a sleep timer that kills the worker after 2 minutes
+export const SLEEP_MINUTES = 2;
 
 let sleepTimeout: NodeJS.Timeout;
 

--- a/api/download/src/sleep.ts
+++ b/api/download/src/sleep.ts
@@ -1,5 +1,5 @@
-// Have a sleep timer that kills the worker after 5 minutes
-export const SLEEP_MINUTES = 4;
+// Have a sleep timer that kills the worker after 3 minutes
+export const SLEEP_MINUTES = 3;
 
 let sleepTimeout: NodeJS.Timeout;
 

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -134,8 +134,9 @@ router.put(
 				if (!uploadId)
 					throw new StatusError(400, 'Bad Request. Upload ID is required.');
 
-				const file = formData.get('file');
+				const file = formData.get('file') as unknown as Blob | undefined;
 				if (!file) throw new StatusError(400, 'Bad Request. File is required.');
+				const fileBuffer = await file.arrayBuffer();
 
 				const multipartUpload = env.BUCKET.resumeMultipartUpload(
 					path,
@@ -146,7 +147,7 @@ router.put(
 				try {
 					const uploadedPart: R2UploadedPart = await multipartUpload.uploadPart(
 						Number(partNumber),
-						file,
+						new Uint8Array(fileBuffer),
 					);
 
 					return json(

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -147,7 +147,7 @@ router.put(
 						ETag: uploadedPart.etag,
 					};
 
-					return json({ status: 200, resp }, { status: 200 });
+					return json({ status: 201, resp }, { status: 201 });
 				} catch (error: any) {
 					return error(400, error.message);
 				}
@@ -207,7 +207,7 @@ router.put(
 		const body = await request.arrayBuffer();
 
 		await env.BUCKET.put(path, body);
-		return json({ status: 200, message: 'Success' }, { status: 200 });
+		return json({ status: 201, message: 'Success.' }, { status: 201 });
 	},
 );
 

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -159,6 +159,21 @@ router.put(
 	},
 );
 
+router.put(
+	'/put/:path+',
+	withParams,
+	verifyAuth,
+	async (request, env, _ctx) => {
+		const { path } = request;
+		if (!path) return error(400, 'Bad Request. Path is required.');
+
+		const body = await request.arrayBuffer();
+
+		await env.BUCKET.put(path, body);
+		return json({ status: 200 }, { status: 200 });
+	},
+);
+
 router.delete(
 	'/multipart/:path+',
 	withParams,

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -3,15 +3,22 @@ import {
 	type IRequestStrict,
 	json,
 	Router,
+	withContent,
 	withParams,
 } from 'itty-router';
 
 import { verifyAuth } from './auth';
 import { type CFRouterContext } from './types';
 
+interface MultipartContent {
+	uploadId?: string;
+	parts?: R2UploadedPart[];
+}
+
 interface DownloadRequest extends IRequestStrict {
 	path: string;
 	prefix: string;
+	content: MultipartContent;
 }
 
 const router = Router<DownloadRequest, CFRouterContext>();
@@ -50,17 +57,142 @@ router.get(
 	},
 );
 
+router.post(
+	'/multipart/:path+',
+	withParams,
+	withContent,
+	verifyAuth,
+	async (request, env, _ctx) => {
+		const { path, query, content } = request;
+		if (!path) return error(400, 'Bad Request. Path is required.');
+
+		const action = query.action;
+		if (!action) return error(400, 'Bad Request. Action is required.');
+
+		switch (action) {
+			case 'mpu-create': {
+				const multipartUpload = await env.BUCKET.createMultipartUpload(path);
+				const body = {
+					uploadId: multipartUpload.uploadId,
+				};
+
+				return json({ status: 200, body }, { status: 200 });
+			}
+			case 'mpu-complete': {
+				const { uploadId, parts } = content;
+				if (!uploadId) return error(400, 'Bad Request. Upload ID is required.');
+				if (!parts) return error(400, 'Bad Request. Parts are required.');
+
+				const multipartUpload = env.BUCKET.resumeMultipartUpload(
+					path,
+					uploadId,
+				);
+
+				// Error handling in case the multipart upload does not exist anymore
+				try {
+					const object = await multipartUpload.complete(parts);
+					return new Response(undefined, {
+						headers: {
+							etag: object.httpEtag,
+						},
+					});
+				} catch (error: any) {
+					return error(400, error.message);
+				}
+			}
+			default: {
+				return error(400, 'Bad Request. Invalid action.');
+			}
+		}
+	},
+);
+
 router.put(
-	'/put/:path+',
+	'/multipart/:path+',
 	withParams,
 	verifyAuth,
 	async (request, env, _ctx) => {
-		const { path } = request;
+		const { path, query } = request;
 		if (!path) return error(400, 'Bad Request. Path is required.');
 
-		const body = await request.arrayBuffer();
-		await env.BUCKET.put(path, body);
-		return json({ status: 201, message: 'Success.' }, { status: 201 });
+		const action = query.action;
+		if (!action) return error(400, 'Bad Request. Action is required.');
+
+		switch (action) {
+			case 'mpu-uploadpart': {
+				// Parse form data body
+				const formData = await request.formData();
+				const partNumber = formData.get('partNumber');
+				if (!partNumber)
+					return error(400, 'Bad Request. Part number is required.');
+
+				const uploadId = formData.get('uploadId');
+				if (!uploadId) return error(400, 'Bad Request. Upload ID is required.');
+
+				const file = formData.get('file');
+				if (!file) return error(400, 'Bad Request. File is required.');
+
+				const multipartUpload = env.BUCKET.resumeMultipartUpload(
+					path,
+					uploadId,
+				);
+
+				// Error handling in case the multipart upload does not exist anymore
+				try {
+					const uploadedPart: R2UploadedPart = await multipartUpload.uploadPart(
+						Number(partNumber),
+						file,
+					);
+					const resp = {
+						ETag: uploadedPart.etag,
+					};
+
+					return json({ status: 200, resp }, { status: 200 });
+				} catch (error: any) {
+					return error(400, error.message);
+				}
+			}
+			default: {
+				return error(400, 'Bad Request. Invalid action.');
+			}
+		}
+	},
+);
+
+router.delete(
+	'/multipart/:path+',
+	withParams,
+	withContent,
+	verifyAuth,
+	async (request, env, _ctx) => {
+		const { path, content, query } = request;
+		if (!path) return error(400, 'Bad Request. Path is required.');
+
+		const action = query.action;
+		if (!action) return error(400, 'Bad Request. Action is required.');
+
+		switch (action) {
+			case 'mpu-abort': {
+				const { uploadId } = content;
+				if (!uploadId) return error(400, 'Bad Request. Upload ID is required.');
+
+				const multipartUpload = env.BUCKET.resumeMultipartUpload(
+					path,
+					uploadId,
+				);
+
+				// Error handling in case the multipart upload does not exist anymore
+				try {
+					await multipartUpload.abort();
+					return json({ status: 200 }, { status: 200 });
+				} catch (error: any) {
+					return error(400, error.message);
+				}
+			}
+			default: {
+				return error(400, 'Bad Request. Invalid action.');
+			}
+		}
 	},
 );
 

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -159,21 +159,6 @@ router.put(
 	},
 );
 
-router.put(
-	'/put/:path+',
-	withParams,
-	verifyAuth,
-	async (request, env, _ctx) => {
-		const { path } = request;
-		if (!path) return error(400, 'Bad Request. Path is required.');
-
-		const body = await request.arrayBuffer();
-
-		await env.BUCKET.put(path, body);
-		return json({ status: 200 }, { status: 200 });
-	},
-);
-
 router.delete(
 	'/multipart/:path+',
 	withParams,
@@ -208,6 +193,21 @@ router.delete(
 				return error(400, 'Bad Request. Invalid action.');
 			}
 		}
+	},
+);
+
+router.put(
+	'/put/:path+',
+	withParams,
+	verifyAuth,
+	async (request, env, _ctx) => {
+		const { path } = request;
+		if (!path) return error(400, 'Bad Request. Path is required.');
+
+		const body = await request.arrayBuffer();
+
+		await env.BUCKET.put(path, body);
+		return json({ status: 200, message: 'Success' }, { status: 200 });
 	},
 );
 

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -49,7 +49,11 @@ router.get(
 		if (!object)
 			throw new StatusError(404, `Not Found. Object ${path} does not exist.`);
 
-		return new Response(await object.arrayBuffer(), {
+		const headers = new Headers();
+		headers.set('etag', object.httpEtag);
+
+		return new Response(object.body, {
+			headers,
 			status: 200,
 		});
 	},
@@ -216,10 +220,8 @@ router.put(
 	withParams,
 	verifyAuth,
 	async (request, env, _ctx) => {
-		const { path } = request;
+		const { path, body } = request;
 		if (!path) throw new StatusError(400, 'Bad Request. Path is required.');
-
-		const body = await request.arrayBuffer();
 
 		await env.BUCKET.put(path, body);
 		return json({ status: 201, message: 'Success.' }, { status: 201 });

--- a/api/upload/src/router.ts
+++ b/api/upload/src/router.ts
@@ -50,6 +50,7 @@ router.get(
 			throw new StatusError(404, `Not Found. Object ${path} does not exist.`);
 
 		const headers = new Headers();
+		object.writeHttpMetadata(headers);
 		headers.set('etag', object.httpEtag);
 
 		return new Response(object.body, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       diary:
         specifier: ^0.4.4
         version: 0.4.4
+      fflate:
+        specifier: ^0.8.1
+        version: 0.8.1
       itty-router:
         specifier: ^4.0.23
         version: 4.0.23
@@ -5732,7 +5735,7 @@ packages:
       '@typescript-eslint/utils': 6.7.3(eslint@8.50.0)(typescript@5.3.3)
       eslint: 8.50.0
       typescript: 5.3.3
-      vitest: 0.34.6
+      vitest: 0.34.6(sass@1.62.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6158,6 +6161,10 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.2.1
+    dev: false
+
+  /fflate@0.8.1:
+    resolution: {integrity: sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==}
     dev: false
 
   /file-entry-cache@6.0.1:
@@ -11059,28 +11066,6 @@ packages:
       - terser
     dev: false
 
-  /vite-node@0.34.6(@types/node@20.10.4):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      mlly: 1.4.2
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      vite: 4.5.1(@types/node@20.10.4)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@0.34.6(@types/node@20.10.4)(sass@1.62.1):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -11256,71 +11241,6 @@ packages:
       - supports-color
       - terser
     dev: false
-
-  /vitest@0.34.6:
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.6
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.10.4
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.11.2
-      acorn-walk: 8.3.1
-      cac: 6.7.14
-      chai: 4.3.10
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.4
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.4.3
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.7.0
-      vite: 4.5.1(@types/node@20.10.4)
-      vite-node: 0.34.6(@types/node@20.10.4)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@0.34.6(sass@1.62.1):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       itty-router:
         specifier: ^4.0.23
         version: 4.0.23
-      jszip:
-        specifier: ^3.10.1
-        version: 3.10.1
       p-queue:
         specifier: ^7.4.1
         version: 7.4.1
@@ -4518,6 +4515,7 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: true
 
   /cosmiconfig@8.3.6(typescript@5.3.3):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -5734,7 +5732,7 @@ packages:
       '@typescript-eslint/utils': 6.7.3(eslint@8.50.0)(typescript@5.3.3)
       eslint: 8.50.0
       typescript: 5.3.3
-      vitest: 0.34.6(sass@1.62.1)
+      vitest: 0.34.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6859,10 +6857,6 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /immediate@3.0.6:
-    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-    dev: false
-
   /immutable@4.3.0:
     resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
 
@@ -7203,6 +7197,7 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -7380,15 +7375,6 @@ packages:
       object.values: 1.1.7
     dev: true
 
-  /jszip@3.10.1:
-    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
-    dependencies:
-      lie: 3.3.0
-      pako: 1.0.11
-      readable-stream: 2.3.8
-      setimmediate: 1.0.5
-    dev: false
-
   /keyv@4.5.3:
     resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
     dependencies:
@@ -7424,12 +7410,6 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  /lie@3.3.0:
-    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
-    dependencies:
-      immediate: 3.0.6
-    dev: false
 
   /lilconfig@3.0.0:
     resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
@@ -9224,6 +9204,7 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    dev: true
 
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -9588,6 +9569,7 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+    dev: true
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -10040,10 +10022,6 @@ packages:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.0
 
-  /setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-    dev: false
-
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -10316,6 +10294,7 @@ packages:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
       safe-buffer: 5.1.2
+    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -10941,6 +10920,7 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
 
   /util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -11078,6 +11058,28 @@ packages:
       - supports-color
       - terser
     dev: false
+
+  /vite-node@0.34.6(@types/node@20.10.4):
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.5.1(@types/node@20.10.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vite-node@0.34.6(@types/node@20.10.4)(sass@1.62.1):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
@@ -11254,6 +11256,71 @@ packages:
       - supports-color
       - terser
     dev: false
+
+  /vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.6
+      '@types/chai-subset': 1.3.3
+      '@types/node': 20.10.4
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.11.2
+      acorn-walk: 8.3.1
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      magic-string: 0.30.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 4.5.1(@types/node@20.10.4)
+      vite-node: 0.34.6(@types/node@20.10.4)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vitest@0.34.6(sass@1.62.1):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}


### PR DESCRIPTION
Closes #866.

This change also migrates our `JSZip` dependency to use `fflate` as there are serious performance limitations when using the former that breaks downloads for zip files greater than 10MB. WOFF2 is an already compressed standard that uses deflate, so deflating all the content again is completely unnecessary compared to selectively compressing with `fflate`'s options. 