### PR TITLE
fix(api): multi word subset

### DIFF
--- a/.changeset/smooth-bats-heal.md
+++ b/.changeset/smooth-bats-heal.md
@@ -1,0 +1,5 @@
+---
+"download": patch
+---
+
+fix(api): handle multi word subsets

--- a/.changeset/smooth-bats-heal.md
+++ b/.changeset/smooth-bats-heal.md
@@ -2,4 +2,4 @@
 "download": patch
 ---
 
-fix(api): handle multi word subsets
+fix(api): handle multi word subsets in download manifest

--- a/api/download/src/manifest.ts
+++ b/api/download/src/manifest.ts
@@ -42,7 +42,10 @@ export const generateManifestItem = (
 ): Manifest => {
 	const { id, version } = splitTag(tag);
 	let [filename, extension] = file.split('.');
-	const [subset, weight, style] = filename.split('-');
+	const filenameArr = filename.split('-');
+	const style = filenameArr.pop();
+	const weight = filenameArr.pop();
+	const subset = filenameArr.join('-');
 	if (!subset || !weight || !style) {
 		throw new StatusError(400, 'Bad Request. Invalid filename.');
 	}


### PR DESCRIPTION
Some subsets may have multiple words, e.g. caucasian-albanian, which would incorrectly be cutoff with the previous logic when creating download manifests.