### PR TITLE
perf(website): prerender static routes

### DIFF
--- a/website/app/components/docs/Layout.module.css
+++ b/website/app/components/docs/Layout.module.css
@@ -13,6 +13,10 @@
 	}
 
 	@media (--lt-md) {
+		padding: 0 32px;
+	}
+
+	@media (--lt-sm) {
 		grid-template-columns: 1fr;
 		padding: 0;
 	}
@@ -21,7 +25,7 @@
 .sidebar {
 	min-width: 0;
 
-	@media (--lt-md) {
+	@media (--lt-sm) {
 		display: none;
 	}
 }

--- a/website/react-router.config.ts
+++ b/website/react-router.config.ts
@@ -1,5 +1,48 @@
+import { readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Config } from '@react-router/dev/config';
+
+const docsDirectory = fileURLToPath(new URL('./docs', import.meta.url));
+const mdxExtension = '.mdx';
+
+const staticPageRoutes = ['/tools', '/tools/converter'];
+const staticResourceRoutes = ['/llms.txt', '/llms-full.txt', '/robots.txt'];
+
+const getDocsPageRoutes = (directory: string): string[] => {
+	const routes: string[] = [];
+
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const entryPath = join(directory, entry.name);
+
+		if (entry.isDirectory()) {
+			routes.push(...getDocsPageRoutes(entryPath));
+			continue;
+		}
+
+		if (!entry.isFile() || !entry.name.endsWith(mdxExtension)) {
+			continue;
+		}
+
+		const docsPath = relative(docsDirectory, entryPath)
+			.slice(0, -mdxExtension.length)
+			.split(sep)
+			.join('/');
+
+		routes.push(`/docs/${docsPath}`);
+	}
+
+	return routes;
+};
+
+const prerenderRoutes = [
+	...staticPageRoutes,
+	...staticResourceRoutes,
+	// Docs pages use the dynamic docs.$ route, so each MDX page is listed.
+	...getDocsPageRoutes(docsDirectory),
+].sort();
 
 export default {
 	ssr: true,
+	prerender: prerenderRoutes,
 } satisfies Config;


### PR DESCRIPTION
Pre-render some routes that are knowingly static such as documentation or tools.