### PR TITLE
feat(website): persist selected package manager preference

### DIFF
--- a/website/app/components/code/PackageManagerCode.tsx
+++ b/website/app/components/code/PackageManagerCode.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 
 import { getPackageManagerCommands } from '@/utils/docs/packageManagers';
 
@@ -12,9 +13,17 @@ export interface PackageManagerProps {
 export const PackageManagerCode = ({ cmd }: PackageManagerProps) => {
 	const commands = getPackageManagerCommands(cmd);
 
+	const [packageManager, setPackageManager] = useLocalStorage({
+		key: 'package-manager',
+		defaultValue: 'npm',
+	});
+
 	return (
 		<Tabs
-			defaultValue="npm"
+			value={packageManager}
+			onChange={(value) => {
+				if (value) setPackageManager(value);
+			}}
 			className={classes.wrapper}
 			classNames={{ tab: classes.tab }}
 		>


### PR DESCRIPTION
## Summary

Persist the selected package manager across page navigations and browser sessions.

## Motivation

Currently, the package manager tabs always default to `npm` when navigating between font pages or refreshing the page, requiring users to repeatedly reselect their preferred package manager (`bun`, `pnpm`, `yarn`, etc.).

This change remembers the user's previous selection for a smoother browsing experience.

## Implementation

- Use `useLocalStorage` from `@mantine/hooks` to persist the selected package manager.
- Convert the package manager tabs from an uncontrolled component to a controlled component backed by the persisted state.

## Testing

- [x] Verified the selected package manager persists across page navigations.
- [x] Verified the selected package manager persists after refreshing the page.
- [x] Ran `bun run ci:lint`.
- [x] Ran `bun run typecheck`.

Closes #1124