### PR TITLE
fix(website): empty css cache response generates invalid font-face

### DIFF
--- a/website/app/components/search/Filters.tsx
+++ b/website/app/components/search/Filters.tsx
@@ -70,7 +70,6 @@ const Filters = () => {
 							readOnly
 							style={{
 								pointerEvents: 'none',
-								display: 'flex',
 							}}
 						/>
 					</UnstyledButton>

--- a/website/app/routes/fonts.$id._index.tsx
+++ b/website/app/routes/fonts.$id._index.tsx
@@ -70,7 +70,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 	}
 
 	// Generate static CSS
-	let staticCSS = getCSSCache(`s:${id}`) as string;
+	let staticCSS = getCSSCache(`s:${id}`) ?? '';
 	if (!staticCSS) {
 		for (const weight of weights) {
 			for (const style of styles) {
@@ -101,7 +101,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 	// Generate variable CSS
 	let variableCSS: string | undefined;
 	if (variable) {
-		variableCSS = getCSSCache(`v:${id}`);
+		variableCSS = getCSSCache(`v:${id}`) ?? '';
 		if (!variableCSS) {
 			for (const style of styles) {
 				variableCSS += unicodeKeys


### PR DESCRIPTION
When converting an undefined variable to string later in the `@font-face` generate, it actually converts it to "undefined" as a string which mangles the CSS into something like `undefined@font-face {...}`. This broke loading fonts in some areas of the website.

Also a tiny styling fix to the variable filters checkbox that broke the flex gap between the checkbox and text. 