### PR TITLE
fix(docs): normalize trailing slash on html

### DIFF
--- a/website/app/components/docs/Breadcrumbs.tsx
+++ b/website/app/components/docs/Breadcrumbs.tsx
@@ -12,7 +12,7 @@ interface BreadcrumbsProps {
 export const Breadcrumbs = ({ items }: BreadcrumbsProps) => (
 	<nav className={classes.breadcrumbs} aria-label="Breadcrumb">
 		{items.map((item, index) => (
-			<span key={item.url ?? item.name}>
+			<span key={`${item.url ?? ''}-${item.name}`}>
 				{item.url && index < items.length - 1 ? (
 					<Link to={item.url} prefetch="render">
 						{item.name}

--- a/website/app/components/docs/LeftSidebar.tsx
+++ b/website/app/components/docs/LeftSidebar.tsx
@@ -37,6 +37,9 @@ const nodeKey = (node: PageTree.Node) =>
 		? node.url
 		: `${node.type}-${String(node.name ?? node.type)}`);
 
+const normalizePathname = (pathname: string) =>
+	pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+
 const containsCurrentPage = (
 	node: PageTree.Node,
 	currentPath: string,
@@ -211,7 +214,8 @@ const LeftSidebar = ({ tree, toggle }: LeftSidebarProps) => {
 
 	if (!pageTree) return null;
 
-	const activeFolder = activeRootFolder(pageTree, location.pathname);
+	const currentPath = normalizePathname(location.pathname);
+	const activeFolder = activeRootFolder(pageTree, currentPath);
 
 	return (
 		<nav className={classes.wrapper} aria-label="Documentation">
@@ -220,7 +224,7 @@ const LeftSidebar = ({ tree, toggle }: LeftSidebarProps) => {
 					<RootSection
 						key={nodeKey(node)}
 						node={node}
-						currentPath={location.pathname}
+						currentPath={currentPath}
 						toggle={toggle}
 					/>
 				))}
@@ -229,7 +233,7 @@ const LeftSidebar = ({ tree, toggle }: LeftSidebarProps) => {
 				<Stack className={classes.activeSection} gap={3}>
 					<SidebarNodes
 						nodes={activeFolder.children}
-						currentPath={location.pathname}
+						currentPath={currentPath}
 						toggle={toggle}
 					/>
 				</Stack>

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -9,6 +9,7 @@ compatibility_date = "2025-08-15"
 [assets]
 binding = "ASSETS"
 directory = "./build/client"
+html_handling = "drop-trailing-slash"
 
 [[kv_namespaces]]
 binding = "ALGOLIA"


### PR DESCRIPTION
Pre-rendering the docs causes some page loads to have a trailing slash on CF, so this enables a relevant setting and also makes the docs pages more resilient to this format.