### PR TITLE
fix(api): add retry logic when fetching updated file

### DIFF
--- a/.changeset/perfect-garlics-do.md
+++ b/.changeset/perfect-garlics-do.md
@@ -1,0 +1,5 @@
+---
+"cdn": patch
+---
+
+fix(api): add retry logic when fetching updated file

--- a/api/cdn/src/router.ts
+++ b/api/cdn/src/router.ts
@@ -40,7 +40,7 @@ router.get('/fonts/:tag/:file', withParams, async (request, env, ctx) => {
 	const cacheKey = new Request(url, request.clone());
 	const cache = caches.default;
 
-	const response = await cache.match(cacheKey);
+	let response = await cache.match(cacheKey);
 	if (response) {
 		return response;
 	}
@@ -116,18 +116,14 @@ router.get('/fonts/:tag/:file', withParams, async (request, env, ctx) => {
 	} else {
 		item = await updateFile(fullTag, file, env);
 	}
-	if (item !== null) {
-		headers.set('ETag', item.etag);
-		const response = new Response(item.body, {
-			status: 200,
-			headers,
-		});
-		ctx.waitUntil(cache.put(cacheKey, response.clone()));
-		return response;
-	}
 
-	// If file does not exist, return 404
-	throw new StatusError(404, 'Not Found. File does not exist.');
+	headers.set('ETag', item.etag);
+	response = new Response(item.body, {
+		status: 200,
+		headers,
+	});
+	ctx.waitUntil(cache.put(cacheKey, response.clone()));
+	return response;
 });
 
 router.get('/css/:tag/:file', withParams, async (request, env, ctx) => {

--- a/api/cdn/src/update.ts
+++ b/api/cdn/src/update.ts
@@ -27,7 +27,22 @@ export const updateZip = async (tag: string, env: Env) => {
 	}
 
 	// Check again if download.zip exists in bucket
-	const zip = await env.FONTS.get(`${tag}/download.zip`);
+	let retries = 0;
+	let zip = await env.FONTS.get(`${tag}/download.zip`);
+	while (!zip && retries < 3) {
+		zip = await env.FONTS.get(`${tag}/download.zip`);
+		retries++;
+		// Exponential backoff
+		await new Promise((resolve) => setTimeout(resolve, retries * 300));
+	}
+
+	if (!zip) {
+		throw new StatusError(
+			500,
+			'Internal Server Error. Failed to update zip file.',
+		);
+	}
+
 	return zip;
 };
 
@@ -41,7 +56,7 @@ export const updateFile = async (tag: string, file: string, env: Env) => {
 	});
 
 	const resp = await fetch(req);
-	if (!resp.ok) {
+	if (resp.status !== 201) {
 		if (resp.status === 404) {
 			throw new StatusError(resp.status, 'Not Found. File does not exist.');
 		}
@@ -53,7 +68,19 @@ export const updateFile = async (tag: string, file: string, env: Env) => {
 		);
 	}
 	// Check again if file exists in bucket
-	const font = await env.FONTS.get(`${tag}/${file}`);
+	let retries = 0;
+	let font = await env.FONTS.get(`${tag}/${file}`);
+	while (!font && retries < 3) {
+		font = await env.FONTS.get(`${tag}/${file}`);
+		retries++;
+		// Exponential backoff
+		await new Promise((resolve) => setTimeout(resolve, retries * 300));
+	}
+
+	if (!font) {
+		throw new StatusError(500, 'Internal Server Error. Failed to update file.');
+	}
+
 	return font;
 };
 
@@ -71,7 +98,7 @@ export const updateVariableFile = async (
 	});
 
 	const resp = await fetch(req);
-	if (!resp.ok) {
+	if (resp.status !== 201) {
 		if (resp.status === 404) {
 			throw new StatusError(resp.status, 'Not Found. File does not exist.');
 		}
@@ -83,6 +110,18 @@ export const updateVariableFile = async (
 		);
 	}
 	// Check again if file exists in bucket
-	const font = await env.FONTS.get(`${tag}/variable/${file}`);
+	let retries = 0;
+	let font = await env.FONTS.get(`${tag}/variable/${file}`);
+	while (!font && retries < 3) {
+		font = await env.FONTS.get(`${tag}/variable/${file}`);
+		retries++;
+		// Exponential backoff
+		await new Promise((resolve) => setTimeout(resolve, retries * 300));
+	}
+
+	if (!font) {
+		throw new StatusError(500, 'Internal Server Error. Failed to update file.');
+	}
+
 	return font;
 };


### PR DESCRIPTION
Closes #916. 

When fetching an uncached file from our CDN, we call a separate high-powered VM to process and store the necessary files into our R2 bucket. However, even if our download service returns `201`, the bucket may still not be ready to be read from (possibly due to streaming). This adds some retry logic to give the bucket time to catch up to our worker on new updates.