### PR TITLE
fix(website): remove gap in badge css

### DIFF
--- a/website/app/components/preview/CDN.module.css
+++ b/website/app/components/preview/CDN.module.css
@@ -1,6 +1,5 @@
 .badge {
 	padding: rem(4px) rem(8px);
-	gap: rem(10px);
 
 	border-radius: rem(4px);
 	font-family: var(--mantine-font-family-monospace);

--- a/website/app/components/preview/InstallCode.module.css
+++ b/website/app/components/preview/InstallCode.module.css
@@ -10,7 +10,6 @@
 
 .badge {
 	padding: rem(4px) rem(8px);
-	gap: rem(10px);
 
 	border-radius: rem(4px);
 	font-family: var(--mantine-font-family-monospace);

--- a/website/app/components/preview/Tabs.module.css
+++ b/website/app/components/preview/Tabs.module.css
@@ -1,7 +1,6 @@
 /* Tabs */
 .badge {
 	padding: rem(4px) rem(8px);
-	gap: rem(10px);
 
 	border-radius: rem(4px);
 	font-family: var(--mantine-font-family-monospace);


### PR DESCRIPTION
This should remove the extra spacing around badges that seems to only show up in production.