### PR TITLE
fix(website): use seconds for algolia ttl

### DIFF
--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -31,7 +31,7 @@ interface SearchProps {
 	serverUrl: string;
 }
 
-const ALGOLIA_TTL_SECONDS = 6 * 60 * 60; // 6 hours; Cloudflare KV expects seconds
+const ALGOLIA_TTL_SECONDS = 6 * 60 * 60; // 6 hours
 
 const searchClient = algoliasearch(
 	'WNATE69PVR',

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -31,7 +31,7 @@ interface SearchProps {
 	serverUrl: string;
 }
 
-const ALGOLIA_TTL = 6 * 60 * 60 * 1000; // 6 hours
+const ALGOLIA_TTL_SECONDS = 6 * 60 * 60; // 6 hours; Cloudflare KV expects seconds
 
 const searchClient = algoliasearch(
 	'WNATE69PVR',
@@ -161,7 +161,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	// Add server state to local cache before responding
 	context.cloudflare.ctx.waitUntil(
 		ALGOLIA.put(serverUrl, JSON.stringify(serverState), {
-			expirationTtl: ALGOLIA_TTL,
+			expirationTtl: ALGOLIA_TTL_SECONDS,
 		}),
 	);
 


### PR DESCRIPTION
The expiration TTL is in seconds, not milliseconds, so our Cloudflare cache was never expiring.