### PR TITLE
feat(website): refine font details links

### DIFF
--- a/website/app/components/preview/Info.module.css
+++ b/website/app/components/preview/Info.module.css
@@ -15,13 +15,57 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
+	height: 41px;
 	padding: 8px 16px;
 	border-radius: 4px;
+	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
+	background-color: light-dark(var(--mantine-color-background-0), var(--mantine-color-background-4));
 
 	border: light-dark(1px solid var(--mantine-color-border-0), 1px solid var(--mantine-color-border-1));
 
 	&:hover {
 		background-color: light-dark(var(--mantine-color-purple-hover), var(--mantine-color-purple-hover));
+	}
+
+	&[aria-expanded="true"] {
+		border-color: var(--mantine-color-purple-0);
+		background-color: var(--mantine-color-button-hover);
+	}
+}
+
+.button-content {
+	width: 100%;
+	justify-content: center;
+}
+
+.caret {
+	margin-left: 2px;
+	width: 10px;
+	height: 10px;
+}
+
+.link-popover {
+	padding: 4px;
+	border-radius: 4px;
+	border: light-dark(1px solid var(--mantine-color-border-0), 1px solid var(--mantine-color-border-1));
+	background-color: light-dark(var(--mantine-color-background-0), var(--mantine-color-background-4));
+	box-shadow: light-dark(0 8px 18px rgb(1 17 44 / 0.06), 0 8px 18px rgb(0 0 0 / 0.18));
+}
+
+.popover-link {
+	display: block;
+	width: 100%;
+	min-height: 36px;
+	padding: 8px 12px;
+	border-radius: 3px;
+	font-size: 14px;
+	line-height: 1.25;
+	text-align: left;
+	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
+
+	&:hover {
+		background-color: light-dark(var(--mantine-color-purple-hover), var(--mantine-color-background-6));
 	}
 }
 

--- a/website/app/components/preview/Info.module.css
+++ b/website/app/components/preview/Info.module.css
@@ -45,7 +45,7 @@
 	height: 10px;
 }
 
