### PR TITLE
fix(api): return empty stats object if font exists but no stats

### DIFF
--- a/.changeset/wise-dolls-wait.md
+++ b/.changeset/wise-dolls-wait.md
@@ -1,0 +1,6 @@
+---
+"cdn": patch
+"api": patch
+---
+
+fix(api): return empty stats object if font exists but no stats

--- a/api/cdn/wrangler.toml
+++ b/api/cdn/wrangler.toml
@@ -15,5 +15,8 @@ services = [
 logpush = true
 workers_dev = false
 
+[triggers]
+crons = ["0 0 * * *"]
+
 [miniflare.mounts]
 api = "../api/"

--- a/api/metadata/src/stats/router.ts
+++ b/api/metadata/src/stats/router.ts
@@ -95,9 +95,30 @@ router.get('/v1/stats/:id', withParams, async (request, env, ctx) => {
 		throw new StatusError(404, 'Not found. Font does not exist.');
 	}
 
-	const stats = await getPackageStat(id, env, ctx);
+	let stats = await getPackageStat(id, env, ctx);
 	if (!stats) {
-		throw new StatusError(500, 'Internal Server Error. Stats list empty.');
+		stats = {
+			total: {
+				npmDownloadMonthly: 0,
+				npmDownloadTotal: 0,
+				jsDelivrHitsMonthly: 0,
+				jsDelivrHitsTotal: 0,
+			},
+			static: {
+				npmDownloadMonthly: 0,
+				npmDownloadTotal: 0,
+				jsDelivrHitsMonthly: 0,
+				jsDelivrHitsTotal: 0,
+			},
+			variable: metadata.variable
+				? {
+						npmDownloadMonthly: 0,
+						npmDownloadTotal: 0,
+						jsDelivrHitsMonthly: 0,
+						jsDelivrHitsTotal: 0,
+				  }
+				: undefined,
+		};
 	}
 
 	response = json(stats, {


### PR DESCRIPTION
This change fixes an unintended 500 error where a new font may be published but our download stat sources have not yet updated, leading to an unexpected error code. This change returns an empty download count for the time being until our sources get the chance to update.