### PR TITLE
refactor(api): flatten download archive layout

### DIFF
--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -37,9 +37,7 @@ import { getObjectBytes, listKeys, putObject } from './r2';
 
 interface BuiltArtifact {
 	key: string;
-	archivePath: string;
 	bytes: Uint8Array;
-	compress: boolean;
 }
 
 /** Catches `UpstreamNotFoundError` and returns `undefined` instead of throwing. */
@@ -60,7 +58,7 @@ const ignoreUpstream404 = async <T>(
 const storeArtifact = async (
 	key: string,
 	bytes: Uint8Array,
-	item: { archivePath: string; extension: string; buildMode: string },
+	item: { extension: string },
 ): Promise<BuiltArtifact> => {
 	await putObject(key, bytes, {
 		cacheControl: IMMUTABLE_ASSET_CACHE_CONTROL,
@@ -70,9 +68,7 @@ const storeArtifact = async (
 
 	return {
 		key,
-		archivePath: item.archivePath,
 		bytes,
-		compress: item.buildMode === 'copy',
 	};
 };
 
@@ -329,10 +325,15 @@ const buildFamilyArtifacts = async (
 		// Collect every artifact for the archive, using fresh bytes first and
 		// loading existing objects from R2 when needed.
 		const allManifestEntries = [
-			...staticManifest.map((item, i) => ({ item, key: staticKeys[i] })),
+			...staticManifest.map((item, i) => ({
+				item,
+				key: staticKeys[i],
+				directory: 'static',
+			})),
 			...variableManifest.map((item, i) => ({
 				item,
 				key: variableKeys[i],
+				directory: 'variable',
 			})),
 		];
 
@@ -340,23 +341,22 @@ const buildFamilyArtifacts = async (
 
 		const allArtifactEntries = await Promise.all(
 			allManifestEntries.map(
-				limitConcur(16, async ({ item, key }) => {
+				limitConcur(16, async ({ item, key, directory }) => {
 					const built = builtByKey.get(key);
-					if (built) return built;
+					if (!built) {
+						fetchedFromR2++;
+					}
 
-					// Load the existing artifact from R2 for the zip.
-					fetchedFromR2++;
-					const bytes = await getObjectBytes(key);
+					const bytes = built?.bytes ?? (await getObjectBytes(key));
 					if (!bytes) {
 						throw new Error(`Expected artifact ${key} not found in R2`);
 					}
 
 					return {
-						key,
-						archivePath: item.archivePath,
+						archivePath: `${directory}/${tag.id}-${item.filename}`,
 						bytes,
 						compress: item.buildMode === 'copy',
-					} as BuiltArtifact;
+					};
 				}),
 			),
 		);

--- a/api/worker/shared/font-package-manifest.ts
+++ b/api/worker/shared/font-package-manifest.ts
@@ -7,7 +7,6 @@ type FontBuildMode = 'copy' | 'convert-woff-to-ttf';
 interface FontEntry {
 	filename: string;
 	sourceFilename: string;
-	archivePath: string;
 	buildMode: FontBuildMode;
 	subset: string;
 	style: string;
@@ -76,10 +75,6 @@ const buildStaticPlan = (metadata: SourceFontMetadata): StaticFontEntry[] => {
 					source.format === 'ttf'
 						? source.publicFilename.replace(/\.ttf$/, '.woff')
 						: source.publicFilename,
-				archivePath:
-					source.format === 'ttf'
-						? `static/ttf/${source.filename}`
-						: `static/webfonts/${source.filename}`,
 				buildMode:
 					source.format === 'ttf' ? 'convert-woff-to-ttf' : ('copy' as const),
 				subset: face.subset,
@@ -113,7 +108,6 @@ const buildVariablePlan = (
 			return {
 				filename: source.publicFilename,
 				sourceFilename: source.publicFilename,
-				archivePath: `variable/webfonts/${source.filename}`,
 				buildMode: 'copy' as const,
 				subset: face.subset,
 				axisKey,

--- a/api/worker/tests/__snapshots__/cdn.test.ts.snap
+++ b/api/worker/tests/__snapshots__/cdn.test.ts.snap
@@ -29,9 +29,9 @@ exports[`cdn routes > public asset outputs > serves zip archives with correct fi
   "abel": {
     "files": [
       "LICENSE",
-      "static/ttf/abel-latin-400-normal.ttf",
-      "static/webfonts/abel-latin-400-normal.woff",
-      "static/webfonts/abel-latin-400-normal.woff2",
+      "static/abel-latin-400-normal.ttf",
+      "static/abel-latin-400-normal.woff",
+      "static/abel-latin-400-normal.woff2",
     ],
     "headers": {
       "cacheControl": "public, max-age=31536000, immutable",
@@ -47,11 +47,11 @@ exports[`cdn routes > public asset outputs > serves zip archives with correct fi
   "recursive": {
     "files": [
       "LICENSE",
-      "static/ttf/recursive-latin-400-normal.ttf",
-      "static/webfonts/recursive-latin-400-normal.woff",
-      "static/webfonts/recursive-latin-400-normal.woff2",
-      "variable/webfonts/recursive-latin-full-normal.woff2",
-      "variable/webfonts/recursive-latin-mono-normal.woff2",
+      "static/recursive-latin-400-normal.ttf",
+      "static/recursive-latin-400-normal.woff",
+      "static/recursive-latin-400-normal.woff2",
+      "variable/recursive-latin-full-normal.woff2",
+      "variable/recursive-latin-mono-normal.woff2",
     ],
     "headers": {
       "cacheControl": "public, max-age=31536000, immutable",

--- a/api/worker/tests/__snapshots__/manifest.test.ts.snap
+++ b/api/worker/tests/__snapshots__/manifest.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`generates static manifest entries 1`] = `
 [
   {
-    "archivePath": "static/webfonts/abel-latin-400-normal.woff2",
     "buildMode": "copy",
     "extension": "woff2",
     "filename": "latin-400-normal.woff2",
@@ -13,7 +12,6 @@ exports[`generates static manifest entries 1`] = `
     "weight": 400,
   },
   {
-    "archivePath": "static/webfonts/abel-latin-400-normal.woff",
     "buildMode": "copy",
     "extension": "woff",
     "filename": "latin-400-normal.woff",
@@ -23,7 +21,6 @@ exports[`generates static manifest entries 1`] = `
     "weight": 400,
   },
   {
-    "archivePath": "static/ttf/abel-latin-400-normal.ttf",
     "buildMode": "convert-woff-to-ttf",
     "extension": "ttf",
     "filename": "latin-400-normal.ttf",
@@ -38,7 +35,6 @@ exports[`generates static manifest entries 1`] = `
 exports[`generates variable manifest entries 1`] = `
 [
   {
-    "archivePath": "variable/webfonts/recursive-latin-mono-normal.woff2",
     "axisKey": "MONO",
     "buildMode": "copy",
     "extension": "woff2",
@@ -48,7 +44,6 @@ exports[`generates variable manifest entries 1`] = `
     "subset": "latin",
   },
   {
-    "archivePath": "variable/webfonts/recursive-latin-full-normal.woff2",
     "axisKey": "full",
     "buildMode": "copy",
     "extension": "woff2",

--- a/api/worker/tests/artifacts.test.ts
+++ b/api/worker/tests/artifacts.test.ts
@@ -260,26 +260,26 @@ describe('container artifact builder', () => {
 		const archive = unzipSync(zipPut?.[1] as Uint8Array);
 		expect(Object.keys(archive).sort()).toEqual([
 			'LICENSE',
-			'static/ttf/familypack-latin-400-normal.ttf',
-			'static/ttf/familypack-latin-700-normal.ttf',
-			'static/ttf/familypack-latin-ext-400-normal.ttf',
-			'static/ttf/familypack-latin-ext-700-normal.ttf',
-			'static/webfonts/familypack-latin-400-normal.woff',
-			'static/webfonts/familypack-latin-400-normal.woff2',
-			'static/webfonts/familypack-latin-700-normal.woff',
-			'static/webfonts/familypack-latin-700-normal.woff2',
-			'static/webfonts/familypack-latin-ext-400-normal.woff',
-			'static/webfonts/familypack-latin-ext-400-normal.woff2',
-			'static/webfonts/familypack-latin-ext-700-normal.woff',
-			'static/webfonts/familypack-latin-ext-700-normal.woff2',
+			'static/familypack-latin-400-normal.ttf',
+			'static/familypack-latin-400-normal.woff',
+			'static/familypack-latin-400-normal.woff2',
+			'static/familypack-latin-700-normal.ttf',
+			'static/familypack-latin-700-normal.woff',
+			'static/familypack-latin-700-normal.woff2',
+			'static/familypack-latin-ext-400-normal.ttf',
+			'static/familypack-latin-ext-400-normal.woff',
+			'static/familypack-latin-ext-400-normal.woff2',
+			'static/familypack-latin-ext-700-normal.ttf',
+			'static/familypack-latin-ext-700-normal.woff',
+			'static/familypack-latin-ext-700-normal.woff2',
 		]);
-		expect(
-			archive['static/webfonts/familypack-latin-400-normal.woff2'],
-		).toEqual(staticWoff2Bytes);
-		expect(
-			archive['static/webfonts/familypack-latin-ext-700-normal.woff'],
-		).toEqual(staticWoffBytes);
-		expect(archive['static/ttf/familypack-latin-700-normal.ttf']).toEqual(
+		expect(archive['static/familypack-latin-400-normal.woff2']).toEqual(
+			staticWoff2Bytes,
+		);
+		expect(archive['static/familypack-latin-ext-700-normal.woff']).toEqual(
+			staticWoffBytes,
+		);
+		expect(archive['static/familypack-latin-700-normal.ttf']).toEqual(
 			staticTtfBytes,
 		);
 	});
@@ -324,12 +324,12 @@ describe('container artifact builder', () => {
 		const archive = unzipSync(zipPut?.[1] as Uint8Array);
 		expect(Object.keys(archive).sort()).toEqual([
 			'LICENSE',
-			'static/ttf/familypack-latin-400-normal.ttf',
-			'static/ttf/familypack-latin-700-normal.ttf',
-			'static/webfonts/familypack-latin-400-normal.woff',
-			'static/webfonts/familypack-latin-400-normal.woff2',
-			'static/webfonts/familypack-latin-700-normal.woff',
-			'static/webfonts/familypack-latin-700-normal.woff2',
+			'static/familypack-latin-400-normal.ttf',
+			'static/familypack-latin-400-normal.woff',
+			'static/familypack-latin-400-normal.woff2',
+			'static/familypack-latin-700-normal.ttf',
+			'static/familypack-latin-700-normal.woff',
+			'static/familypack-latin-700-normal.woff2',
 		]);
 	});
 });

--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -198,24 +198,20 @@ describe('cdn routes', () => {
 			await testEnv.FONTS.put(
 				'recursive@5.0.0/download.zip',
 				zipSync({
-					'static/webfonts/recursive-latin-400-normal.woff2': staticWoff2Bytes,
-					'static/webfonts/recursive-latin-400-normal.woff': new Uint8Array([
-						1,
-					]),
-					'static/ttf/recursive-latin-400-normal.ttf': new Uint8Array([2]),
-					'variable/webfonts/recursive-latin-mono-normal.woff2':
-						variableWoff2Bytes,
-					'variable/webfonts/recursive-latin-full-normal.woff2':
-						variableWoff2Bytes,
+					'static/recursive-latin-400-normal.woff2': staticWoff2Bytes,
+					'static/recursive-latin-400-normal.woff': new Uint8Array([1]),
+					'static/recursive-latin-400-normal.ttf': new Uint8Array([2]),
+					'variable/recursive-latin-mono-normal.woff2': variableWoff2Bytes,
+					'variable/recursive-latin-full-normal.woff2': variableWoff2Bytes,
 					LICENSE: new TextEncoder().encode('Example License'),
 				}),
 			);
 			await testEnv.FONTS.put(
 				'abel@5.0.0/download.zip',
 				zipSync({
-					'static/webfonts/abel-latin-400-normal.woff2': staticWoff2Bytes,
-					'static/webfonts/abel-latin-400-normal.woff': new Uint8Array([1]),
-					'static/ttf/abel-latin-400-normal.ttf': new Uint8Array([2]),
+					'static/abel-latin-400-normal.woff2': staticWoff2Bytes,
+					'static/abel-latin-400-normal.woff': new Uint8Array([1]),
+					'static/abel-latin-400-normal.ttf': new Uint8Array([2]),
 					LICENSE: new TextEncoder().encode('Example License'),
 				}),
 			);
@@ -299,12 +295,12 @@ describe('cdn routes', () => {
 			expect(builder.calls).toHaveBeenCalledTimes(1);
 			expect(Object.keys(archive)).toEqual(
 				expect.arrayContaining([
-					'static/webfonts/slanted-latin-400-normal.woff2',
-					'variable/webfonts/slanted-latin-mono-normal.woff2',
-					'variable/webfonts/slanted-latin-wght-normal.woff2',
-					'variable/webfonts/slanted-latin-slnt-normal.woff2',
-					'variable/webfonts/slanted-latin-standard-normal.woff2',
-					'variable/webfonts/slanted-latin-full-normal.woff2',
+					'static/slanted-latin-400-normal.woff2',
+					'variable/slanted-latin-mono-normal.woff2',
+					'variable/slanted-latin-wght-normal.woff2',
+					'variable/slanted-latin-slnt-normal.woff2',
+					'variable/slanted-latin-standard-normal.woff2',
+					'variable/slanted-latin-full-normal.woff2',
 					'LICENSE',
 				]),
 			);
@@ -420,23 +416,23 @@ describe('cdn routes', () => {
 		const files = Object.keys(archive).sort();
 		expect(files).toEqual([
 			'LICENSE',
-			'static/ttf/recursive-latin-400-normal.ttf',
-			'static/webfonts/recursive-latin-400-normal.woff',
-			'static/webfonts/recursive-latin-400-normal.woff2',
-			'variable/webfonts/recursive-latin-full-normal.woff2',
-			'variable/webfonts/recursive-latin-mono-normal.woff2',
+			'static/recursive-latin-400-normal.ttf',
+			'static/recursive-latin-400-normal.woff',
+			'static/recursive-latin-400-normal.woff2',
+			'variable/recursive-latin-full-normal.woff2',
+			'variable/recursive-latin-mono-normal.woff2',
 		]);
 
 		// Verify binary sizes match the fixtures
+		expect(archive['static/recursive-latin-400-normal.woff2'].byteLength).toBe(
+			staticWoff2Bytes.byteLength,
+		);
 		expect(
-			archive['static/webfonts/recursive-latin-400-normal.woff2'].byteLength,
-		).toBe(staticWoff2Bytes.byteLength);
-		expect(
-			archive['variable/webfonts/recursive-latin-full-normal.woff2'].byteLength,
+			archive['variable/recursive-latin-full-normal.woff2'].byteLength,
 		).toBe(variableWoff2Bytes.byteLength);
-		expect(
-			archive['static/ttf/recursive-latin-400-normal.ttf'].byteLength,
-		).toBe(staticTtfBytes.byteLength);
+		expect(archive['static/recursive-latin-400-normal.ttf'].byteLength).toBe(
+			staticTtfBytes.byteLength,
+		);
 
 		// LICENSE should be present and non-empty
 		expect(new TextDecoder().decode(archive.LICENSE)).toBe('Example License');
@@ -535,15 +531,14 @@ describe('cdn routes', () => {
 		await testEnv.FONTS.put(
 			'recursive@5.0.0/download.zip',
 			zipSync({
-				'static/webfonts/recursive-latin-400-normal.woff2': staticWoff2Bytes,
+				'static/recursive-latin-400-normal.woff2': staticWoff2Bytes,
 				LICENSE: new TextEncoder().encode('static latest'),
 			}),
 		);
 		await testEnv.FONTS.put(
 			'recursive@1.1.0/download.zip',
 			zipSync({
-				'variable/webfonts/recursive-latin-full-normal.woff2':
-					variableWoff2Bytes,
+				'variable/recursive-latin-full-normal.woff2': variableWoff2Bytes,
 				LICENSE: new TextEncoder().encode('variable latest'),
 			}),
 		);

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -438,7 +438,7 @@ const putStaticArtifacts = async (
 
 	for (const item of resolveFontPackageManifest(metadata).static) {
 		const bytes = await putStaticArtifact(env, metadata, version, item);
-		zipFiles[item.archivePath] =
+		zipFiles[`static/${metadata.id}-${item.filename}`] =
 			item.buildMode === 'copy' ? [bytes, { level: 0 }] : bytes;
 		artifactCount += 1;
 	}
@@ -457,7 +457,10 @@ const putVariableArtifacts = async (
 
 	for (const item of resolveFontPackageManifest(metadata, axes).variable) {
 		const bytes = await putVariableArtifact(env, metadata, version, item);
-		zipFiles[item.archivePath] = [bytes, { level: 0 }];
+		zipFiles[`variable/${metadata.id}-${item.filename}`] = [
+			bytes,
+			{ level: 0 },
+		];
 		artifactCount += 1;
 	}
 


### PR DESCRIPTION
This flattens the download API zip structure and removes the nested `ttf/` and `webfonts/` directories. It's now a much flatter directory with all the files in one place.