### PR TITLE
docs(website): update Next.js guide for App Router

### DIFF
--- a/website/docs/guides/nextjs.mdx
+++ b/website/docs/guides/nextjs.mdx
@@ -5,25 +5,84 @@ section: Frameworks
 
 # Next.js
 
-To include Fontsource into your Next.js project, it is required to use a custom App component.
-[Next.js Documentation](https://nextjs.org/docs/advanced-features/custom-app).
+Next.js is a React framework for building web applications. Importing fonts depends on the router you are using. Below are the steps to import fonts into a Next.js project.
 
-## Installation
+## App Router
 
-To add Fontsource to your Next.js project, you can import it globally in the custom `_app.js` or `_app.tsx` file. Alternatively, you can choose to import it into a specific page component, but the CSS will only be present within that page and not globally.
+To import fonts into a Next.js project using the [App Router](https://nextjs.org/docs/app), you can simply import the CSS file directly into your root layout file.
 
-```jsx
+### 1. Installation
+
+<PackageManagerCode cmd="@fontsource-variable/open-sans" />
+
+### 2. Import CSS
+
+Modify `app/layout.tsx` to include the following code:
+
+```tsx
 import "@fontsource-variable/open-sans/wght.css";
 
-function MyApp({ Component, pageProps }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+> **Note:** You can also import fonts in individual `layout.tsx` or `page.tsx` files to scope them to specific routes.
+
+### 3. Usage
+
+You can now use the imported fonts in your Next.js project.
+
+```css
+h1 {
+  font-family: "Open Sans Variable", sans-serif;
+}
+```
+
+## Pages Router
+
+With the [Pages Router](https://nextjs.org/docs/pages/building-your-application/routing/custom-app), you can import fonts in your custom `_app.tsx` file.
+
+### 1. Installation
+
+<PackageManagerCode cmd="@fontsource-variable/open-sans" />
+
+### 2. Import CSS
+
+Modify `_app.tsx` to include the following code:
+
+```tsx
+import "@fontsource-variable/open-sans/wght.css";
+
+function MyApp({ Component, pageProps }: { Component: any; pageProps: any }) {
   return <Component {...pageProps} />;
 }
 
 export default MyApp;
 ```
 
-### Comparison to `next/font`
+> **Note:** You can also import fonts in individual page components, but the CSS will only be present within that page and not globally.
 
-Next.js offers a built-in way to load fonts using the `next/font` package. This package serves as a straightforward alternative to Fontsource as a simple setup. It embeds the CSS from the Google Fonts API, eliminating an additional round-trip response. It performs well for most use cases and is a good choice if you do not need to customise the font loading behaviour.
+### 3. Usage
+
+You can now use the imported fonts in your Next.js project.
+
+```css
+h1 {
+  font-family: "Open Sans Variable", sans-serif;
+}
+```
+
+## Comparison to `next/font`
+
+Next.js offers a built-in way to load fonts using the `next/font` package. This package serves as a straightforward alternative to Fontsource with a simple setup. It embeds the CSS from the Google Fonts API, eliminating an additional round-trip response. It performs well for most use cases and is a good choice if you do not need to customise the font loading behaviour.
 
 We recommend using Fontsource if you need more control over versioning your dependencies and do not want an invisible abstraction over the Google Fonts API. We also offer an escape hatch to directly modify the `@font-face` rules suitable for more advanced use cases.


### PR DESCRIPTION
Rewrite the Next.js guide to lead with App Router instructions using app/layout.tsx, which is the default for Next.js. The Pages Router instructions are preserved in a separate section.

Closes #1082