-.link-popover {
+.link-menu {
 	padding: 4px;
 	border-radius: 4px;
 	border: light-dark(1px solid var(--mantine-color-border-0), 1px solid var(--mantine-color-border-1));
@@ -53,18 +53,16 @@
 	box-shadow: light-dark(0 8px 18px rgb(1 17 44 / 0.06), 0 8px 18px rgb(0 0 0 / 0.18));
 }
 
-.popover-link {
-	display: block;
-	width: 100%;
+.link-menu-item {
 	min-height: 36px;
 	padding: 8px 12px;
 	border-radius: 3px;
 	font-size: 14px;
 	line-height: 1.25;
-	text-align: left;
 	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
 
-	&:hover {
+	&:hover,
+	&[data-hovered] {
 		background-color: light-dark(var(--mantine-color-purple-hover), var(--mantine-color-background-6));
 	}
 }

--- a/website/app/components/preview/Info.tsx
+++ b/website/app/components/preview/Info.tsx
@@ -39,6 +39,18 @@ interface DetailsMenuProps {
 	label: string;
 }
 
+const getSourcePath = (metadata: Metadata, variant: 'static' | 'variable') => {
+	if (metadata.category === 'icons') {
+		return variant === 'variable' ? 'variable-icons' : 'icons';
+	}
+
+	if (variant === 'variable') {
+		return metadata.type === 'google' ? 'variable' : metadata.type;
+	}
+
+	return metadata.type;
+};
+
 const handleMenuTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
 	if (event.key === 'Enter' || event.key === ' ') {
 		event.preventDefault();
@@ -90,9 +102,8 @@ const DetailsMenu = ({ ariaLabel, icon, items, label }: DetailsMenuProps) => (
 );
 
 export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
-	const staticSourcePath =
-		metadata.category === 'icons' ? 'icons' : metadata.type;
-	const staticSourceUrl = `https://github.com/fontsource/font-files/tree/main/fonts/${staticSourcePath}/${metadata.id}`;
+	const staticSourceUrl = `https://github.com/fontsource/font-files/tree/main/fonts/${getSourcePath(metadata, 'static')}/${metadata.id}`;
+	const variableSourceUrl = `https://github.com/fontsource/font-files/tree/main/fonts/${getSourcePath(metadata, 'variable')}/${metadata.id}`;
 
 	return (
 		<div className={classes.wrapper}>
@@ -121,11 +132,7 @@ export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
 							items={[
 								{
 									ariaLabel: 'Open variable GitHub source',
-									href: `https://github.com/fontsource/font-files/tree/main/fonts/${
-										metadata.category === 'icons'
-											? 'variable-icons'
-											: 'variable'
-									}/${metadata.id}`,
+									href: variableSourceUrl,
 									label: 'Variable',
 								},
 								{

--- a/website/app/components/preview/Info.tsx
+++ b/website/app/components/preview/Info.tsx
@@ -1,13 +1,23 @@
-import { Divider, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import {
+	Divider,
+	Group,
+	Popover,
+	Stack,
+	Text,
+	UnstyledButton,
+} from '@mantine/core';
 import { millify } from 'millify';
 
 import {
+	IconCaret,
 	IconDownload,
 	IconEdit,
 	IconGithub,
 	IconNpm,
 } from '@/components/icons';
 import type { Metadata } from '@/utils/types';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { useRef, useState } from 'react';
 
 import classes from './Info.module.css';
 
@@ -17,7 +27,98 @@ interface InfoProps {
 	hits?: number;
 }
 
+interface DetailsPopoverLink {
+	ariaLabel: string;
+	href: string;
+	label: string;
+}
+
+interface DetailsPopoverProps {
+	ariaLabel: string;
+	icon: ReactNode;
+	links: DetailsPopoverLink[];
+	label: string;
+}
+
+const handleMenuTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+	if (event.key === 'Enter' || event.key === ' ') {
+		event.preventDefault();
+		event.currentTarget.click();
+	}
+};
+
+const DetailsPopover = ({
+	ariaLabel,
+	icon,
+	links,
+	label,
+}: DetailsPopoverProps) => {
+	const [opened, setOpened] = useState(false);
+	const firstLinkRef = useRef<HTMLAnchorElement>(null);
+
+	const handleOpenedChange = (nextOpened: boolean) => {
+		setOpened(nextOpened);
+
+		if (nextOpened) {
+			setTimeout(() => firstLinkRef.current?.focus(), 0);
+		}
+	};
+
+	return (
+		<Popover
+			shadow="none"
+			width="target"
+			position="bottom-start"
+			offset={4}
+			opened={opened}
+			onChange={handleOpenedChange}
+			trapFocus
+			classNames={{
+				dropdown: classes['link-popover'],
+			}}
+		>
+			<Popover.Target>
+				<UnstyledButton
+					aria-label={ariaLabel}
+					className={classes.button}
+					onClick={() => handleOpenedChange(!opened)}
+					onKeyDown={handleMenuTriggerKeyDown}
+					type="button"
+				>
+					<Group className={classes['button-content']} gap="xs">
+						{icon}
+						{label}
+						<IconCaret className={classes.caret} />
+					</Group>
+				</UnstyledButton>
+			</Popover.Target>
+			<Popover.Dropdown>
+				<Stack gap={2}>
+					{links.map((link, index) => (
+						<UnstyledButton
+							key={link.href}
+							component="a"
+							aria-label={link.ariaLabel}
+							className={classes['popover-link']}
+							href={link.href}
+							ref={index === 0 ? firstLinkRef : undefined}
+							target="_blank"
+							rel="noreferrer"
+						>
+							{link.label}
+						</UnstyledButton>
+					))}
+				</Stack>
+			</Popover.Dropdown>
+		</Popover>
+	);
+};
+
 export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
+	const staticSourcePath =
+		metadata.category === 'icons' ? 'icons' : metadata.type;
+	const staticSourceUrl = `https://github.com/fontsource/font-files/tree/main/fonts/${staticSourcePath}/${metadata.id}`;
+
 	return (
 		<div className={classes.wrapper}>
 			<Text fw={700} fz={15}>
@@ -37,30 +138,76 @@ export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
 					<Text>Last Modified: {metadata.lastModified}</Text>
 				</Group>
 				<Group className={classes['button-group']} justify="space-between" grow>
-					<UnstyledButton
-						component="a"
-						className={classes.button}
-						href={`https://github.com/fontsource/font-files/tree/main/fonts/${
-							metadata.category === 'icons' ? 'icons' : metadata.type
-						}/${metadata.id}`}
-						target="_blank"
-					>
-						<Group>
-							<IconGithub />
-							Github
-						</Group>
-					</UnstyledButton>
-					<UnstyledButton
-						component="a"
-						className={classes.button}
-						href={`https://www.npmjs.com/package/@fontsource/${metadata.id}`}
-						target="_blank"
-					>
-						<Group>
-							<IconNpm />
-							NPM
-						</Group>
-					</UnstyledButton>
+					{metadata.variable ? (
+						<DetailsPopover
+							ariaLabel="Open GitHub source links"
+							icon={<IconGithub />}
+							label="Github"
+							links={[
+								{
+									ariaLabel: 'Open variable GitHub source',
+									href: `https://github.com/fontsource/font-files/tree/main/fonts/${
+										metadata.category === 'icons'
+											? 'variable-icons'
+											: 'variable'
+									}/${metadata.id}`,
+									label: 'Variable',
+								},
+								{
+									ariaLabel: 'Open static GitHub source',
+									href: staticSourceUrl,
+									label: 'Static',
+								},
+							]}
+						/>
+					) : (
+						<UnstyledButton
+							component="a"
+							aria-label="Open GitHub source"
+							className={classes.button}
+							href={staticSourceUrl}
+							target="_blank"
+							rel="noreferrer"
+						>
+							<Group className={classes['button-content']} gap="xs">
+								<IconGithub />
+								Github
+							</Group>
+						</UnstyledButton>
+					)}
+					{metadata.variable ? (
+						<DetailsPopover
+							ariaLabel="Open NPM package links"
+							icon={<IconNpm />}
+							label="NPM"
+							links={[
+								{
+									ariaLabel: 'Open variable NPM package',
+									href: `https://www.npmjs.com/package/@fontsource-variable/${metadata.id}`,
+									label: 'Variable',
+								},
+								{
+									ariaLabel: 'Open static NPM package',
+									href: `https://www.npmjs.com/package/@fontsource/${metadata.id}`,
+									label: 'Static',
+								},
+							]}
+						/>
+					) : (
+						<UnstyledButton
+							component="a"
+							aria-label="Open NPM package"
+							className={classes.button}
+							href={`https://www.npmjs.com/package/@fontsource/${metadata.id}`}
+							target="_blank"
+							rel="noreferrer"
+						>
+							<Group className={classes['button-content']} gap="xs">
+								<IconNpm />
+								NPM
+							</Group>
+						</UnstyledButton>
+					)}
 				</Group>
 			</Stack>
 		</div>

--- a/website/app/components/preview/Info.tsx
+++ b/website/app/components/preview/Info.tsx
@@ -1,7 +1,7 @@
 import {
 	Divider,
 	Group,
-	Popover,
+	Menu,
 	Stack,
 	Text,
 	UnstyledButton,
@@ -17,7 +17,6 @@ import {
 } from '@/components/icons';
 import type { Metadata } from '@/utils/types';
 import type { KeyboardEvent, ReactNode } from 'react';
-import { useRef, useState } from 'react';
 
 import classes from './Info.module.css';
 
@@ -27,16 +26,16 @@ interface InfoProps {
 	hits?: number;
 }
 
-interface DetailsPopoverLink {
+interface DetailsMenuItem {
 	ariaLabel: string;
 	href: string;
 	label: string;
 }
 
-interface DetailsPopoverProps {
+interface DetailsMenuProps {
 	ariaLabel: string;
 	icon: ReactNode;
-	links: DetailsPopoverLink[];
+	items: DetailsMenuItem[];
 	label: string;
 }
 
@@ -47,72 +46,48 @@ const handleMenuTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
 	}
 };
 
-const DetailsPopover = ({
-	ariaLabel,
-	icon,
-	links,
-	label,
-}: DetailsPopoverProps) => {
-	const [opened, setOpened] = useState(false);
-	const firstLinkRef = useRef<HTMLAnchorElement>(null);
-
-	const handleOpenedChange = (nextOpened: boolean) => {
-		setOpened(nextOpened);
-
-		if (nextOpened) {
-			setTimeout(() => firstLinkRef.current?.focus(), 0);
-		}
-	};
-
-	return (
-		<Popover
-			shadow="none"
-			width="target"
-			position="bottom-start"
-			offset={4}
-			opened={opened}
-			onChange={handleOpenedChange}
-			trapFocus
-			classNames={{
-				dropdown: classes['link-popover'],
-			}}
-		>
-			<Popover.Target>
-				<UnstyledButton
-					aria-label={ariaLabel}
-					className={classes.button}
-					onClick={() => handleOpenedChange(!opened)}
-					onKeyDown={handleMenuTriggerKeyDown}
-					type="button"
+const DetailsMenu = ({ ariaLabel, icon, items, label }: DetailsMenuProps) => (
+	<Menu
+		shadow="none"
+		width="target"
+		position="bottom-start"
+		offset={4}
+		menuItemTabIndex={0}
+		classNames={{
+			dropdown: classes['link-menu'],
+			item: classes['link-menu-item'],
+		}}
+	>
+		<Menu.Target>
+			<UnstyledButton
+				aria-label={ariaLabel}
+				className={classes.button}
+				onKeyDown={handleMenuTriggerKeyDown}
+				type="button"
+			>
+				<Group className={classes['button-content']} gap="xs">
+					{icon}
+					{label}
+					<IconCaret className={classes.caret} />
+				</Group>
+			</UnstyledButton>
+		</Menu.Target>
+		<Menu.Dropdown>
+			{items.map((item) => (
+				<Menu.Item
+					key={item.href}
+					component="a"
+					aria-label={item.ariaLabel}
+					href={item.href}
+					target="_blank"
+					rel="noreferrer"
 				>
-					<Group className={classes['button-content']} gap="xs">
-						{icon}
-						{label}
-						<IconCaret className={classes.caret} />
-					</Group>
-				</UnstyledButton>
-			</Popover.Target>
-			<Popover.Dropdown>
-				<Stack gap={2}>
-					{links.map((link, index) => (
-						<UnstyledButton
-							key={link.href}
-							component="a"
-							aria-label={link.ariaLabel}
-							className={classes['popover-link']}
-							href={link.href}
-							ref={index === 0 ? firstLinkRef : undefined}
-							target="_blank"
-							rel="noreferrer"
-						>
-							{link.label}
-						</UnstyledButton>
-					))}
-				</Stack>
-			</Popover.Dropdown>
-		</Popover>
-	);
-};
+					{item.label}
+				</Menu.Item>
+			))}
+		</Menu.Dropdown>
+	</Menu>
+);
 
 export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
 	const staticSourcePath =
@@ -139,11 +114,11 @@ export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
 				</Group>
 				<Group className={classes['button-group']} justify="space-between" grow>
 					{metadata.variable ? (
-						<DetailsPopover
+						<DetailsMenu
 							ariaLabel="Open GitHub source links"
 							icon={<IconGithub />}
 							label="Github"
-							links={[
+							items={[
 								{
 									ariaLabel: 'Open variable GitHub source',
 									href: `https://github.com/fontsource/font-files/tree/main/fonts/${
@@ -176,11 +151,11 @@ export const InfoWrapper = ({ metadata, isCDN, hits }: InfoProps) => {
 						</UnstyledButton>
 					)}
 					{metadata.variable ? (
-						<DetailsPopover
+						<DetailsMenu
 							ariaLabel="Open NPM package links"
 							icon={<IconNpm />}
 							label="NPM"
-							links={[
+							items={[
 								{
 									ariaLabel: 'Open variable NPM package',
 									href: `https://www.npmjs.com/package/@fontsource-variable/${metadata.id}`,

--- a/website/app/utils/types.ts
+++ b/website/app/utils/types.ts
@@ -22,7 +22,7 @@ export interface Metadata {
 	category: string;
 	source: string;
 	license: LicenseData;
-	type: 'google' | 'other';
+	type: 'google' | 'icons' | 'league' | 'other';
 	unicodeRange: UnicodeData;
 }
 


### PR DESCRIPTION
Adds menus for the Github and NPM buttons on each font detail page, so you can differentiate between static and variable sources.