### PR TITLE
feat(publish): include npm provenance flag

### DIFF
--- a/.changeset/cuddly-poets-tap.md
+++ b/.changeset/cuddly-poets-tap.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/publish": minor
+---
+
+feat(publish): include npm provenance flag

--- a/packages/publish/src/cli.ts
+++ b/packages/publish/src/cli.ts
@@ -74,6 +74,7 @@ cli
 	)
 	.option('--commit-message', 'Change commit message')
 	.option('--packages', 'Package directory')
+	.option('--provenance', 'Include NPM provenance attestations')
 	.action(async (version: string, opts: PublishFlags) => {
 		try {
 			await publishPackages(version, opts);

--- a/packages/publish/src/types.ts
+++ b/packages/publish/src/types.ts
@@ -38,7 +38,9 @@ export interface BumpFlags extends ChangedFlags {
 	yes?: boolean;
 }
 
-export type PublishFlags = BumpFlags;
+export interface PublishFlags extends BumpFlags {
+	provenance?: boolean;
+}
 
 export type Flags = ChangedFlags | BumpFlags | PublishFlags;
 


### PR DESCRIPTION
This adds the ability for the publisher to pass through the NPM provenance flag for our CI builders to generate NPM publish attestations! Super simple and an easy win for supply-chain security.