### PR TITLE
fix(sass): deprecate mixin import from npm package

### DIFF
--- a/.changeset/pink-dots-repeat.md
+++ b/.changeset/pink-dots-repeat.md
@@ -1,0 +1,6 @@
+---
+"@fontsource-utils/cli": patch
+"@fontsource-utils/scss": patch
+---
+
+fix(sass): deprecate mixin import from npm package

--- a/packages/cli/src/sass/mixins.ts
+++ b/packages/cli/src/sass/mixins.ts
@@ -34,6 +34,7 @@ $displayVar: null !default;
   // Deprecated
   $displayVar: $displayVar
 ) {
+	@warn "Importing mixins via the fontsource package is deprecated and will be removed in the next major release. Please use the @fontsource-utils/scss package instead.";
 
   @if $displayVar != null {
     @warn "$displayVar is deprecated due to the limitation of using css variables in @font-face (https://github.com/fontsource/fontsource/issues/726).";

--- a/packages/cli/version.ts
+++ b/packages/cli/version.ts
@@ -1,3 +1,3 @@
-const BASE_VERSION = '5.0.0';
+const BASE_VERSION = '5.2.0';
 
 export default BASE_VERSION;

--- a/packages/scss/package.json
+++ b/packages/scss/package.json
@@ -23,6 +23,7 @@
 		"access": "public"
 	},
 	"scripts": {
+		"build": "echo 'No build step required for SCSS package.'",
 		"coverage": "vitest run",
 		"test": "vitest",
 		"prepublish": "bun run build",


### PR DESCRIPTION
This deprecates the existing mixin import in favour of the new import strategy.