### PR TITLE
fix(website): serialize carbon ad refreshes

### DIFF
--- a/website/app/components/CarbonAd.tsx
+++ b/website/app/components/CarbonAd.tsx
@@ -1,29 +1,91 @@
 import type { BoxProps } from '@mantine/core';
 import { Box } from '@mantine/core';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
 import Balancer from 'react-wrap-balancer';
 
 import classes from './CarbonAd.module.css';
 
-export const CarbonAd = ({ ...props }: BoxProps) => {
-	const location = useLocation();
+type CarbonWindow = typeof window & {
+	_carbonads?: { refresh(): void };
+};
 
-	// We need to rerender the carbon ad when the route changes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Selective.
+// Carbon finds its insertion point by a global script ID after its request
+// completes. Keep that host connected and never refresh it concurrently.
+let carbonHost: HTMLSpanElement | undefined;
+let isRefreshing = false;
+let refreshQueued = false;
+
+const getCarbonHost = () => {
+	carbonHost ??= document.createElement('span');
+	return carbonHost;
+};
+
+const refreshCarbonAd = () => {
+	const host = getCarbonHost();
+	isRefreshing = true;
+
+	const observer = new MutationObserver(() => {
+		if (host.querySelector('.carbon-wrap')) completeRefresh();
+	});
+	function completeRefresh() {
+		observer.disconnect();
+
+		if (refreshQueued) {
+			refreshQueued = false;
+			refreshCarbonAd();
+			return;
+		}
+
+		isRefreshing = false;
+	}
+
+	observer.observe(host, { childList: true, subtree: true });
+
+	const carbon = (window as CarbonWindow)._carbonads;
+	if (carbon) {
+		carbon.refresh();
+		return;
+	}
+
+	const script = document.createElement('script');
+	script.src =
+		'//cdn.carbonads.com/carbon.js?serve=CEAI42QN&placement=fontsourceorg';
+	script.id = '_carbonads_js';
+	script.async = true;
+	script.onerror = () => {
+		script.remove();
+		completeRefresh();
+	};
+	host.appendChild(script);
+};
+
+export const CarbonAd = ({ ...props }: BoxProps) => {
+	const { pathname } = useLocation();
+	const mountRef = useRef<HTMLSpanElement>(null);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Refresh the ad when the tab route changes.
 	useEffect(() => {
-		const script = document.createElement('script');
-		script.src =
-			'//cdn.carbonads.com/carbon.js?serve=CEAI42QN&placement=fontsourceorg';
-		script.id = '_carbonads_js';
-		script.async = true;
-		document.querySelector('#carbonads')?.replaceWith(script);
-	}, [location]);
+		const host = getCarbonHost();
+		host.hidden = false;
+		mountRef.current?.appendChild(host);
+
+		if (isRefreshing) {
+			refreshQueued = true;
+		} else {
+			refreshCarbonAd();
+		}
+
+		return () => {
+			host.hidden = true;
+			document.body.appendChild(host);
+		};
+	}, [pathname]);
 
 	return (
 		<Box className={classes.wrapper} {...props}>
 			<Balancer>
-				<span id="carbonads" />
+				<span ref={mountRef} />
 			</Balancer>
 		</Box>
 	);


### PR DESCRIPTION
Tab switching really quickly can cause some of the Carbon placements to double render badly. This serializes them so we don't have this race condition occur.