### PR TITLE
fix(website): prevent preview buttons disappearing on hover

### DIFF
--- a/website/app/components/preview/Buttons.module.css
+++ b/website/app/components/preview/Buttons.module.css
@@ -13,6 +13,7 @@
 
 	&:not([data-disabled]) {
 		&:hover {
+			color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
 			background-color: light-dark(lighten("#625BF8", 0.95), darken("#121B31", 0.2));
 		}
 	}


### PR DESCRIPTION
Preserves the preview button foreground color on hover so the controls remain visible in both themes, verified in the browser and by the production website build.