### PR TITLE
fix(website): handle font loading failed state

### DIFF
--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -243,7 +243,7 @@ describe('cdn routes', () => {
 			expect(css).toContain('.woff2');
 		});
 
-		it('uses published variable filenames in CSS for slanted axis combinations', async () => {
+		it('serves published CSS filenames for custom variable axes', async () => {
 			await testEnv.METADATA.put(
 				KV_KEYS.catalog,
 				JSON.stringify({
@@ -263,6 +263,17 @@ describe('cdn routes', () => {
 			expect(css).toContain('font-style: oblique 0deg 15deg;');
 			expect(css).toContain('slanted:vf@5.0.0/latin-full-normal.woff2');
 			expect(css).not.toContain('oblique%200deg%2015deg');
+
+			const customAxis = await dispatch(
+				'https://fontsource.test/css/slanted:vf@5.0.0/mono.css',
+			);
+			const customAxisCss = await customAxis.response.text();
+			await customAxis.settle();
+
+			expect(customAxis.response.status).toBe(200);
+			expect(customAxisCss).toContain(
+				'slanted:vf@5.0.0/latin-mono-normal.woff2',
+			);
 		});
 
 		it('builds canonical download zips for slanted variable families', async () => {

--- a/api/worker/worker/src/features/cdn/css.ts
+++ b/api/worker/worker/src/features/cdn/css.ts
@@ -65,6 +65,7 @@ const findCssAsset = (
 		: ['woff2', 'woff'];
 	const config = buildFontConfig(metadata, { formats, axes: options.axes });
 
+	// Variable package CSS filenames are lowercase even when custom axis tags are not.
 	return generateCSSAssets(config, {
 		...options,
 		resolver: ({ face, source }) => {
@@ -81,7 +82,11 @@ const findCssAsset = (
 			const publicFilename = getPublicFilename(metadata.id, source.filename);
 			return buildPublicUrl(`fonts/${resolvedTag}/${publicFilename}`);
 		},
-	}).find((asset) => asset.filename === filename);
+	}).find(
+		(asset) =>
+			asset.filename === filename ||
+			(options.axes !== undefined && asset.filename.toLowerCase() === filename),
+	);
 };
 
 /**

--- a/website/app/components/preview/TextArea.tsx
+++ b/website/app/components/preview/TextArea.tsx
@@ -10,7 +10,7 @@ import { useFocusWithin } from '@mantine/hooks';
 import { useEffect } from 'react';
 
 import { Skeleton } from '@/components/Skeleton';
-import { useIsFontLoaded } from '@/hooks/useIsFontLoaded';
+import { useIsFontReady } from '@/hooks/useIsFontLoaded';
 import { getPreviewText } from '@/utils/language/language';
 import type { Metadata } from '@/utils/types';
 
@@ -71,7 +71,7 @@ const TextBox = observer(({ state$, family, weight, style }: TextBoxProps) => {
 			: state$.preview.color.set('#000000');
 	}, [colorScheme]);
 
-	const isFontLoaded = useIsFontLoaded(family, true, {
+	const isFontReady = useIsFontReady(family, true, {
 		weights: [weight],
 		style,
 	});
@@ -79,7 +79,7 @@ const TextBox = observer(({ state$, family, weight, style }: TextBoxProps) => {
 	return (
 		<Box className={classes.row} ref={ref}>
 			<Box className={classes['text-wrapper']}>
-				<Skeleton name="font-preview-row" loading={!isFontLoaded}>
+				<Skeleton name="font-preview-row" loading={!isFontReady}>
 					<TextInput
 						variant="unstyled"
 						className={classes.text}

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -14,7 +14,7 @@ import { useInfiniteHits, useInstantSearch } from 'react-instantsearch';
 import { Link as NavLink } from 'react-router';
 
 import { Skeleton } from '@/components/Skeleton';
-import { useIsFontLoaded } from '@/hooks/useIsFontLoaded';
+import { useIsFontReady } from '@/hooks/useIsFontLoaded';
 import { getPreviewText } from '@/utils/language/language';
 import type { AlgoliaMetadata } from '@/utils/types';
 
@@ -52,7 +52,7 @@ const HitComponent = observer(({ hit, state$ }: HitComponentProps) => {
 
 	// State to track if the font's CSS stylesheet has loaded.
 	const [isStylesheetLoaded, setStylesheetLoaded] = useState(false);
-	const isFontLoaded = useIsFontLoaded(hit.family, isStylesheetLoaded);
+	const isFontReady = useIsFontReady(hit.family, isStylesheetLoaded);
 
 	useEffect(() => {
 		if (isStylesheetLoaded) {
@@ -103,7 +103,7 @@ const HitComponent = observer(({ hit, state$ }: HitComponentProps) => {
 				onLoad={() => setStylesheetLoaded(true)}
 				onError={() => setStylesheetLoaded(true)} // Also enable on error to prevent infinite skeleton.
 			/>
-			<Skeleton name="search-hit-preview" loading={!isFontLoaded}>
+			<Skeleton name="search-hit-preview" loading={!isFontReady}>
 				<Text
 					fz={size}
 					mih={display === 'grid' ? getGridPreviewHeight(size) : undefined}

--- a/website/app/hooks/useIsFontLoaded.ts
+++ b/website/app/hooks/useIsFontLoaded.ts
@@ -91,7 +91,7 @@ const triggerFontLoad = (cacheKey: string, fontFaces: FontFace[]) => {
 		return;
 	}
 
-	if (status === 'loading') {
+	if (status === 'loading' || status === 'failed') {
 		return;
 	}
 
@@ -177,10 +177,11 @@ export const useFontStatus = (
 	return status;
 };
 
-export const useIsFontLoaded = (
+export const useIsFontReady = (
 	family: string,
 	enabled = true,
 	options?: ObserverOptions,
 ) => {
-	return useFontStatus(family, enabled, options) === 'loaded';
+	const status = useFontStatus(family, enabled, options);
+	return status === 'loaded' || status === 'failed';
 };

--- a/website/app/routes/fonts.$id._index.tsx
+++ b/website/app/routes/fonts.$id._index.tsx
@@ -1,4 +1,8 @@
-import { type FontStyle, generateCSS } from '@fontsource-utils/core';
+import {
+	type FontStyle,
+	generateCSS,
+	selectVariableAxisKey,
+} from '@fontsource-utils/core';
 import { useObservable } from '@legendapp/state/react';
 import { Grid } from '@mantine/core';
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
@@ -77,6 +81,9 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 					variable: variable.axes,
 				},
 				{
+					axisKeys: [
+						selectVariableAxisKey(variable.axes, Object.keys(variable.axes)),
+					],
 					resolver: jsDelivrResolver(id, true),
 					display: 'block',
 				},


### PR DESCRIPTION
This resolves a bug where the font loader hook spins infinitely causing the browser to hang if the font loader state fails. There is also another fix to normalize variable axis names which may all be uppercase.