### PR TITLE
docs: use crossorigin anonymous explicitly for preload

### DIFF
--- a/website/docs/getting-started/preload.mdx
+++ b/website/docs/getting-started/preload.mdx
@@ -23,7 +23,7 @@ const App = () => {
   return (
     <html lang="en">
       <head>
-        <link rel="preload" as="font" type="font/woff2" href={openSansWoff2} crossorigin/>
+        <link rel="preload" as="font" type="font/woff2" href={openSansWoff2} crossorigin="anonymous" />
       </head>
     </html>
   );


### PR DESCRIPTION
Fixes this issue:

![image](https://github.com/user-attachments/assets/5eef0d95-1855-404d-b42f-e7fa8295c96f)
