### PR TITLE
fix(api): variable variants for numbered subsets

### DIFF
--- a/.changeset/quiet-zebras-relate.md
+++ b/.changeset/quiet-zebras-relate.md
@@ -1,0 +1,5 @@
+---
+"cdn": patch
+---
+
+fix(api): variable variants for numbered subsets

--- a/api/cdn/src/util.ts
+++ b/api/cdn/src/util.ts
@@ -117,7 +117,8 @@ export const generateVariableVariants = (
 		for (const style of metadata.styles) {
 			variants[axis][style] = {};
 
-			for (const subset of metadata.subsets) {
+			for (const unicodeKey of Object.keys(metadata.unicodeRange)) {
+				const subset = unicodeKey.replace('[', '').replace(']', '');
 				const value = makeFontFileVariablePath(
 					metadata.family,
 					style,
@@ -156,7 +157,8 @@ export const generateVariableVariants = (
 			variants.full = {};
 			variants.full[style] = {};
 
-			for (const subset of metadata.subsets) {
+			for (const unicodeKey of Object.keys(metadata.unicodeRange)) {
+				const subset = unicodeKey.replace('[', '').replace(']', '');
 				const value = makeFontFileVariablePath(
 					metadata.family,
 					style,


### PR DESCRIPTION
Variable fonts such as Noto Sans JP use numbered subsets to help reduce bundle sizes. Our variant generator from #909 didn't account for that which then caused some incorrect CSS to be generated.