### PR TITLE
fix(api): introduce separate versions kv space

### DIFF
--- a/.changeset/polite-elephants-grab.md
+++ b/.changeset/polite-elephants-grab.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix(api): introduce separate versions kv space

--- a/api/metadata/src/stats/get.ts
+++ b/api/metadata/src/stats/get.ts
@@ -10,7 +10,7 @@ export const getVersion = async (
 	env: Env,
 	ctx: ExecutionContext,
 ) => {
-	const value = await env.STATS.get<VersionResponse>(
+	const value = await env.VERSIONS.get<VersionResponse>(
 		METADATA_KEYS.version(id),
 		{
 			type: 'json',

--- a/api/metadata/src/stats/update.ts
+++ b/api/metadata/src/stats/update.ts
@@ -28,7 +28,7 @@ export const updateVersion = async (
 
 	// Add to KV cache
 	ctx.waitUntil(
-		env.STATS.put(METADATA_KEYS.version(id), JSON.stringify(resp), {
+		env.VERSIONS.put(METADATA_KEYS.version(id), JSON.stringify(resp), {
 			expirationTtl: KV_TTL, // We want to expire these as we can't cron trigger these yet
 		}),
 	);

--- a/api/metadata/worker-configuration.d.ts
+++ b/api/metadata/worker-configuration.d.ts
@@ -1,6 +1,6 @@
 interface Env {
 	METADATA: KVNamespace;
-	STATS: KVNamespace;
+	VERSIONS: KVNamespace;
 	BUCKET: R2Bucket;
 
 	// Secrets

--- a/api/metadata/wrangler.toml
+++ b/api/metadata/wrangler.toml
@@ -3,7 +3,7 @@ main = "src/worker.ts"
 compatibility_date = "2023-05-27"
 
 kv_namespaces = [
-  { binding = "STATS", id = "f1bd4c1a63df46d894f8030079597982" },
+  { binding = "VERSIONS", id = "722f0fadd97343ebb8a51c925d1d4316" },
   { binding = "METADATA", id = "49e9d329349446cf948f84af9828914f" },
 ]
 
@@ -15,4 +15,4 @@ logpush = true
 workers_dev = false
 
 [triggers]
-crons = ["0 0 * * *"]
+crons = ["0 */3 * * *"]


### PR DESCRIPTION
Closes #895. This should force refresh the keys with new expiration ttls and lets us delete the old KV namespace with redundant data.