### PR TITLE
fix(template): widen exports for LICENSE import

### DIFF
--- a/.changeset/breezy-guests-wash.md
+++ b/.changeset/breezy-guests-wash.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+fix(template): widen exports field to support LICENSE import

--- a/packages/cli/src/templates/package.ts
+++ b/packages/cli/src/templates/package.ts
@@ -39,6 +39,7 @@ const template = (
 			sass: './index.css',
 			default: './index.css',
 		},
+		'./LICENSE': './LICENSE',
 		'./*': {
 			sass: './*.css',
 			default: './*.css',


### PR DESCRIPTION
Allow directly importing the `LICENSE` file for a specific font.

For example, in v5.1.1, [Vite supported importing these with the `?raw` suffix][1], e.g.

```typescript
import fontLicenseText from '@fontsource-variable/recursive/LICENSE?raw';
```

This is mainly useful in case we want to automatically add the license somewhere when we use/distribute the font!

[1]: https://vite.dev/guide/assets.html#importing-asset-as-string

### Implementation details

I basically just copied #1033 since that's a very similar PR!