### PR TITLE
fix(website): generate css using subsets if no unicode keys found

### DIFF
--- a/website/app/routes/fonts.$id._index.tsx
+++ b/website/app/routes/fonts.$id._index.tsx
@@ -58,11 +58,16 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		}
 	}
 
-	const { family, weights, unicodeRange, styles } = metadata;
+	const { family, weights, unicodeRange, styles, subsets } = metadata;
 
-	const unicodeKeys = Object.keys(unicodeRange).map((key) =>
+	let unicodeKeys = Object.keys(unicodeRange).map((key) =>
 		key.replace('[', '').replace(']', ''),
 	);
+
+	// Non-google fonts have no unicode keys stored, thus we need to use the subsets
+	if (unicodeKeys.length === 0) {
+		unicodeKeys = subsets;
+	}
 
 	// Generate static CSS
 	let staticCSS = getCSSCache(`s:${id}`) as string;


### PR DESCRIPTION
Non-Google fonts don't have unicode key metadata for us to iterate on when generating CSS for previews, thus we'll default to subsets if it is empty.