### PR TITLE
perf(website): cache only root algolia ssr state

### DIFF
--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -22,10 +22,10 @@ import { Filters } from '@/components/search/Filters';
 import { InfiniteHits } from '@/components/search/Hits';
 import type { SearchObject } from '@/components/search/observables';
 import { ScrollToTop } from '@/components/search/ScrollToTop';
-import { buildAlgoliaCacheKey } from '@/utils/algolia';
 
 import classes from '@/styles/global.module.css';
 import { theme } from '@/styles/theme';
+import { buildAlgoliaCacheKey } from '@/utils/algolia';
 
 interface SearchProps {
 	serverState?: InstantSearchServerState;
@@ -141,7 +141,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	});
 
 	// Check local cache for server state first to avoid unnecessary API calls
-	let serverState = await ALGOLIA.get(cacheKey, 'json');
+	let serverState = cacheKey ? await ALGOLIA.get(cacheKey, 'json') : null;
 	if (serverState) {
 		return data<SearchProps>({
 			serverState,
@@ -169,11 +169,13 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	);
 
 	// Add server state to local cache before responding
-	context.cloudflare.ctx.waitUntil(
-		ALGOLIA.put(cacheKey, JSON.stringify(serverState), {
-			expirationTtl: ALGOLIA_TTL_SECONDS,
-		}),
-	);
+	if (cacheKey) {
+		context.cloudflare.ctx.waitUntil(
+			ALGOLIA.put(cacheKey, JSON.stringify(serverState), {
+				expirationTtl: ALGOLIA_TTL_SECONDS,
+			}),
+		);
+	}
 
 	return data<SearchProps>(
 		{

--- a/website/app/utils/algolia.test.ts
+++ b/website/app/utils/algolia.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { buildAlgoliaCacheKey } from './algolia';
 
 describe('buildAlgoliaCacheKey', () => {
-	it('ignores unknown params', () => {
+	it('ignores unknown params and skips search params', () => {
 		expect(
 			buildAlgoliaCacheKey(
 				'https://fontsource.org/?utm_source=bot&fbclid=garbage',
@@ -14,27 +14,15 @@ describe('buildAlgoliaCacheKey', () => {
 			buildAlgoliaCacheKey(
 				'https://fontsource.org/?query=inter&utm_source=bot&fbclid=garbage',
 			),
-		).toBe('algolia:ssr:query=inter');
+		).toBeUndefined();
 	});
 
-	it('normalizes param order', () => {
-		expect(
-			buildAlgoliaCacheKey(
-				'https://fontsource.org/?sort=newest&category=serif&query=inter',
-			),
-		).toBe(
-			buildAlgoliaCacheKey(
-				'https://fontsource.org/?query=inter&category=serif&sort=newest',
-			),
-		);
-	});
-
-	it('normalizes repeated and comma-separated subsets', () => {
+	it('skips repeated and comma-separated subsets', () => {
 		expect(
 			buildAlgoliaCacheKey(
 				'https://fontsource.org/?subsets=latin-ext,latin&subsets=latin',
 			),
-		).toBe('algolia:ssr:subsets=latin%2Clatin-ext');
+		).toBeUndefined();
 	});
 
 	it('omits an empty query', () => {
@@ -43,11 +31,11 @@ describe('buildAlgoliaCacheKey', () => {
 		);
 	});
 
-	it('preserves known params with arbitrary values', () => {
+	it('skips known params with arbitrary values', () => {
 		expect(
 			buildAlgoliaCacheKey(
 				'https://fontsource.org/?sort=garbage&category=unknown&variable=garbage',
 			),
-		).toBe('algolia:ssr:category=unknown&variable=true&sort=garbage');
+		).toBeUndefined();
 	});
 });

--- a/website/app/utils/algolia.ts
+++ b/website/app/utils/algolia.ts
@@ -1,39 +1,20 @@
 const ALGOLIA_CACHE_KEY_PREFIX = 'algolia:ssr';
 
-export const buildAlgoliaCacheKey = (requestUrl: string): string => {
+export const buildAlgoliaCacheKey = (
+	requestUrl: string,
+): string | undefined => {
 	const source = new URL(requestUrl).searchParams;
-	const params = new URLSearchParams();
 
-	const query = source.get('query')?.trim();
-	if (query) {
-		params.set('query', query);
+	if (
+		['query', 'category', 'variable', 'sort'].some((param) =>
+			source.getAll(param).some((value) => value.trim()),
+		) ||
+		source
+			.getAll('subsets')
+			.some((value) => value.split(',').some((subset) => subset.trim()))
+	) {
+		return undefined;
 	}
 
-	const subsets = source
-		.getAll('subsets')
-		.flatMap((value) => value.split(','))
-		.map((value) => value.trim())
-		.filter(Boolean);
-	if (subsets.length) {
-		params.set('subsets', [...new Set(subsets)].sort().join(','));
-	}
-
-	const category = source.get('category')?.trim();
-	if (category) {
-		params.set('category', category);
-	}
-
-	if (source.getAll('variable').some((value) => value.trim())) {
-		params.set('variable', 'true');
-	}
-
-	const sort = source.get('sort')?.trim();
-	if (sort) {
-		params.set('sort', sort);
-	}
-
-	const suffix = params.toString();
-	return suffix
-		? `${ALGOLIA_CACHE_KEY_PREFIX}:${suffix}`
-		: `${ALGOLIA_CACHE_KEY_PREFIX}:root`;
+	return `${ALGOLIA_CACHE_KEY_PREFIX}:root`;
 };


### PR DESCRIPTION
This tweaks the Algolia SSR cache to be conditional. A lot of queries just write to the cache, but never actually call from it.