### PR TITLE
fix(algolia): clean up cache key logic for ssr

### DIFF
--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -22,6 +22,7 @@ import { Filters } from '@/components/search/Filters';
 import { InfiniteHits } from '@/components/search/Hits';
 import type { SearchObject } from '@/components/search/observables';
 import { ScrollToTop } from '@/components/search/ScrollToTop';
+import { buildAlgoliaCacheKey } from '@/utils/algolia';
 
 import classes from '@/styles/global.module.css';
 import { theme } from '@/styles/theme';
@@ -125,6 +126,7 @@ const routing = (serverUrl: string): RouterProps<UiState, UiState> => {
 export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	const { ALGOLIA } = context.cloudflare.env;
 	const serverUrl = request.url;
+	const cacheKey = buildAlgoliaCacheKey(serverUrl);
 
 	// Generate default state object for ssr
 	const state$ = observable<SearchObject>({
@@ -139,7 +141,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	});
 
 	// Check local cache for server state first to avoid unnecessary API calls
-	let serverState = await ALGOLIA.get(serverUrl, 'json');
+	let serverState = await ALGOLIA.get(cacheKey, 'json');
 	if (serverState) {
 		return data<SearchProps>({
 			serverState,
@@ -168,7 +170,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 
 	// Add server state to local cache before responding
 	context.cloudflare.ctx.waitUntil(
-		ALGOLIA.put(serverUrl, JSON.stringify(serverState), {
+		ALGOLIA.put(cacheKey, JSON.stringify(serverState), {
 			expirationTtl: ALGOLIA_TTL_SECONDS,
 		}),
 	);

--- a/website/app/utils/algolia.test.ts
+++ b/website/app/utils/algolia.test.ts
@@ -6,6 +6,12 @@ describe('buildAlgoliaCacheKey', () => {
 	it('ignores unknown params', () => {
 		expect(
 			buildAlgoliaCacheKey(
+				'https://fontsource.org/?utm_source=bot&fbclid=garbage',
+			),
+		).toBe('algolia:ssr:root');
+
+		expect(
+			buildAlgoliaCacheKey(
 				'https://fontsource.org/?query=inter&utm_source=bot&fbclid=garbage',
 			),
 		).toBe('algolia:ssr:query=inter');

--- a/website/app/utils/algolia.test.ts
+++ b/website/app/utils/algolia.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAlgoliaCacheKey } from './algolia';
+
+describe('buildAlgoliaCacheKey', () => {
+	it('ignores unknown params', () => {
+		expect(
+			buildAlgoliaCacheKey(
+				'https://fontsource.org/?query=inter&utm_source=bot&fbclid=garbage',
+			),
+		).toBe('algolia:ssr:query=inter');
+	});
+
+	it('normalizes param order', () => {
+		expect(
+			buildAlgoliaCacheKey(
+				'https://fontsource.org/?sort=newest&category=serif&query=inter',
+			),
+		).toBe(
+			buildAlgoliaCacheKey(
+				'https://fontsource.org/?query=inter&category=serif&sort=newest',
+			),
+		);
+	});
+
+	it('normalizes repeated and comma-separated subsets', () => {
+		expect(
+			buildAlgoliaCacheKey(
+				'https://fontsource.org/?subsets=latin-ext,latin&subsets=latin',
+			),
+		).toBe('algolia:ssr:subsets=latin%2Clatin-ext');
+	});
+
+	it('omits an empty query', () => {
+		expect(buildAlgoliaCacheKey('https://fontsource.org/?query=%20%20')).toBe(
+			'algolia:ssr:root',
+		);
+	});
+
+	it('preserves known params with arbitrary values', () => {
+		expect(
+			buildAlgoliaCacheKey(
+				'https://fontsource.org/?sort=garbage&category=unknown&variable=garbage',
+			),
+		).toBe('algolia:ssr:category=unknown&variable=true&sort=garbage');
+	});
+});

--- a/website/app/utils/algolia.ts
+++ b/website/app/utils/algolia.ts
@@ -1,0 +1,39 @@
+const ALGOLIA_CACHE_KEY_PREFIX = 'algolia:ssr';
+
+export const buildAlgoliaCacheKey = (requestUrl: string): string => {
+	const source = new URL(requestUrl).searchParams;
+	const params = new URLSearchParams();
+
+	const query = source.get('query')?.trim();
+	if (query) {
+		params.set('query', query);
+	}
+
+	const subsets = source
+		.getAll('subsets')
+		.flatMap((value) => value.split(','))
+		.map((value) => value.trim())
+		.filter(Boolean);
+	if (subsets.length) {
+		params.set('subsets', [...new Set(subsets)].sort().join(','));
+	}
+
+	const category = source.get('category')?.trim();
+	if (category) {
+		params.set('category', category);
+	}
+
+	if (source.getAll('variable').some((value) => value.trim())) {
+		params.set('variable', 'true');
+	}
+
+	const sort = source.get('sort')?.trim();
+	if (sort) {
+		params.set('sort', sort);
+	}
+
+	const suffix = params.toString();
+	return suffix
+		? `${ALGOLIA_CACHE_KEY_PREFIX}:${suffix}`
+		: `${ALGOLIA_CACHE_KEY_PREFIX}:root`;
+};


### PR DESCRIPTION
This is a quick fix to reduce query param cache bombing from crawlers and agents that spam our Algolia KV records with many unnecessary writes.

This drops any unrecognized query params and also sorts them so we get better cache hits and not stress our KV so much.