### PR TITLE
fix(website): add `translate` attr to code

### DIFF
--- a/website/app/components/code/Code.tsx
+++ b/website/app/components/code/Code.tsx
@@ -31,7 +31,7 @@ export const CodeWrapper = ({ children, language, code }: CodeWrapperProps) => {
 	const copiedLabel = 'Copied';
 
 	return (
-		<Box className={classes.root}>
+		<Box className={classes.root} translate="no">
 			<Text className={classes.dots}>&#11044;&#11044;</Text>
 			{children}
 			<Group gap={0} className={classes.tools}>


### PR DESCRIPTION
Hi!
I added `translate` attribute with value `no` to code blocks for prevent auto translate code. 
I think it's rule of good manners.

More information of `translate` on mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate