### PR TITLE
Fix: Buggy SVG on hover

### DIFF
--- a/website/app/components/tools/ResultsTable.module.css
+++ b/website/app/components/tools/ResultsTable.module.css
@@ -1,0 +1,9 @@
+.downloadButton {
+  &:not([data-disabled]):hover {
+    svg {
+      path {
+        stroke: white;
+      }
+    }
+  }
+}

--- a/website/app/components/tools/ResultsTable.tsx
+++ b/website/app/components/tools/ResultsTable.tsx
@@ -2,6 +2,7 @@ import type { ConversionResult } from '@fontsource-utils/core';
 import { Box, Button, Stack, Table, Text, Title } from '@mantine/core';
 import { IconFileDownload } from '@tabler/icons-react';
 import { formatFileSize } from './utils';
+import classes from './ResultsTable.module.css';
 
 interface ResultsTableProps {
 	results: ConversionResult[];
@@ -47,6 +48,7 @@ export const ResultsTable = ({
 										onClick={() => onDownloadSingle(index)}
 										title="Download file"
 										disabled={disabled}
+										className={classes.downloadButton}
 									>
 										<IconFileDownload size={18} />
 									</Button>


### PR DESCRIPTION
### Description

When hovering on the single file download, the SVG has `stroke` of `currentColor` and it filled with blue, making it impossible to see with the buttons background.

|State |Live Site|Fix applied|
|---------|---------|------------|
|Not hovered|<img width="122" height="48" alt="image" src="https://github.com/user-attachments/assets/ad264815-3fce-4903-8d0d-652b0c6d5864" />|<img width="93" height="55" alt="image" src="https://github.com/user-attachments/assets/98e5672d-1bcf-4199-b71b-dddade5c42ac" />|
|Hovered|<img width="159" height="69" alt="image" src="https://github.com/user-attachments/assets/69c115ad-032f-4468-9b54-9f455943703c" />|<img width="143" height="87" alt="image" src="https://github.com/user-attachments/assets/70cdad5f-1fd0-41b9-afc4-7458d6bc6a9f" />|


### Changes

Added a new CSS file `ResultsTable.module.css`, containing the rule and added a classname on the button of `ResultsTable.tsx`.


--- 

Let me know your thoughts on this PR.