### PR TITLE
fix(website): handle repeated query params

### DIFF
--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -53,6 +53,14 @@ const sortMap: Record<string, string> = {
 	random: 'prod_RANDOM',
 };
 
+const parseSubsets = (value: unknown): string[] | undefined => {
+	const subsets = (Array.isArray(value) ? value : [value])
+		.filter((subset): subset is string => typeof subset === 'string')
+		.flatMap((subset) => subset.split(',').filter(Boolean));
+
+	return subsets.length > 0 ? subsets : undefined;
+};
+
 const routing = (serverUrl: string): RouterProps<UiState, UiState> => {
 	const indexName = 'prod_POPULAR';
 	return {
@@ -85,12 +93,13 @@ const routing = (serverUrl: string): RouterProps<UiState, UiState> => {
 			},
 			// @ts-expect-error - This is a valid function signature
 			routeToState(routeState) {
+				const subsets = parseSubsets(routeState.subsets);
+
 				const state = {
 					query: routeState.query,
 					// RefinementList facets
-					...(routeState.subsets
-						? // @ts-expect-error - This is a valid object
-							{ refinementList: { subsets: routeState.subsets.split(',') } }
+					...(subsets?.length
+						? { refinementList: { subsets } }
 						: {}),
 					// Menu facets
 					...(routeState.category

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -56,6 +56,7 @@ const sortMap: Record<string, string> = {
 const parseSubsets = (value: unknown): string[] | undefined => {
 	const subsets = (Array.isArray(value) ? value : [value])
 		.filter((subset): subset is string => typeof subset === 'string')
+		// Split comma-separated values and flatten the resulting arrays.
 		.flatMap((subset) => subset.split(',').filter(Boolean));
 
 	return subsets.length > 0 ? subsets : undefined;
@@ -98,9 +99,7 @@ const routing = (serverUrl: string): RouterProps<UiState, UiState> => {
 				const state = {
 					query: routeState.query,
 					// RefinementList facets
-					...(subsets?.length
-						? { refinementList: { subsets } }
-						: {}),
+					...(subsets?.length ? { refinementList: { subsets } } : {}),
 					// Menu facets
 					...(routeState.category
 						? { menu: { category: routeState.category } }


### PR DESCRIPTION
Repeated query params on subsets can cause a throw for the Algolia search handler. This cleans that up a little.