### PR TITLE
fix(cli): bump google font metadata

### DIFF
--- a/.changeset/shiny-cups-kneel.md
+++ b/.changeset/shiny-cups-kneel.md
@@ -1,0 +1,5 @@
+---
+"@fontsource-utils/cli": patch
+---
+
+fix(cli): bump google font metadata to resolve failing CJK font subsetting

--- a/bun.lock
+++ b/bun.lock
@@ -95,14 +95,14 @@
       "devDependencies": {
         "@types/fs-extra": "^11.0.1",
         "@types/node": "^20.7.1",
-        "google-font-metadata": "^6.0.0",
+        "google-font-metadata": "^6.0.4",
         "magic-string": "^0.30.0",
         "pkgroll": "^2.6.0",
         "sass": "^1.62.1",
         "typescript": "^5.2.2",
       },
       "peerDependencies": {
-        "google-font-metadata": "^6.0.0",
+        "google-font-metadata": "^6.0.4",
       },
     },
     "packages/generate": {
@@ -1113,7 +1113,7 @@
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
-    "google-font-metadata": ["google-font-metadata@6.0.3", "", { "dependencies": { "@evan/concurrency": "^0.0.3", "@octokit/core": "^6.1.2", "cac": "^6.7.14", "consola": "^3.3.3", "deepmerge": "^4.3.1", "json-stringify-pretty-compact": "^4.0.0", "linkedom": "^0.18.6", "pathe": "^1.1.2", "picocolors": "^1.1.1", "playwright": "^1.49.1", "stylis": "^4.3.4", "zod": "^3.24.1" }, "bin": { "gfm": "dist/cli.mjs" } }, "sha512-62+QB+nmBKppHrxwvILZkV/EvKctEAdzkKBIJY26TtwZkUjeEqmAQnE5uHvtMTdB8odqGpQu5LAKPqqUYHI9wA=="],
+    "google-font-metadata": ["google-font-metadata@6.0.4", "", { "dependencies": { "@evan/concurrency": "^0.0.3", "@octokit/core": "^6.1.2", "cac": "^6.7.14", "consola": "^3.3.3", "deepmerge": "^4.3.1", "json-stringify-pretty-compact": "^4.0.0", "linkedom": "^0.18.6", "pathe": "^1.1.2", "picocolors": "^1.1.1", "playwright": "^1.49.1", "stylis": "^4.3.4", "zod": "^3.24.1" }, "bin": { "gfm": "dist/cli.mjs" } }, "sha512-10thPdMO8iG9knlF7HMurnyb6vBRWiRRO/2b5Lxix0ONJ5NA55ZwHKgZoQFxCp9F/NjKcIy3U/wuQwyksyr4Lw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,14 +64,14 @@
 	"devDependencies": {
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.7.1",
-		"google-font-metadata": "^6.0.0",
+		"google-font-metadata": "^6.0.4",
 		"magic-string": "^0.30.0",
 		"pkgroll": "^2.6.0",
 		"sass": "^1.62.1",
 		"typescript": "^5.2.2"
 	},
 	"peerDependencies": {
-		"google-font-metadata": "^6.0.0"
+		"google-font-metadata": "^6.0.4"
 	},
 	"files": [
 		"dist/*"

--- a/packages/cli/scripts/add-hashbang.ts
+++ b/packages/cli/scripts/add-hashbang.ts
@@ -17,4 +17,3 @@ const addHashbang = (filepath: string) => {
 };
 
 addHashbang('dist/cli.mjs');
-addHashbang('dist/cli.cjs');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,16 +1,16 @@
 import 'dotenv/config';
 
 import { cac } from 'cac';
-import consola from 'consola';
+import { consola } from 'consola';
 import {
 	fetchAPI,
 	fetchVariable,
 	generateAxis,
 	parseIcons,
 	parseLicenses,
+	parseVariable,
 	parsev1,
 	parsev2,
-	parseVariable,
 } from 'google-font-metadata';
 import colors from 'picocolors';
 

--- a/packages/cli/src/custom/create.ts
+++ b/packages/cli/src/custom/create.ts
@@ -8,7 +8,7 @@ import {
 	select,
 	text,
 } from '@clack/prompts';
-import consola from 'consola';
+import { consola } from 'consola';
 import colors from 'picocolors';
 
 import { isCategoryName, type Metadata } from '../types';

--- a/packages/cli/src/custom/packager.ts
+++ b/packages/cli/src/custom/packager.ts
@@ -34,11 +34,11 @@ export const packagerCustom = async (
 					weight,
 					src: [
 						{
-							url: makeFontFilePath(id, subset, weight, style, 'woff2'),
+							url: makeFontFilePath(id, subset, String(weight), style, 'woff2'),
 							format: 'woff2' as const,
 						},
 						{
-							url: makeFontFilePath(id, subset, weight, style, 'woff'),
+							url: makeFontFilePath(id, subset, String(weight), style, 'woff'),
 							format: 'woff' as const,
 						},
 					],

--- a/packages/cli/src/google/build.ts
+++ b/packages/cli/src/google/build.ts
@@ -1,11 +1,11 @@
-import consola from 'consola';
+import { consola } from 'consola';
 import fs from 'fs-extra';
 import {
 	APIIconStatic as APIIconStaticImport,
 	APIIconVariable as APIIconVariableImport,
 	APILicense as APILicenseImport,
-	APIv2 as APIv2Import,
 	APIVariable as APIVariableImport,
+	APIv2 as APIv2Import,
 } from 'google-font-metadata';
 import stringify from 'json-stringify-pretty-compact';
 import * as path from 'pathe';

--- a/packages/cli/src/google/queue.ts
+++ b/packages/cli/src/google/queue.ts
@@ -1,4 +1,4 @@
-import consola from 'consola';
+import { consola } from 'consola';
 import fs from 'fs-extra';
 import {
 	APIIconStatic,

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -16,7 +16,7 @@ describe('utils', () => {
 		});
 
 		it('should generate font file paths', () => {
-			expect(makeFontFilePath('font', 'subset', 400, 'normal', 'woff2')).toBe(
+			expect(makeFontFilePath('font', 'subset', '400', 'normal', 'woff2')).toBe(
 				'./files/font-subset-400-normal.woff2',
 			);
 		});


### PR DESCRIPTION
Closes #1075. Bumps `google-font-metadata` to handle new Google changes.