### PR TITLE
fix: language filter disabled after invalid search

### DIFF
--- a/website/app/components/Dropdown.tsx
+++ b/website/app/components/Dropdown.tsx
@@ -191,7 +191,7 @@ const DropdownCheckbox = ({
 			noBorder={noBorder}
 			refine={refine}
 			search={search}
-			disabled={items.length === 0}
+			disabled={items.length === 0 && !search}
 		/>
 	);
 };


### PR DESCRIPTION
In response to #987

I would prevent disable if items length is 0 and if it has a search.
Unsure if this solution is optimal, open to other fixes.

Thanks!