### PR TITLE
perf(website): generate css locally and cache loaders

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       ky:
         specifier: ^1.1.3
         version: 1.1.3
+      lru-cache:
+        specifier: ^10.1.0
+        version: 10.1.0
       millify:
         specifier: ^6.1.0
         version: 6.1.0
@@ -7517,7 +7520,6 @@ packages:
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}

--- a/website/app/components/preview/TextArea.tsx
+++ b/website/app/components/preview/TextArea.tsx
@@ -8,9 +8,10 @@ import {
 	useComputedColorScheme,
 } from '@mantine/core';
 import { useFocusWithin } from '@mantine/hooks';
-import { Fragment, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useIsFontLoaded } from '@/hooks/useIsFontLoaded';
+import { getPreviewText } from '@/utils/language/language';
 import type { Metadata } from '@/utils/types';
 
 import { fontVariation, previewState } from './observables';
@@ -23,13 +24,13 @@ interface TagProps {
 interface TextBoxProps {
 	family: string;
 	weight: number;
-	loaded: boolean;
+	style: string;
 }
 
 interface TextAreaProps {
 	metadata: Metadata;
-	variableCssKey?: string;
-	previewText: string;
+	staticCSS: string;
+	variableCSS?: string;
 }
 
 const Tag = ({ weight, active }: TagProps) => {
@@ -55,7 +56,7 @@ const Tag = ({ weight, active }: TagProps) => {
 	);
 };
 
-const TextBox = ({ family, weight, loaded }: TextBoxProps) => {
+const TextBox = ({ family, weight, style }: TextBoxProps) => {
 	const { ref, focused } = useFocusWithin();
 	const state = useSelector(previewState);
 	const variation = useSelector(fontVariation);
@@ -67,12 +68,15 @@ const TextBox = ({ family, weight, loaded }: TextBoxProps) => {
 			: previewState.color.set('#000000');
 	}, [colorScheme]);
 
+	const isFontLoaded = useIsFontLoaded(family, { weights: [weight], style });
+
 	return (
 		<>
-			<Skeleton visible={loaded}>
-				<Box className={classes['text-wrapper']}>
+			<Box className={classes['text-wrapper']}>
+				<Skeleton visible={!isFontLoaded}>
 					<TextInput
 						variant="unstyled"
+						className={classes.text}
 						styles={{
 							input: {
 								fontFamily: `"${family}", "Fallback Outline"`,
@@ -94,49 +98,61 @@ const TextBox = ({ family, weight, loaded }: TextBoxProps) => {
 						autoComplete="off"
 						ref={ref}
 					/>
-				</Box>
-			</Skeleton>
+				</Skeleton>
+			</Box>
 			<Tag weight={weight} active={focused} />
 		</>
 	);
 };
 
-const TextArea = ({ metadata, variableCssKey }: TextAreaProps) => {
-	const { id, family, weights, variable } = metadata;
-
-	const variableFamily = `${family} Variable`;
+const TextArea = ({ metadata, staticCSS, variableCSS }: TextAreaProps) => {
+	const { id, family, weights, variable, defSubset, category } = metadata;
 	const isVariable = Boolean(variable);
 
-	const isFontLoaded = useIsFontLoaded(isVariable ? variableFamily : family);
+	const isItal = useSelector(previewState.italic);
+	const style = isItal ? 'italic' : 'normal';
+
+	const isNotLatin =
+		defSubset !== 'latin' || category === 'icons' || category === 'other';
+	useEffect(() => {
+		if (isNotLatin) {
+			previewState.text.set(getPreviewText(defSubset, id));
+		}
+	}, [isNotLatin, defSubset, id]);
 
 	return (
 		<Flex direction="column">
 			<Text className={classes.header}>Font Preview</Text>
+			{!isVariable && (
+				<style
+					dangerouslySetInnerHTML={{
+						__html: staticCSS,
+					}}
+				/>
+			)}
 			{!isVariable &&
 				weights.map((weight) => (
-					<Fragment key={`s-${weight}`}>
-						<link
-							rel="stylesheet"
-							href={`https://cdn.jsdelivr.net/fontsource/css/${id}@latest/${weight}.css`}
-						/>
-						<TextBox weight={weight} family={family} loaded={!isFontLoaded} />
-					</Fragment>
+					<TextBox
+						key={`s-${weight}-${style}`}
+						family={family}
+						weight={weight}
+						style={style}
+					/>
 				))}
-			{isVariable && (
-				<link
-					rel="stylesheet"
-					href={`https://cdn.jsdelivr.net/fontsource/css/${id}:vf@latest/${
-						variableCssKey ?? 'wght'
-					}.css`}
+			{isVariable && variableCSS && (
+				<style
+					dangerouslySetInnerHTML={{
+						__html: variableCSS,
+					}}
 				/>
 			)}
 			{isVariable &&
 				weights.map((weight) => (
 					<TextBox
-						key={`v-${weight}`}
+						key={`v-${weight}-${style}`}
+						family={`${family} Variable`}
 						weight={weight}
-						family={variableFamily}
-						loaded={!isFontLoaded}
+						style={style}
 					/>
 				))}
 		</Flex>

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from '@legendapp/state/react';
 import { Box, Group, SimpleGrid, Skeleton, Text } from '@mantine/core';
+import { Link as NavLink } from '@remix-run/react';
 import { useEffect, useRef, useState } from 'react';
 import { useInfiniteHits, useInstantSearch } from 'react-instantsearch';
 
@@ -47,8 +48,9 @@ const HitComponent = ({ hit, fontSize }: HitComponentProps) => {
 
 	return (
 		<Box
-			component="a"
-			href={`/fonts/${hit.objectID}`}
+			renderRoot={({ ...others }) => (
+				<NavLink prefetch="intent" to={`/fonts/${hit.objectID}`} {...others} />
+			)}
 			className={classes.wrapper}
 			mih={{ base: '150px', sm: displaySelect === 'grid' ? '332px' : '150px' }}
 		>

--- a/website/app/hooks/useIsFontLoaded.ts
+++ b/website/app/hooks/useIsFontLoaded.ts
@@ -1,18 +1,21 @@
 // @ts-expect-error - The type definition is wrong
 import useFontFaceObserver from 'use-font-face-observer';
 
-export const useIsFontLoaded = (family: string, weights?: number[]) => {
-	const isFontLoaded = useFontFaceObserver(
-		[
-			{
-				family,
-			},
-		],
-		{ timeout: 15_000 },
-	);
-	if (!weights || weights.length === 0) return isFontLoaded;
+interface ObserverOptions {
+	weights?: number[];
+	style?: string;
+}
 
-	const loadingArray = weights.map((weight) => {
+export const useIsFontLoaded = (family: string, options?: ObserverOptions) => {
+	if (!options?.weights || options.weights.length === 0)
+		return useFontFaceObserver(
+			[{ family, style: options?.style ?? 'normal' }],
+			{
+				timeout: 15_000,
+			},
+		);
+
+	const loadingArray = options?.weights.map((weight) => {
 		// Loop loading order is guaranteed to be consistent, so we can disable the rule
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		return useFontFaceObserver(
@@ -20,6 +23,7 @@ export const useIsFontLoaded = (family: string, weights?: number[]) => {
 				{
 					family,
 					weight: String(weight),
+					style: options.style ?? 'normal',
 				},
 			],
 			{ timeout: 15_000 },

--- a/website/app/root.tsx
+++ b/website/app/root.tsx
@@ -2,7 +2,7 @@ import '@fontsource-variable/inter/wght.css';
 import '@fontsource-variable/source-code-pro/wght.css';
 import 'fallback-font/fallback-outline.css';
 import '@mantine/core/styles.css';
-import './styles/global.css';
+import '@/styles/global.css';
 
 import { enableLegendStateReact } from '@legendapp/state/react';
 import { ColorSchemeScript, MantineProvider } from '@mantine/core';

--- a/website/app/root.tsx
+++ b/website/app/root.tsx
@@ -32,7 +32,6 @@ export const meta: MetaFunction = () => {
 };
 
 export const headers: HeadersFunction = () => ({
-	'Accept-CH': 'Sec-CH-Prefers-Color-Scheme',
 	'Cache-Control': 'public, s-maxage=60',
 });
 

--- a/website/app/root.tsx
+++ b/website/app/root.tsx
@@ -33,6 +33,7 @@ export const meta: MetaFunction = () => {
 
 export const headers: HeadersFunction = () => ({
 	'Accept-CH': 'Sec-CH-Prefers-Color-Scheme',
+	'Cache-Control': 'public, s-maxage=60',
 });
 
 export const links: LinksFunction = () => [

--- a/website/app/routes/[robots.txt].tsx
+++ b/website/app/routes/[robots.txt].tsx
@@ -6,11 +6,14 @@ Allow: /
 
 Sitemap: https://fontsource.org/sitemap.xml`;
 
+	const headers = {
+		'Content-Type': 'text/plain',
+		'Cache-Control': 'public, max-age=86400', // 1 day
+	};
+
 	if (process.env.FLY_APP_NAME === 'fontsource') {
 		return new Response(prod, {
-			headers: {
-				'Content-Type': 'text/plain',
-			},
+			headers,
 		});
 	}
 
@@ -18,8 +21,6 @@ Sitemap: https://fontsource.org/sitemap.xml`;
 Disallow: /`;
 
 	return new Response(dev, {
-		headers: {
-			'Content-Type': 'text/plain',
-		},
+		headers,
 	});
 };

--- a/website/app/routes/[sitemap.xml].tsx
+++ b/website/app/routes/[sitemap.xml].tsx
@@ -42,6 +42,7 @@ export const loader: LoaderFunction = async () => {
 	return new Response(sitemap, {
 		headers: {
 			'Content-Type': 'application/xml',
+			'Cache-Control': 'public, max-age=86400', // 1 day
 		},
 	});
 };

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -135,10 +135,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 	// Add server state to local cache before responding
 	setSSRCache(serverUrl, serverState);
 
-	return json<SearchProps>({
-		serverState,
-		serverUrl,
-	});
+	return json<SearchProps>(
+		{
+			serverState,
+			serverUrl,
+		},
+		{
+			headers: {
+				'Cache-Control': 'public, max-age=300',
+			},
+		},
+	);
 };
 
 export default function Index() {

--- a/website/app/routes/docs.$.tsx
+++ b/website/app/routes/docs.$.tsx
@@ -32,7 +32,14 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		throw new Response('Not found', { status: 404 });
 	}
 
-	return json<LoaderData>({ code: mdx.code, frontmatter: mdx.frontmatter });
+	return json<LoaderData>(
+		{ code: mdx.code, frontmatter: mdx.frontmatter },
+		{
+			headers: {
+				'Cache-Control': 'public, max-age=300',
+			},
+		},
+	);
 };
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/website/app/routes/fonts.$id._index.tsx
+++ b/website/app/routes/fonts.$id._index.tsx
@@ -137,7 +137,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		downloadCount: stats.total.npmDownloadTotal,
 	};
 
-	return json(res);
+	return json(res, {
+		headers: {
+			'Cache-Control': 'public, max-age=300',
+		},
+	});
 };
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/website/app/routes/fonts.$id._index.tsx
+++ b/website/app/routes/fonts.$id._index.tsx
@@ -9,6 +9,7 @@ import { Configure } from '@/components/preview/Configure';
 import { TabsWrapper } from '@/components/preview/Tabs';
 import { TextArea } from '@/components/preview/TextArea';
 import classes from '@/styles/global.module.css';
+import { getCSSCache, setCSSCache } from '@/utils/cache.server';
 import { ogMeta } from '@/utils/meta';
 import {
 	getAxisRegistry,
@@ -64,56 +65,66 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 	);
 
 	// Generate static CSS
-	let staticCSS = '';
-	for (const weight of weights) {
-		for (const style of styles) {
-			staticCSS += unicodeKeys
-				.map((subset) =>
-					generateFontFace({
-						family,
-						display: 'block',
-						style,
-						weight,
-						src: [
-							{
-								url: `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${subset}-${weight}-${style}.woff2`,
-								format: 'woff2',
-							},
-						],
-						unicodeRange: unicodeRange[subset],
-					}),
-				)
-				.join('\n');
+	let staticCSS = getCSSCache(`s:${id}`) as string;
+	if (!staticCSS) {
+		for (const weight of weights) {
+			for (const style of styles) {
+				staticCSS += unicodeKeys
+					.map((subset) =>
+						generateFontFace({
+							family,
+							display: 'block',
+							style,
+							weight,
+							src: [
+								{
+									url: `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${subset}-${weight}-${style}.woff2`,
+									format: 'woff2',
+								},
+							],
+							unicodeRange: unicodeRange[subset],
+						}),
+					)
+					.join('\n');
+			}
 		}
+
+		// Cache in memory
+		if (staticCSS) setCSSCache(`s:${id}`, staticCSS);
 	}
 
 	// Generate variable CSS
 	let variableCSS: string | undefined;
 	if (variable) {
-		variableCSS = '';
-		for (const style of styles) {
-			variableCSS += unicodeKeys
-				.map((subset) =>
-					generateFontFace({
-						family,
-						display: 'block',
-						style,
-						weight: 400,
-						src: [
-							{
-								url: `https://cdn.jsdelivr.net/fontsource/fonts/${id}:vf@latest/${subset}-${variableCssKey}-${style}.woff2`,
-								format: 'woff2-variations',
+		variableCSS = getCSSCache(`v:${id}`);
+		if (!variableCSS) {
+			for (const style of styles) {
+				variableCSS += unicodeKeys
+					.map((subset) =>
+						generateFontFace({
+							family,
+							display: 'block',
+							style,
+							weight: 400,
+							src: [
+								{
+									url: `https://cdn.jsdelivr.net/fontsource/fonts/${id}:vf@latest/${subset}-${variableCssKey}-${style}.woff2`,
+									format: 'woff2-variations',
+								},
+							],
+							unicodeRange: unicodeRange[subset],
+							variable: {
+								wght: variable.axes.wght,
+								stretch: variable.axes.wdth,
+								slnt: variable.axes.slnt,
 							},
-						],
-						unicodeRange: unicodeRange[subset],
-						variable: {
-							wght: variable.axes.wght,
-							stretch: variable.axes.wdth,
-							slnt: variable.axes.slnt,
-						},
-					}),
-				)
-				.join('\n');
+						}),
+					)
+					.join('\n');
+
+				// Cache in memory
+				if (variableCSS) setCSSCache(`v:${id}`, variableCSS);
+			}
 		}
 	}
 

--- a/website/app/routes/fonts.$id.cdn.tsx
+++ b/website/app/routes/fonts.$id.cdn.tsx
@@ -31,7 +31,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		hits: stats.total.jsDelivrHitsTotal,
 	};
 
-	return json(res);
+	return json(res, {
+		headers: {
+			'Cache-Control': 'public, max-age=300',
+		},
+	});
 };
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/website/app/routes/fonts.$id.install.tsx
+++ b/website/app/routes/fonts.$id.install.tsx
@@ -31,7 +31,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		downloadCount: stats.total.npmDownloadTotal,
 	};
 
-	return json(res);
+	return json(res, {
+		headers: {
+			'Cache-Control': 'public, max-age=300',
+		},
+	});
 };
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/website/app/utils/cache.server.ts
+++ b/website/app/utils/cache.server.ts
@@ -1,0 +1,16 @@
+import { LRUCache } from 'lru-cache';
+
+const cssCache = new LRUCache<string, string>({
+	max: 1000,
+	ttl: 1000 * 60 * 60 * 24, // 1 day
+});
+
+const getCSSCache = (key: string) => {
+	return cssCache.get(key);
+};
+
+const setCSSCache = (key: string, value: string) => {
+	cssCache.set(key, value);
+};
+
+export { getCSSCache, setCSSCache };

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,7 @@
 		"instantsearch.js": "^4.62.0",
 		"isbot": "^3.7.1",
 		"ky": "^1.1.3",
+		"lru-cache": "^10.1.0",
 		"millify": "^6.1.0",
 		"nanoid": "^5.0.4",
 		"pathe": "^1.1.1",


### PR DESCRIPTION
Closes #923. This also closes #925, although using more aggressive caching rules instead as service workers offline semantics didn't seem necessary for this website.

This PR has general performance improvements and user experience improvements for the preview page, especially when it comes to loading fonts and switching them around. We're now locally generating our CSS instead of relying on the experimental CSS API since it is faster and more flexible too.