### PR TITLE
fix(sass): update exports field for importers

### DIFF
--- a/.changeset/shaggy-ants-wonder.md
+++ b/.changeset/shaggy-ants-wonder.md
@@ -1,0 +1,6 @@
+---
+"@fontsource-utils/cli": patch
+"@fontsource-utils/scss": patch
+---
+
+fix(sass): update exports field for importers

--- a/packages/cli/src/templates/package.ts
+++ b/packages/cli/src/templates/package.ts
@@ -36,6 +36,10 @@ const template = (
 	],
 	exports: {
 		'.': {
+			sass: './index.css',
+			default: './index.css',
+		},
+		scss: {
 			sass: './scss/metadata.scss',
 		},
 	},

--- a/packages/scss/tests/__snapshots__/import.test.ts.snap
+++ b/packages/scss/tests/__snapshots__/import.test.ts.snap
@@ -1,0 +1,199 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`scss imports > should import with default and namespace 1`] = `
+"/* carlito-cyrillic-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-ext-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-ext-400-normal.woff) format("woff");
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* carlito-cyrillic-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-400-normal.woff) format("woff");
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* carlito-greek-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-ext-400-normal.woff2) format("woff2"), url(./files/carlito-greek-ext-400-normal.woff) format("woff");
+  unicode-range: U+1F00-1FFF;
+}
+/* carlito-greek-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-400-normal.woff2) format("woff2"), url(./files/carlito-greek-400-normal.woff) format("woff");
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+/* carlito-vietnamese-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-vietnamese-400-normal.woff2) format("woff2"), url(./files/carlito-vietnamese-400-normal.woff) format("woff");
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* carlito-latin-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-ext-400-normal.woff2) format("woff2"), url(./files/carlito-latin-ext-400-normal.woff) format("woff");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* carlito-latin-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-400-normal.woff2) format("woff2"), url(./files/carlito-latin-400-normal.woff) format("woff");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}"
+`;
+
+exports[`scss imports > should import with default path 1`] = `
+"/* carlito-cyrillic-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-ext-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-ext-400-normal.woff) format("woff");
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* carlito-cyrillic-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-400-normal.woff) format("woff");
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* carlito-greek-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-ext-400-normal.woff2) format("woff2"), url(./files/carlito-greek-ext-400-normal.woff) format("woff");
+  unicode-range: U+1F00-1FFF;
+}
+/* carlito-greek-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-400-normal.woff2) format("woff2"), url(./files/carlito-greek-400-normal.woff) format("woff");
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+/* carlito-vietnamese-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-vietnamese-400-normal.woff2) format("woff2"), url(./files/carlito-vietnamese-400-normal.woff) format("woff");
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* carlito-latin-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-ext-400-normal.woff2) format("woff2"), url(./files/carlito-latin-ext-400-normal.woff) format("woff");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* carlito-latin-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-400-normal.woff2) format("woff2"), url(./files/carlito-latin-400-normal.woff) format("woff");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}"
+`;
+
+exports[`scss imports > should import with weight path and extension 1`] = `
+"/* carlito-cyrillic-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-ext-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-ext-400-normal.woff) format("woff");
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* carlito-cyrillic-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-cyrillic-400-normal.woff2) format("woff2"), url(./files/carlito-cyrillic-400-normal.woff) format("woff");
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* carlito-greek-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-ext-400-normal.woff2) format("woff2"), url(./files/carlito-greek-ext-400-normal.woff) format("woff");
+  unicode-range: U+1F00-1FFF;
+}
+/* carlito-greek-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-greek-400-normal.woff2) format("woff2"), url(./files/carlito-greek-400-normal.woff) format("woff");
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+/* carlito-vietnamese-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-vietnamese-400-normal.woff2) format("woff2"), url(./files/carlito-vietnamese-400-normal.woff) format("woff");
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* carlito-latin-ext-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-ext-400-normal.woff2) format("woff2"), url(./files/carlito-latin-ext-400-normal.woff) format("woff");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* carlito-latin-400-normal */
+@font-face {
+  font-family: "Carlito";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url(./files/carlito-latin-400-normal.woff2) format("woff2"), url(./files/carlito-latin-400-normal.woff) format("woff");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}"
+`;

--- a/packages/scss/tests/import.test.ts
+++ b/packages/scss/tests/import.test.ts
@@ -1,0 +1,30 @@
+import { compileString, NodePackageImporter } from 'sass';
+import { describe, expect, it } from 'vitest';
+
+const compileSass = (path: string) => {
+	const res = compileString(`@use ${path};`, {
+		importers: [new NodePackageImporter()],
+	});
+
+	return res.css.toString();
+};
+
+describe('scss imports', () => {
+	it('should import with default path', async () => {
+		expect(
+			compileSass("'pkg:@fontsource/carlito/index.css'"),
+		).toMatchSnapshot();
+	});
+
+	it('should import with default and namespace', async () => {
+		expect(
+			compileSass("'pkg:@fontsource/carlito/index.css' as carlito"),
+		).toMatchSnapshot();
+	});
+
+	it('should import with weight path and extension', async () => {
+		expect(
+			compileSass("'pkg:@fontsource/carlito/400.css' as carlito"),
+		).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
While adding a few test cases for default imports, I found a bug for the old style of importing CSS files via Sass. Thus this updates the `exports` field in `package.json` for something a little more ergonomic.