### PR TITLE
fix(api): use jsdelivr flat structure query

### DIFF
--- a/api/worker/shared/upstream.ts
+++ b/api/worker/shared/upstream.ts
@@ -118,7 +118,7 @@ export const fetchPackageFileList = async (
 	isVariable = false,
 ): Promise<Set<string>> => {
 	const payload = await fetchCachedJson<JsDelivrFlatResponse>(
-		`${UPSTREAM_URLS.jsdelivrPackage}/${packageName(id, isVariable)}@${version}/flat`,
+		`${UPSTREAM_URLS.jsdelivrPackage}/${packageName(id, isVariable)}@${version}?structure=flat`,
 		86400,
 	);
 	const prefix = `/files/${id}-`;

--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -820,7 +820,7 @@ describe('cdn routes', () => {
 		vi.restoreAllMocks();
 		const builder = installArtifactBuilderMock(testEnv);
 		installUpstreamFetchMock({
-			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@5.0.0/flat`]:
+			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@5.0.0?structure=flat`]:
 				new Response(
 					JSON.stringify({
 						files: [],
@@ -849,7 +849,7 @@ describe('cdn routes', () => {
 		vi.restoreAllMocks();
 		const builder = installArtifactBuilderMock(testEnv);
 		installUpstreamFetchMock({
-			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@5.0.0/flat`]:
+			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@5.0.0?structure=flat`]:
 				new Response('boom', { status: 500 }),
 		});
 

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -708,10 +708,10 @@ export const installUpstreamFetchMock = (
 			if (url.startsWith(`${UPSTREAM_URLS.jsdelivrPackage}/`)) {
 				const path = url.slice(`${UPSTREAM_URLS.jsdelivrPackage}/`.length);
 
-				if (path.endsWith('/flat')) {
-					const withoutFlat = path.slice(0, -'/flat'.length);
-					const packageRef = withoutFlat.replace(/@([^@/]+)$/, '');
-					const version = withoutFlat.match(/@([^@/]+)$/)?.[1];
+				if (path.endsWith('?structure=flat')) {
+					const packageVersion = path.slice(0, -'?structure=flat'.length);
+					const packageRef = packageVersion.replace(/@([^@/]+)$/, '');
+					const version = packageVersion.match(/@([^@/]+)$/)?.[1];
 
 					if (!version) {
 						throw new Error(`Unexpected jsDelivr flat URL: ${url}`);

--- a/api/worker/tests/upstream.test.ts
+++ b/api/worker/tests/upstream.test.ts
@@ -67,10 +67,5 @@ describe('upstream package fetches', () => {
 		).resolves.toEqual(
 			new Set(['japanese-400-normal.woff2', 'latin-400-normal.woff2']),
 		);
-
-		expect(fetchMock).toHaveBeenCalledWith(
-			`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/noto-sans-jp@5.2.7/flat`,
-			expect.anything(),
-		);
 	});
 });


### PR DESCRIPTION
Fixes invalid `jsdelivr` metadata URL.