### PR TITLE
fix(website): invalid robots txt

### DIFF
--- a/website/app/routes/[robots.txt].tsx
+++ b/website/app/routes/[robots.txt].tsx
@@ -1,26 +1,15 @@
 import type { LoaderFunction } from '@remix-run/cloudflare';
 
-export const loader: LoaderFunction = async () => {
-	const prod = `User-agent: *
+const prod = `User-agent: *
 Allow: /
 
 Sitemap: https://fontsource.org/sitemap.xml`;
 
-	const headers = {
-		'Content-Type': 'text/plain',
-		'Cache-Control': 'public, max-age=86400', // 1 day
-	};
-
-	if (process.env.FLY_APP_NAME === 'fontsource') {
-		return new Response(prod, {
-			headers,
-		});
-	}
-
-	const dev = `User-agent: *
-Disallow: /`;
-
-	return new Response(dev, {
-		headers,
+export const loader: LoaderFunction = async () => {
+	return new Response(prod, {
+		headers: {
+			'Content-Type': 'text/plain',
+			'Cache-Control': 'public, max-age=86400', // 1 day
+		},
 	});
 };


### PR DESCRIPTION
We've been serving an fully restricted `robots.txt` for months now by accident since the switch to CF workers where I forgot to set the env 🙈 No wonder our search indexing has been in freefall...