### PR TITLE
fix(website): keyboard navigation links in docsearch

### DIFF
--- a/website/app/components/docs/DocsHeader.tsx
+++ b/website/app/components/docs/DocsHeader.tsx
@@ -56,7 +56,12 @@ export const DocsHeader = () => {
 	const navigator = useRef({
 		navigate({ itemUrl }: { itemUrl?: string }) {
 			if (itemUrl) {
-				navigate(itemUrl);
+				const url = new URL(itemUrl);
+				if (url.hostname === 'fontsource.org') {
+					navigate(url.pathname);
+				} else {
+					window.open(itemUrl, '_blank');
+				}
 			}
 		},
 	}).current;


### PR DESCRIPTION
Follow-up PR to #966. While clicking on the hits in DocSearch will redirect correctly, using keyboard navigation and submitting via the enter key would lead to incorrect redirects. 