### PR TITLE
perf(api): use cron triggers to update kv metadata

### DIFF
--- a/.changeset/twenty-parents-marry.md
+++ b/.changeset/twenty-parents-marry.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+perf(api): use cron triggers to update kv metadata

--- a/api/metadata/src/fontlist/router.ts
+++ b/api/metadata/src/fontlist/router.ts
@@ -2,7 +2,7 @@ import { error, type IRequestStrict, json, Router } from 'itty-router';
 
 import type { CFRouterContext } from '../types';
 import { API_BROWSER_TTL, CF_EDGE_TTL } from '../utils';
-import { getOrUpdateList } from './get';
+import { getList } from './get';
 import { type Fontlist, isFontlistQuery } from './types';
 
 const router = Router<IRequestStrict, CFRouterContext>();
@@ -30,7 +30,7 @@ router.get('/fontlist', async (request, env, ctx) => {
 	// If there is no query string, then return the type list
 	let list: Fontlist | undefined;
 	if (queryString.length === 0) {
-		list = await getOrUpdateList('type', env, ctx);
+		list = await getList('type', env, ctx);
 	}
 
 	// If there is a query string, then return the respective list
@@ -44,11 +44,11 @@ router.get('/fontlist', async (request, env, ctx) => {
 		}
 
 		// Get or update the list
-		list = await getOrUpdateList(query, env, ctx);
+		list = await getList(query, env, ctx);
 	}
 
 	if (!list) {
-		return error(500, 'Internal server error.');
+		return error(500, 'Unable to determine query type.');
 	}
 
 	response = json(list, {

--- a/api/metadata/src/fontlist/types.ts
+++ b/api/metadata/src/fontlist/types.ts
@@ -1,3 +1,5 @@
+import { type IDResponse } from 'common-api/types';
+
 import type { FontMetadata } from '../types';
 
 const fontlistQueries = [
@@ -11,11 +13,13 @@ const fontlistQueries = [
 	'version',
 	'type',
 ] as const;
-type FontlistQueries = typeof fontlistQueries[number] & keyof FontMetadata;
+type FontlistQueries = (typeof fontlistQueries)[number] & keyof FontMetadata;
 const isFontlistQuery = (query: string): query is FontlistQueries =>
 	fontlistQueries.includes(query as FontlistQueries);
 
 type Fontlist = Record<string, string | string[] | number[] | boolean>;
 
+type MetadataList = Record<string, IDResponse>;
+
 export { fontlistQueries, isFontlistQuery };
-export type { Fontlist, FontlistQueries };
+export type { Fontlist, FontlistQueries, MetadataList };

--- a/api/metadata/src/fonts/router.ts
+++ b/api/metadata/src/fonts/router.ts
@@ -9,7 +9,7 @@ import {
 
 import { type CFRouterContext } from '../types';
 import { API_BROWSER_TTL, CF_EDGE_TTL } from '../utils';
-import { getOrUpdateArrayMetadata, getOrUpdateId } from './get';
+import { getArrayMetadata, getId } from './get';
 import { isFontsQueries } from './types';
 
 interface FontRequest extends IRequestStrict {
@@ -35,7 +35,7 @@ router.get('/v1/fonts', async (request, env, ctx) => {
 		'Cache-Control': `public, max-age=${API_BROWSER_TTL}`,
 		'CDN-Cache-Control': `max-age=${CF_EDGE_TTL}`,
 	};
-	const data = await getOrUpdateArrayMetadata(env, ctx);
+	const data = await getArrayMetadata(env, ctx);
 
 	// If no query string, return the entire list
 	if (url.searchParams.toString().length === 0) {
@@ -96,7 +96,7 @@ router.get('/v1/fonts/:id', withParams, async (request, env, ctx) => {
 		return response;
 	}
 
-	const data = await getOrUpdateId(id, env, ctx);
+	const data = await getId(id, env, ctx);
 	if (!data) {
 		return error(404, 'Not Found. Font does not exist.');
 	}

--- a/api/metadata/src/fonts/update.ts
+++ b/api/metadata/src/fonts/update.ts
@@ -1,11 +1,10 @@
-import { getOrUpdateMetadata } from '../fontlist/get';
-import type { FontMetadata } from '../types';
-import { KV_TTL } from '../utils';
-import type { ArrayMetadata, FontVariants, IDResponse } from './types';
+import { getMetadata } from '../fontlist/get';
+import { METADATA_KEYS } from '../utils';
+import type { ArrayMetadata } from './types';
 
 // This updates the main array of fonts dataset
 const updateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
-	const data = await getOrUpdateMetadata(env, ctx);
+	const data = await getMetadata(env, ctx);
 
 	// v1 Response
 	const list: ArrayMetadata = [];
@@ -18,88 +17,19 @@ const updateArrayMetadata = async (env: Env, ctx: ExecutionContext) => {
 			weights: value.weights,
 			styles: value.styles,
 			defSubset: value.defSubset,
-			variable: Boolean(value.variable),
+			variable: value.variable,
 			lastModified: value.lastModified,
 			category: value.category,
-			license: value.license.type,
+			license: value.license,
 			type: value.type,
 		});
 	}
 
 	// Store the list in KV
-	await env.FONTLIST.put('metadata_arr', JSON.stringify(list), {
-		metadata: {
-			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() / 1000 + KV_TTL,
-		},
-	});
+	ctx.waitUntil(
+		env.METADATA.put(METADATA_KEYS.fonts_arr, JSON.stringify(list)),
+	);
 	return list;
 };
 
-const generateFontVariants = ({
-	id,
-	subsets,
-	weights,
-	styles,
-}: FontMetadata): FontVariants => {
-	const variants: FontVariants = {};
-
-	for (const weight of weights) {
-		variants[weight] = variants[weight] || {};
-
-		for (const style of styles) {
-			variants[weight][style] = variants[weight][style] || {};
-
-			for (const subset of subsets) {
-				variants[weight][style][subset] = {
-					url: {
-						woff2: `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${subset}-${weight}-${style}.woff2`,
-						woff: `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${subset}-${weight}-${style}.woff`,
-						ttf: `https://cdn.jsdelivr.net/fontsource/fonts/${id}@latest/${subset}-${weight}-${style}.ttf`,
-					},
-				};
-			}
-		}
-	}
-
-	return variants;
-};
-
-const updateId = async (
-	id: string,
-	env: Env,
-	ctx: ExecutionContext,
-): Promise<IDResponse | undefined> => {
-	const data = await getOrUpdateMetadata(env, ctx);
-
-	if (data[id] === undefined) {
-		return;
-	}
-
-	const value: IDResponse = {
-		id: data[id].id,
-		family: data[id].family,
-		subsets: data[id].subsets,
-		weights: data[id].weights,
-		styles: data[id].styles,
-		defSubset: data[id].defSubset,
-		variable: Boolean(data[id].variable),
-		lastModified: data[id].lastModified,
-		category: data[id].category,
-		license: data[id].license.type,
-		type: data[id].type,
-		unicodeRange: data[id].unicodeRange,
-		variants: generateFontVariants(data[id]),
-	};
-
-	// Store the list in KV
-	await env.FONTS.put(id, JSON.stringify(value), {
-		metadata: {
-			// We need to set a custom ttl for a stale-while-revalidate strategy
-			ttl: Date.now() / 1000 + KV_TTL,
-		},
-	});
-	return value;
-};
-
-export { updateArrayMetadata, updateId };
+export { updateArrayMetadata };

--- a/api/metadata/src/stats/router.ts
+++ b/api/metadata/src/stats/router.ts
@@ -7,10 +7,10 @@ import {
 	withParams,
 } from 'itty-router';
 
-import { getOrUpdateId } from '../fonts/get';
+import { getId } from '../fonts/get';
 import type { CFRouterContext } from '../types';
 import { API_BROWSER_TTL, CF_EDGE_TTL } from '../utils';
-import { getOrUpdatePackageStat, getOrUpdateVersion } from './get';
+import { getPackageStat, getVersion } from './get';
 
 interface StatsRequest extends IRequestStrict {
 	id: string;
@@ -30,12 +30,12 @@ router.get('/v1/version/:id', withParams, async (request, env, ctx) => {
 		return response;
 	}
 
-	const metadata = await getOrUpdateId(id, env, ctx);
+	const metadata = await getId(id, env, ctx);
 	if (!metadata) {
 		throw new StatusError(404, 'Not found. Font does not exist.');
 	}
 
-	const versions = await getOrUpdateVersion(id, metadata.variable, env, ctx);
+	const versions = await getVersion(id, metadata.variable, env, ctx);
 	if (!versions) {
 		throw new StatusError(500, 'Internal Server Error. Version list empty.');
 	}
@@ -64,12 +64,12 @@ router.get('/v1/stats/:id', withParams, async (request, env, ctx) => {
 	}
 
 	// Check if font exists
-	const metadata = await getOrUpdateId(id, env, ctx);
+	const metadata = await getId(id, env, ctx);
 	if (!metadata) {
 		throw new StatusError(404, 'Not found. Font does not exist.');
 	}
 
-	const stats = await getOrUpdatePackageStat(id, env, ctx);
+	const stats = await getPackageStat(id, env, ctx);
 	if (!stats) {
 		throw new StatusError(500, 'Internal Server Error. Stats list empty.');
 	}

--- a/api/metadata/src/stats/types.ts
+++ b/api/metadata/src/stats/types.ts
@@ -1,31 +1,3 @@
-interface NPMDownloadRegistry {
-	downloads: number;
-	start: string;
-	end: string;
-	package: string;
-}
-
-interface NPMDownloadRegistryRange {
-	downloads: Array<{
-		downloads: number;
-		day: string;
-	}>;
-	start: string;
-	end: string;
-	package: string;
-}
-interface JSDelivrStatItem {
-	rank: number;
-	typeRank: number;
-	total: number;
-	dates: Record<string, number>;
-}
-
-interface JSDelivrStat {
-	hits: JSDelivrStatItem;
-	bandwidth: JSDelivrStatItem;
-}
-
 interface StatsResponse {
 	npmDownloadTotal: number;
 	npmDownloadMonthly: number;
@@ -39,10 +11,6 @@ interface StatsResponseAll {
 	variable?: StatsResponse;
 }
 
-export type {
-	JSDelivrStat,
-	NPMDownloadRegistry,
-	NPMDownloadRegistryRange,
-	StatsResponse,
-	StatsResponseAll,
-};
+type StatsResponseAllRecord = Record<string, StatsResponseAll>;
+
+export type { StatsResponse, StatsResponseAll, StatsResponseAllRecord };

--- a/api/metadata/src/stats/update.ts
+++ b/api/metadata/src/stats/update.ts
@@ -1,14 +1,8 @@
 import { type VersionResponse } from 'common-api/types';
 import { StatusError } from 'itty-router';
 
-import { getOrUpdateId } from '../fonts/get';
-import { KV_TTL, STAT_TTL } from '../utils';
-import {
-	type JSDelivrStat,
-	type NPMDownloadRegistry,
-	type NPMDownloadRegistryRange,
-	type StatsResponseAll,
-} from './types';
+import { KV_TTL, METADATA_KEYS } from '../utils';
+import { type StatsResponseAllRecord } from './types';
 import { getAvailableVersions } from './util';
 
 export const updateVersion = async (
@@ -17,7 +11,6 @@ export const updateVersion = async (
 	env: Env,
 	ctx: ExecutionContext,
 ) => {
-	const key = `version:${id}`;
 	const [staticVal, variable] = await Promise.all([
 		getAvailableVersions(id),
 		isVariable ? getAvailableVersions(id, isVariable) : undefined,
@@ -35,205 +28,149 @@ export const updateVersion = async (
 
 	// Add to KV cache
 	ctx.waitUntil(
-		env.STATS.put(key, JSON.stringify(resp), {
-			metadata: {
-				ttl: Date.now() / 1000 + KV_TTL,
-			},
+		env.STATS.put(METADATA_KEYS.version(id), JSON.stringify(resp), {
+			expirationTtl: KV_TTL, // We want to expire these as we can't cron trigger these yet
 		}),
 	);
 
 	return resp;
 };
 
-type StatType = 'static' | 'variable';
+export const updatePackageStatAll = async (env: Env, ctx: ExecutionContext) => {
+	const [npmMonthlyResp, npmTotalResp, jsDelivrMonthlyResp, jsDelivrTotalResp] =
+		await Promise.all([
+			fetch(
+				'https://raw.githubusercontent.com/fontsource/download-stat-aggregator/main/data/lastMonthPopular.json',
+			),
+			fetch(
+				'https://raw.githubusercontent.com/fontsource/download-stat-aggregator/main/data/totalPopular.json',
+			),
+			fetch(
+				'https://raw.githubusercontent.com/fontsource/download-stat-aggregator/main/data/jsDelivrMonthPopular.json',
+			),
+			fetch(
+				'https://raw.githubusercontent.com/fontsource/download-stat-aggregator/main/data/jsDelivrTotalPopular.json',
+			),
+		]);
 
-const npmMonth = (id: string, type: StatType) =>
-	`https://api.npmjs.org/downloads/point/last-month/${
-		type === 'variable' ? '@fontsource-variable' : '@fontsource'
-	}/${id}`;
+	const [npmMonthData, npmTotalData, jsDelivrMonthData, jsDelivrTotalData] =
+		(await Promise.all([
+			npmMonthlyResp.json(),
+			npmTotalResp.json(),
+			jsDelivrMonthlyResp.json(),
+			jsDelivrTotalResp.json(),
+		])) as [
+			Record<string, number>,
+			Record<string, number>,
+			Record<string, number>,
+			Record<string, number>,
+		];
 
-const npmTotal = (id: string, type: StatType) =>
-	`https://api.npmjs.org/downloads/range/2020-01-01:3000-01-01/${
-		type === 'variable' ? '@fontsource-variable' : '@fontsource'
-	}/${id}`;
+	const stats: StatsResponseAllRecord = {};
 
-const jsDelivrMonth = (id: string, type: StatType) =>
-	`https://data.jsdelivr.com/v1/stats/packages/npm/${
-		type === 'variable' ? '@fontsource-variable' : '@fontsource'
-	}/${id}?period=month`;
+	for (const packageName of Object.keys(npmMonthData)) {
+		// Check for scoped packages
+		if (packageName.startsWith('@')) {
+			const [type, id] = packageName.split('/');
+			const isVariable = type === '@fontsource-variable';
 
-const jsDelivrYear = (id: string, type: StatType, period: string) =>
-	`https://data.jsdelivr.com/v1/stats/packages/npm/${
-		type === 'variable' ? '@fontsource-variable' : '@fontsource'
-	}/${id}?period=${period}`;
+			// Initialise stats object
+			stats[id] =
+				stats[id] || isVariable
+					? {
+							total: {
+								npmDownloadMonthly: 0,
+								npmDownloadTotal: 0,
+								jsDelivrHitsMonthly: 0,
+								jsDelivrHitsTotal: 0,
+							},
+							static: {
+								npmDownloadMonthly: 0,
+								npmDownloadTotal: 0,
+								jsDelivrHitsMonthly: 0,
+								jsDelivrHitsTotal: 0,
+							},
+							variable: {
+								npmDownloadMonthly: 0,
+								npmDownloadTotal: 0,
+								jsDelivrHitsMonthly: 0,
+								jsDelivrHitsTotal: 0,
+							},
+					  }
+					: {
+							total: {
+								npmDownloadMonthly: 0,
+								npmDownloadTotal: 0,
+								jsDelivrHitsMonthly: 0,
+								jsDelivrHitsTotal: 0,
+							},
+							static: {
+								npmDownloadMonthly: 0,
+								npmDownloadTotal: 0,
+								jsDelivrHitsMonthly: 0,
+								jsDelivrHitsTotal: 0,
+							},
+					  };
 
-export const updatePackageStat = async (
-	id: string,
-	env: Env,
-	ctx: ExecutionContext,
-) => {
-	const metadata = await getOrUpdateId(id, env, ctx);
-	const isVariable = Boolean(metadata?.variable);
-
-	const [
-		// Static stats
-		npmMonthResp,
-		npmTotalResp,
-		jsDelivrMonthResp,
-		jsDelivrYearResp,
-		jsDelivrLastYearResp,
-
-		// Variable stats
-		npmMonthRespVariable,
-		npmTotalRespVariable,
-		jsDelivrMonthRespVariable,
-		jsDelivrYearRespVariable,
-		jsDelivrLastYearRespVariable,
-	] = await Promise.all([
-		// Static stats
-		// NPM only stores last 18 months of data
-		fetch(npmMonth(id, 'static')),
-		fetch(npmTotal(id, 'static')),
-		fetch(jsDelivrMonth(id, 'static')),
-		// We can't query total stats so we'll query last 24 months
-		fetch(jsDelivrYear(id, 'static', 'year')),
-		fetch(jsDelivrYear(id, 'static', 's-year')),
-
-		// Variable stats
-		isVariable ? fetch(npmMonth(id, 'variable')) : undefined,
-		isVariable ? fetch(npmTotal(id, 'variable')) : undefined,
-		isVariable ? fetch(jsDelivrMonth(id, 'variable')) : undefined,
-		isVariable ? fetch(jsDelivrYear(id, 'variable', 'year')) : undefined,
-		isVariable ? fetch(jsDelivrYear(id, 'variable', 's-year')) : undefined,
-	]);
-
-	if (
-		!npmMonthResp.ok ||
-		!npmTotalResp.ok ||
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-		(npmMonthRespVariable && !npmMonthRespVariable.ok) ||
-		(npmTotalRespVariable && !npmTotalRespVariable.ok)
-	) {
-		console.log(await npmMonthResp.text());
-		console.log(await npmTotalResp.text());
-		throw new StatusError(
-			500,
-			'Internal Server Error. Unable to fetch download stats from NPM registry.',
-		);
-	}
-
-	if (
-		!jsDelivrMonthResp.ok ||
-		!jsDelivrYearResp.ok ||
-		!jsDelivrLastYearResp.ok ||
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-		(jsDelivrMonthRespVariable && !jsDelivrMonthRespVariable.ok) ||
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-		(jsDelivrYearRespVariable && !jsDelivrYearRespVariable.ok) ||
-		(jsDelivrLastYearRespVariable && !jsDelivrLastYearRespVariable.ok)
-	) {
-		console.log(await jsDelivrMonthResp.text());
-		console.log(await jsDelivrYearResp.text());
-		console.log(await jsDelivrLastYearResp.text());
-		if (isVariable) {
-			console.log(await jsDelivrMonthRespVariable?.text());
-			console.log(await jsDelivrYearRespVariable?.text());
-			console.log(await jsDelivrLastYearRespVariable?.text());
+			if (isVariable) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				stats[id].variable!.npmDownloadMonthly +=
+					npmMonthData[packageName] ?? 0;
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				stats[id].variable!.npmDownloadTotal += npmTotalData[packageName] ?? 0;
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				stats[id].variable!.jsDelivrHitsMonthly +=
+					jsDelivrMonthData[packageName] ?? 0;
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				stats[id].variable!.jsDelivrHitsTotal +=
+					jsDelivrTotalData[packageName] ?? 0;
+			} else {
+				stats[id].static.npmDownloadMonthly += npmMonthData[packageName] ?? 0;
+				stats[id].static.npmDownloadTotal += npmTotalData[packageName] ?? 0;
+				stats[id].static.jsDelivrHitsMonthly +=
+					jsDelivrMonthData[packageName] ?? 0;
+				stats[id].static.jsDelivrHitsTotal +=
+					jsDelivrTotalData[packageName] ?? 0;
+			}
+		} else {
+			// Handle unscoped deprecated packages
+			const id = packageName.replace('fontsource-', '');
+			stats[id] = {
+				total: {
+					npmDownloadMonthly: npmMonthData[packageName] ?? 0,
+					npmDownloadTotal: npmTotalData[packageName] ?? 0,
+					jsDelivrHitsMonthly: jsDelivrMonthData[packageName] ?? 0,
+					jsDelivrHitsTotal: jsDelivrTotalData[packageName] ?? 0,
+				},
+				static: {
+					npmDownloadMonthly: npmMonthData[packageName] ?? 0,
+					npmDownloadTotal: npmTotalData[packageName] ?? 0,
+					jsDelivrHitsMonthly: jsDelivrMonthData[packageName] ?? 0,
+					jsDelivrHitsTotal: jsDelivrTotalData[packageName] ?? 0,
+				},
+			};
 		}
-		throw new StatusError(
-			500,
-			'Internal Server Error. Unable to fetch download stats from jsDelivr.',
-		);
 	}
 
-	const [
-		// Static stats
-		npmMonthData,
-		npmTotalData,
-		jsDelivrMonthData,
-		jsDelivrYearData,
-		jsDelivrLastYearData,
-
-		// Variable stats
-		npmMonthDataVariable,
-		npmTotalDataVariable,
-		jsDelivrMonthDataVariable,
-		jsDelivrYearDataVariable,
-		jsDelivrLastYearDataVariable,
-	] = await Promise.all([
-		npmMonthResp.json<NPMDownloadRegistry>(),
-		npmTotalResp.json<NPMDownloadRegistryRange>(),
-		jsDelivrMonthResp.json<JSDelivrStat>(),
-		jsDelivrYearResp.json<JSDelivrStat>(),
-		jsDelivrLastYearResp.json<JSDelivrStat>(),
-
-		// Variable stats
-		isVariable ? npmMonthRespVariable?.json<NPMDownloadRegistry>() : undefined,
-		isVariable
-			? npmTotalRespVariable?.json<NPMDownloadRegistryRange>()
-			: undefined,
-		isVariable ? jsDelivrMonthRespVariable?.json<JSDelivrStat>() : undefined,
-		isVariable ? jsDelivrYearRespVariable?.json<JSDelivrStat>() : undefined,
-		isVariable ? jsDelivrLastYearRespVariable?.json<JSDelivrStat>() : undefined,
-	]);
-
-	const npmTotalCountStatic = npmTotalData.downloads.reduce(
-		(acc, curr) => acc + curr.downloads,
-		0,
-	);
-
-	// Variable stat type assertions
-	const npmTotalCountVariable = npmTotalDataVariable
-		? npmTotalDataVariable.downloads.reduce(
-				(acc, curr) => acc + curr.downloads,
-				0,
-		  )
-		: 0;
-	const npmTotalMonthVariable = npmMonthDataVariable?.downloads ?? 0;
-	const jsDelivrTotalHitsVariable =
-		(jsDelivrYearDataVariable?.hits.total ?? 0) +
-		(jsDelivrLastYearDataVariable?.hits.total ?? 0);
-	const jsDelivrMonthHitsVariable = jsDelivrMonthDataVariable?.hits.total ?? 0;
-
-	const resp: StatsResponseAll = {
-		total: {
-			npmDownloadTotal: npmTotalCountStatic + npmTotalCountVariable,
-			npmDownloadMonthly: npmMonthData.downloads + npmTotalMonthVariable,
-			jsDelivrHitsTotal:
-				jsDelivrYearData.hits.total +
-				jsDelivrLastYearData.hits.total +
-				jsDelivrTotalHitsVariable,
-			jsDelivrHitsMonthly:
-				jsDelivrMonthData.hits.total + jsDelivrMonthHitsVariable,
-		},
-
-		static: {
-			npmDownloadTotal: npmTotalCountStatic,
-			npmDownloadMonthly: npmMonthData.downloads,
-			jsDelivrHitsTotal:
-				jsDelivrYearData.hits.total + jsDelivrLastYearData.hits.total,
-			jsDelivrHitsMonthly: jsDelivrMonthData.hits.total,
-		},
-
-		...(isVariable && {
-			variable: {
-				npmDownloadTotal: npmTotalCountVariable,
-				npmDownloadMonthly: npmTotalMonthVariable,
-				jsDelivrHitsTotal: jsDelivrTotalHitsVariable,
-				jsDelivrHitsMonthly: jsDelivrMonthHitsVariable,
-			},
-		}),
-	};
+	// Calculate totals for all packages
+	for (const key of Object.keys(stats)) {
+		stats[key].total.npmDownloadMonthly +=
+			stats[key].static.npmDownloadMonthly +
+			(stats[key].variable?.npmDownloadMonthly ?? 0);
+		stats[key].total.npmDownloadTotal +=
+			stats[key].static.npmDownloadTotal +
+			(stats[key].variable?.npmDownloadTotal ?? 0);
+		stats[key].total.jsDelivrHitsMonthly +=
+			stats[key].static.jsDelivrHitsMonthly +
+			(stats[key].variable?.jsDelivrHitsMonthly ?? 0);
+		stats[key].total.jsDelivrHitsTotal +=
+			stats[key].static.jsDelivrHitsTotal +
+			(stats[key].variable?.jsDelivrHitsTotal ?? 0);
+	}
 
 	// Add to KV cache
-	const key = `package:${id}`;
 	ctx.waitUntil(
-		env.STATS.put(key, JSON.stringify(resp), {
-			metadata: {
-				ttl: Date.now() / 1000 + STAT_TTL,
-			},
-		}),
+		env.METADATA.put(METADATA_KEYS.downloads, JSON.stringify(stats)),
 	);
-
-	return resp;
+	return stats;
 };

--- a/api/metadata/src/stats/util.ts
+++ b/api/metadata/src/stats/util.ts
@@ -52,7 +52,7 @@ export const getAvailableVersions = async (
 		);
 	}
 
-	const list = await resp.json<JSDelivrAPIVersion>();
+	const list = (await resp.json()) as JSDelivrAPIVersion;
 	if (!list?.versions || list.versions.length === 0) {
 		throw new StatusError(404, `Not Found. No versions found for ${id}.`);
 	}

--- a/api/metadata/src/types.ts
+++ b/api/metadata/src/types.ts
@@ -37,14 +37,9 @@ type FontsourceMetadata = Record<string, FontMetadata>;
 
 type MetadataResponse = Record<string, Omit<FontMetadata, 'npmVersion'>>;
 
-interface TTLMetadata {
-	ttl: number;
-}
-
 export type {
 	CFRouterContext,
 	FontMetadata,
 	FontsourceMetadata,
 	MetadataResponse,
-	TTLMetadata,
 };

--- a/api/metadata/src/utils.ts
+++ b/api/metadata/src/utils.ts
@@ -14,6 +14,15 @@ export const API_BROWSER_TTL = 60 * 5; // 5 minutes
 
 export const CF_EDGE_TTL = 60 * 60 * 24; // 24 hours
 
-export const KV_TTL = 60 * 60 * 12; // 12 hours
+export const KV_TTL = 60 * 60 * 3; // 3 hours
 
-export const STAT_TTL = 60 * 60 * 6; // 6 hours
+// Metadata keys
+export const METADATA_KEYS = {
+	fonts: 'metadata',
+	fonts_arr: 'metadata_arr',
+	variable_list: 'variable_list',
+	axisRegistry: 'axis_registry',
+	fontlist: (key: string) => `fontlist:${key}`,
+	version: (id: string) => `version:${id}`,
+	downloads: 'download_stats',
+};

--- a/api/metadata/src/variable/get.ts
+++ b/api/metadata/src/variable/get.ts
@@ -1,75 +1,48 @@
-import { type VariableMetadata } from 'common-api/types';
-
-import { type TTLMetadata } from '../types';
+import { KV_TTL, METADATA_KEYS } from '../utils';
 import { type AxisRegistry, type VariableList } from './types';
-import {
-	updateAxisRegistry,
-	updateVariable,
-	updateVariableList,
-} from './update';
+import { updateAxisRegistry, updateVariableList } from './update';
 
-export const getOrUpdateVariableList = async (
-	env: Env,
-	ctx: ExecutionContext,
-) => {
-	const { value, metadata } = await env.VARIABLE_LIST.getWithMetadata<
-		VariableList,
-		TTLMetadata
-	>('variable_list', {
-		type: 'json',
-	});
+export const getVariableList = async (env: Env, ctx: ExecutionContext) => {
+	const value = await env.METADATA.get<VariableList>(
+		METADATA_KEYS.variable_list,
+		{
+			type: 'json',
+			cacheTtl: KV_TTL,
+		},
+	);
 
 	if (!value) {
 		return await updateVariableList(env, ctx);
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
-		ctx.waitUntil(updateVariableList(env, ctx));
-	}
-
 	return value;
 };
 
-export const getOrUpdateVariableId = async (
+export const getVariableId = async (
 	id: string,
 	env: Env,
 	ctx: ExecutionContext,
 ) => {
-	const { value, metadata } = await env.VARIABLE.getWithMetadata<
-		VariableMetadata,
-		TTLMetadata
-	>(id, {
-		type: 'json',
-	});
+	const data = await getVariableList(env, ctx);
 
-	if (!value) {
-		return await updateVariable(id, env, ctx);
+	if (!data[id]) {
+		return;
 	}
 
-	if (!metadata?.ttl || metadata.ttl < Date.now()) {
-		ctx.waitUntil(updateVariable(id, env, ctx));
-	}
-
-	return value;
+	return data[id];
 };
 
-export const getOrUpdateAxisRegistry = async (
-	env: Env,
-	ctx: ExecutionContext,
-) => {
-	const { value, metadata } = await env.VARIABLE_LIST.getWithMetadata<
-		AxisRegistry,
-		TTLMetadata
-	>('axis_registry', {
-		type: 'json',
-	});
+export const getAxisRegistry = async (env: Env, ctx: ExecutionContext) => {
+	const value = await env.METADATA.get<AxisRegistry>(
+		METADATA_KEYS.axisRegistry,
+		{
+			type: 'json',
+			cacheTtl: KV_TTL,
+		},
+	);
 
 	if (!value) {
 		return await updateAxisRegistry(env, ctx);
-	}
-
-	if (!metadata?.ttl || metadata.ttl < Date.now() / 1000) {
-		ctx.waitUntil(updateAxisRegistry(env, ctx));
 	}
 
 	return value;

--- a/api/metadata/src/variable/router.ts
+++ b/api/metadata/src/variable/router.ts
@@ -9,11 +9,7 @@ import {
 
 import type { CFRouterContext } from '../types';
 import { API_BROWSER_TTL, CF_EDGE_TTL } from '../utils';
-import {
-	getOrUpdateAxisRegistry,
-	getOrUpdateVariableId,
-	getOrUpdateVariableList,
-} from './get';
+import { getAxisRegistry, getVariableId, getVariableList } from './get';
 import { type AxisRegistry, isAxisRegistryQuery } from './types';
 
 interface DownloadRequest extends IRequestStrict {
@@ -34,7 +30,7 @@ router.get('/v1/variable', async (request, env, ctx) => {
 		return response;
 	}
 
-	const variableList = await getOrUpdateVariableList(env, ctx);
+	const variableList = await getVariableList(env, ctx);
 	if (!variableList) {
 		throw new StatusError(500, 'Internal Server Error. Variable list empty.');
 	}
@@ -63,7 +59,7 @@ router.get('/v1/variable/:id', withParams, async (request, env, ctx) => {
 		return response;
 	}
 
-	const variableId = await getOrUpdateVariableId(id, env, ctx);
+	const variableId = await getVariableId(id, env, ctx);
 	if (!variableId) {
 		throw new StatusError(
 			404,
@@ -95,7 +91,7 @@ router.get('/v1/axis-registry', async (request, env, ctx) => {
 		return response;
 	}
 
-	const registry = await getOrUpdateAxisRegistry(env, ctx);
+	const registry = await getAxisRegistry(env, ctx);
 	if (!registry) {
 		throw new StatusError(500, 'Internal Server Error. Axis registry empty.');
 	}

--- a/api/metadata/src/variable/update.ts
+++ b/api/metadata/src/variable/update.ts
@@ -6,7 +6,7 @@ import { StatusError } from 'itty-router';
 
 import {
 	AXIS_REGISTRY_URL,
-	KV_TTL,
+	METADATA_KEYS,
 	VARIABLE_ICONS_URL,
 	VARIABLE_URL,
 } from '../utils';
@@ -50,48 +50,7 @@ export const updateVariableList = async (env: Env, ctx: ExecutionContext) => {
 
 	// Save entire metadata into KV first
 	ctx.waitUntil(
-		env.VARIABLE_LIST.put('metadata', JSON.stringify(noVariants), {
-			metadata: {
-				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() / 1000 + KV_TTL,
-			},
-		}),
-	);
-
-	return noVariants;
-};
-
-export const updateVariable = async (
-	id: string,
-	env: Env,
-	ctx: ExecutionContext,
-) => {
-	// Fetch from KV store
-	let data = await env.VARIABLE_LIST.get<Record<string, VariableMetadata>>(id, {
-		type: 'json',
-	});
-	if (!data) {
-		data = await updateVariableList(env, ctx);
-	}
-
-	const dataId = data[id];
-	if (!dataId) {
-		throw new StatusError(404, `Variable ${id} not found.`);
-	}
-
-	const noVariants: VariableMetadata = {
-		family: dataId.family,
-		axes: dataId.axes,
-	};
-
-	// Save entire metadata into KV first
-	ctx.waitUntil(
-		env.VARIABLE.put(id, JSON.stringify(noVariants), {
-			metadata: {
-				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() / 1000 + KV_TTL,
-			},
-		}),
+		env.METADATA.put(METADATA_KEYS.variable_list, JSON.stringify(noVariants)),
 	);
 
 	return noVariants;
@@ -117,12 +76,7 @@ export const updateAxisRegistry = async (env: Env, ctx: ExecutionContext) => {
 
 	// Save entire metadata into KV first
 	ctx.waitUntil(
-		env.VARIABLE.put('axis_registry', JSON.stringify(registry), {
-			metadata: {
-				// We need to set a custom ttl for a stale-while-revalidate strategy
-				ttl: Date.now() / 1000 + KV_TTL,
-			},
-		}),
+		env.METADATA.put(METADATA_KEYS.axisRegistry, JSON.stringify(registry)),
 	);
 
 	return registry;

--- a/api/metadata/src/worker.ts
+++ b/api/metadata/src/worker.ts
@@ -1,6 +1,11 @@
 import { error } from 'itty-router';
 
+import { fontlistQueries } from './fontlist/types';
+import { updateList, updateMetadata } from './fontlist/update';
+import { updateArrayMetadata } from './fonts/update';
 import { corsify, router } from './router';
+import { updatePackageStatAll } from './stats/update';
+import { updateAxisRegistry, updateVariableList } from './variable/update';
 
 export default {
 	async fetch(
@@ -15,5 +20,30 @@ export default {
 				return error(error_);
 			})
 			.then(corsify);
+	},
+
+	// This is a daily scheduled event to update the metadata.
+	async scheduled(
+		_event: ScheduledEvent,
+		env: Env,
+		ctx: ExecutionContext,
+	): Promise<void> {
+		// Update fontlist and aggregate metadata object.
+		await updateMetadata(env, ctx);
+		for (const type of fontlistQueries) {
+			await updateList(type, env, ctx);
+		}
+
+		// Update the metadata arr. We'll let the rest of the individual font ids expire
+		// and update on their own.
+		await updateArrayMetadata(env, ctx);
+
+		// Update variable lists.
+		await updateAxisRegistry(env, ctx);
+		await updateVariableList(env, ctx);
+
+		// Update stats.
+		await updatePackageStatAll(env, ctx);
+		// TODO: Versions
 	},
 };

--- a/api/metadata/tests/fonts/__snapshots__/id.test.ts.snap
+++ b/api/metadata/tests/fonts/__snapshots__/id.test.ts.snap
@@ -8,6 +8,8 @@ exports[`fonts id worker > should return normal id response 1`] = `
   "id": "akshar",
   "lastModified": "2023-03-21",
   "license": "OFL-1.1",
+  "npmVersion": "5.0.0",
+  "source": "https://github.com/google/fonts",
   "styles": [
     "normal",
   ],
@@ -150,6 +152,7 @@ exports[`fonts id worker > should return normal id response 1`] = `
       },
     },
   },
+  "version": "v9",
   "weights": [
     300,
     400,

--- a/api/metadata/worker-configuration.d.ts
+++ b/api/metadata/worker-configuration.d.ts
@@ -1,10 +1,6 @@
 interface Env {
-	FONTLIST: KVNamespace;
-	FONTS: KVNamespace;
-	VARIABLE: KVNamespace;
-	VARIABLE_LIST: KVNamespace;
+	METADATA: KVNamespace;
 	STATS: KVNamespace;
-
 	BUCKET: R2Bucket;
 
 	// Secrets

--- a/api/metadata/wrangler.toml
+++ b/api/metadata/wrangler.toml
@@ -3,11 +3,8 @@ main = "src/worker.ts"
 compatibility_date = "2023-05-27"
 
 kv_namespaces = [
-  { binding = "FONTLIST", id = "ef03b5ef10034282a8e6220b9a5258c1" },
-  { binding = "FONTS", id = "3dfa82ada2204c49b2f317a63b72d93c" },
-  { binding = "VARIABLE_LIST", id = "669f1133f5144ab0822980b3d7e18559" },
-  { binding = "VARIABLE", id = "592f7cf6d10f4086ae421d538e3f9bfc" },
   { binding = "STATS", id = "f1bd4c1a63df46d894f8030079597982" },
+  { binding = "METADATA", id = "49e9d329349446cf948f84af9828914f" },
 ]
 
 r2_buckets = [


### PR DESCRIPTION
Closes #873.

This PR hugely simplifies the KV schema for all metadata to fix a bunch of messy caching issues and propagate updates more accurately as the previous schema stored each font with its own key, while now all fonts are stored in a single key with different categories having their own key instead of individual store. 

Since endpoints are cached, performance falloff is negligible and in some cases may improve due to better caching rules in place. We should expect less KV reads in total as there will be a higher cache hit ratio.

The motivation for the KV schema change is to allow us to update our metadata with cron triggers, leading to more predictable and reliable updates.