### PR TITLE
feat(api): return 202 while downloads build

### DIFF
--- a/api/worker/shared/build.ts
+++ b/api/worker/shared/build.ts
@@ -30,13 +30,27 @@ export interface BuildFileRequest extends BuildVersionRequestBase {
 export type BuildVersionRequest = BuildFamilyRequest | BuildFileRequest;
 
 export interface BuildVersionResponse {
-	state: 'ready' | 'failed';
+	state: 'ready';
 	buildKey: string;
 	mode?: BuildVersionRequest['mode'];
 	artifactCount?: number;
 	durationMs?: number;
-	error?: string;
 }
+
+export interface BuildVersionFailure {
+	state: 'failed';
+	buildKey: string;
+	status: number;
+	error: string;
+}
+
+export interface BuildVersionBuilding {
+	state: 'building';
+	buildKey: string;
+}
+
+export type BuildVersionResult = BuildVersionResponse | BuildVersionFailure;
+export type BuildVersionStatus = BuildVersionBuilding | BuildVersionFailure;
 
 /**
  * Exact version cache key. This is also the named container identity, so the

--- a/api/worker/tests/__snapshots__/metadata.test.ts.snap
+++ b/api/worker/tests/__snapshots__/metadata.test.ts.snap
@@ -97,6 +97,20 @@ exports[`metadata routes > matches public metadata responses 1`] = `
     },
     "status": 200,
   },
+  "download": {
+    "body": {
+      "state": "building",
+      "version": "5.0.0",
+    },
+    "headers": {
+      "cacheControl": "no-store",
+      "cdnCacheControl": "no-store",
+      "contentType": "application/json",
+      "edgeCacheControl": "no-store",
+    },
+    "retryAfter": "3",
+    "status": 202,
+  },
   "font": {
     "body": {
       "category": "sans-serif",
@@ -157,18 +171,6 @@ exports[`metadata routes > matches public metadata responses 1`] = `
       "contentType": "application/json",
       "edgeCacheControl": "public, max-age=10800, stale-while-revalidate=86400, stale-if-error=86400",
       "etag": "<etag>",
-    },
-    "status": 200,
-  },
-  "redirect": {
-    "headers": {
-      "cacheControl": "public, max-age=86400, stale-while-revalidate=604800",
-      "cdnCacheControl": "public, max-age=86400, stale-while-revalidate=604800",
-      "contentDisposition": "attachment; filename="abel_5.0.0.zip"",
-      "contentType": "application/zip",
-      "edgeCacheControl": "public, max-age=900, stale-if-error=604800",
-      "etag": "<etag>",
-      "lastModified": "<last-modified>",
     },
     "status": 200,
   },

--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -602,6 +602,69 @@ describe('cdn routes', () => {
 		expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
 	});
 
+	it('deduplicates cold download builds and returns 202 until the archive is ready', async () => {
+		const builder = installArtifactBuilderMock(testEnv, { buildDelayMs: 25 });
+		const url = 'https://fontsource.test/v1/download/abel';
+
+		const [first, second] = await Promise.all([dispatch(url), dispatch(url)]);
+		const [firstBody, secondBody] = await Promise.all([
+			first.response.json(),
+			second.response.json(),
+		]);
+		await Promise.all([first.settle(), second.settle()]);
+
+		expect(first.response.status).toBe(202);
+		expect(second.response.status).toBe(202);
+		expect(firstBody).toEqual({ state: 'building', version: '5.0.0' });
+		expect(secondBody).toEqual(firstBody);
+		expect(first.response.headers.get('Retry-After')).toBe('3');
+		expect(first.response.headers.get('Cache-Control')).toBe('no-store');
+		expect(first.response.headers.get('CDN-Cache-Control')).toBe('no-store');
+		expect(first.response.headers.get('Cloudflare-CDN-Cache-Control')).toBe(
+			'no-store',
+		);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
+
+		for (let attempts = 0; attempts < 100; attempts += 1) {
+			if (await testEnv.FONTS.head('abel@5.0.0/download.zip')) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+		expect(await testEnv.FONTS.head('abel@5.0.0/download.zip')).not.toBeNull();
+
+		const ready = await dispatch(url);
+		const archive = await ready.response.arrayBuffer();
+		await ready.settle();
+
+		expect(ready.response.status).toBe(200);
+		expect(archive.byteLength).toBeGreaterThan(0);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns the raw builder error when polling a failed download build', async () => {
+		const builder = installArtifactBuilderMock(testEnv, {
+			failBuildKeys: ['build:abel@5.0.0'],
+		});
+		const url = 'https://fontsource.test/v1/download/abel';
+
+		const accepted = await dispatch(url);
+		await accepted.response.json();
+		await accepted.settle();
+		expect(accepted.response.status).toBe(202);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const failed = await dispatch(url);
+		const body = (await failed.response.json()) as { error: string };
+		await failed.settle();
+
+		expect(failed.response.status).toBe(502);
+		expect(body.error).toBe(
+			'Bad Gateway. Artifact build failed for build:abel@5.0.0: Mocked builder failure for build:abel@5.0.0',
+		);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
+	});
+
 	it('triggers one version build on cold ttf miss and serves cached files afterwards', async () => {
 		const builder = installArtifactBuilderMock(testEnv);
 		const ttfUrl =

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -9,8 +9,11 @@ import { HTTPException } from 'hono/http-exception';
 import { vi } from 'vitest';
 import type { AxisRegistry } from '../shared/axis-registry';
 import {
+	type BuildVersionFailure,
 	type BuildVersionRequest,
 	type BuildVersionResponse,
+	type BuildVersionResult,
+	type BuildVersionStatus,
 	getBuildKey,
 	getBuildRequestKey,
 	getFamilyBuildRequestKey,
@@ -573,6 +576,8 @@ export const installArtifactBuilderMock = (
 	const buildDelayMs = options.buildDelayMs ?? 0;
 	const calls = vi.fn<(request: BuildVersionRequest) => void>();
 	const activeBuilds = new Map<string, Promise<BuildVersionResponse>>();
+	const asyncBuilds = new Map<string, Promise<BuildVersionResult>>();
+	const failedBuilds = new Map<string, BuildVersionFailure>();
 
 	const ensureBuilt = async (
 		request: BuildVersionRequest,
@@ -642,27 +647,62 @@ export const installArtifactBuilderMock = (
 		activeBuilds.set(requestKey, buildPromise);
 		return await buildPromise;
 	};
+	const buildVersion = async (
+		request: BuildVersionRequest,
+	): Promise<BuildVersionResult> => {
+		try {
+			return await ensureBuilt(request);
+		} catch (error) {
+			const buildKey = getBuildKey(request.tag);
+			return {
+				state: 'failed',
+				buildKey,
+				status: error instanceof HTTPException ? error.status : 502,
+				error:
+					error instanceof HTTPException
+						? error.message
+						: `Bad Gateway. Artifact build failed for ${buildKey}: ${error instanceof Error ? error.message : String(error)}`,
+			};
+		}
+	};
+	const startBuild = async (
+		request: BuildVersionRequest,
+	): Promise<BuildVersionStatus> => {
+		const requestKey = getBuildRequestKey(request);
+		const failed = failedBuilds.get(requestKey);
+
+		if (failed) {
+			failedBuilds.delete(requestKey);
+			return failed;
+		}
+
+		if (asyncBuilds.has(requestKey)) {
+			return {
+				state: 'building',
+				buildKey: getBuildKey(request.tag),
+			};
+		}
+
+		const build = buildVersion(request).then((result) => {
+			asyncBuilds.delete(requestKey);
+			if (result.state === 'failed') {
+				failedBuilds.set(requestKey, result);
+			}
+			return result;
+		});
+		asyncBuilds.set(requestKey, build);
+
+		return {
+			state: 'building',
+			buildKey: getBuildKey(request.tag),
+		};
+	};
 
 	const artifactBuilder = {
-		getByName(name: string) {
+		getByName() {
 			return {
-				async buildVersion(
-					payload: BuildVersionRequest,
-				): Promise<BuildVersionResponse> {
-					try {
-						return await ensureBuilt(payload);
-					} catch (error) {
-						if (error instanceof HTTPException) {
-							throw error;
-						}
-
-						throw new Error(
-							error instanceof Error
-								? error.message
-								: `Mocked builder failure for ${name}: ${String(error)}`,
-						);
-					}
-				},
+				buildVersion,
+				startBuild,
 			} as unknown as ReturnType<Env['ARTIFACT_BUILDER']['getByName']>;
 		},
 	};

--- a/api/worker/tests/metadata.test.ts
+++ b/api/worker/tests/metadata.test.ts
@@ -52,12 +52,13 @@ describe('metadata routes', () => {
 	};
 
 	it('matches public metadata responses', async () => {
-		const redirectResult = await dispatch(
+		const downloadResult = await dispatch(
 			new Request('https://fontsource.test/v1/download/abel', {
 				redirect: 'manual',
 			}),
 		);
-		await redirectResult.settle();
+		const downloadBody = await downloadResult.response.json();
+		await downloadResult.settle();
 
 		expect({
 			fontlist: await jsonSnapshot('https://fontsource.test/fontlist'),
@@ -72,9 +73,11 @@ describe('metadata routes', () => {
 				'https://fontsource.test/v1/version/recursive',
 			),
 			stats: await jsonSnapshot('https://fontsource.test/v1/stats/recursive'),
-			redirect: {
-				status: redirectResult.response.status,
-				headers: serializeHeaders(redirectResult.response),
+			download: {
+				status: downloadResult.response.status,
+				headers: serializeHeaders(downloadResult.response),
+				retryAfter: downloadResult.response.headers.get('Retry-After'),
+				body: downloadBody,
 			},
 		}).toMatchSnapshot();
 	});
@@ -107,28 +110,20 @@ describe('metadata routes', () => {
 		);
 	});
 
-	it('serves canonical download requests directly', async () => {
+	it('accepts cold canonical download requests without redirecting', async () => {
 		const { response, settle } = await dispatch(
 			new Request('https://fontsource.test/v1/download/abel', {
 				redirect: 'manual',
 			}),
 		);
+		const body = await response.json();
 		await settle();
 
-		expect(response.status).toBe(200);
+		expect(response.status).toBe(202);
 		expect(response.headers.get('Location')).toBeNull();
-		expect(response.headers.get('Content-Disposition')).toBe(
-			'attachment; filename="abel_5.0.0.zip"',
-		);
-		expect(response.headers.get('Cache-Control')).toBe(
-			'public, max-age=86400, stale-while-revalidate=604800',
-		);
-		expect(response.headers.get('CDN-Cache-Control')).toBe(
-			'public, max-age=86400, stale-while-revalidate=604800',
-		);
-		expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe(
-			'public, max-age=900, stale-if-error=604800',
-		);
+		expect(response.headers.get('Retry-After')).toBe('3');
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		expect(body).toEqual({ state: 'building', version: '5.0.0' });
 	});
 
 	it('redirects legacy font download aliases to jsDelivr like the public API', async () => {

--- a/api/worker/worker/src/container/binding.ts
+++ b/api/worker/worker/src/container/binding.ts
@@ -1,12 +1,16 @@
 import { Container } from '@cloudflare/containers';
-import { HTTPException } from 'hono/http-exception';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import type {
+	BuildVersionFailure,
 	BuildVersionRequest,
 	BuildVersionResponse,
+	BuildVersionResult,
+	BuildVersionStatus,
 } from '../../../shared/build';
+import { getBuildKey, getBuildRequestKey } from '../../../shared/build';
 import { getBuilderStartupEnv } from '../env';
+
+const BUILD_TIMEOUT_MS = 10 * 60_000;
 
 export const readBuildErrorMessage = async (
 	response: Response,
@@ -37,44 +41,86 @@ export class ArtifactBuilder extends Container<Env> {
 	defaultPort = 3000;
 	sleepAfter = '2m';
 	enableInternet = true;
+	private activeBuilds = new Map<string, Promise<BuildVersionResult>>();
+	private failedBuilds = new Map<string, BuildVersionFailure>();
 
 	async buildVersion(
 		request: BuildVersionRequest,
-	): Promise<BuildVersionResponse> {
-		// Pass only the R2 credentials/config that the container needs to upload
-		// the built artifacts directly.
-		await this.startAndWaitForPorts({
-			startOptions: {
-				envVars: getBuilderStartupEnv(this.env),
-			},
-		});
-
-		const response = await this.containerFetch(
-			`http://localhost:${this.defaultPort}/build-version`,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
+	): Promise<BuildVersionResult> {
+		try {
+			// Pass only the R2 credentials/config that the container needs to upload
+			// the built artifacts directly.
+			await this.startAndWaitForPorts({
+				startOptions: {
+					envVars: getBuilderStartupEnv(this.env),
 				},
-				body: JSON.stringify(request),
-				signal: AbortSignal.timeout(120_000),
-			},
-		);
-
-		if (!response.ok) {
-			throw new HTTPException(response.status as ContentfulStatusCode, {
-				message: await readBuildErrorMessage(response),
 			});
-		}
 
-		const payload = (await response.json()) as BuildVersionResponse;
-
-		if (payload.state !== 'ready') {
-			throw new Error(
-				payload.error ?? 'Artifact build did not complete successfully.',
+			const response = await this.containerFetch(
+				`http://localhost:${this.defaultPort}/build-version`,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify(request),
+					signal: AbortSignal.timeout(BUILD_TIMEOUT_MS),
+				},
 			);
+
+			if (!response.ok) {
+				return {
+					state: 'failed',
+					buildKey: getBuildKey(request.tag),
+					status: response.status,
+					error: await readBuildErrorMessage(response),
+				};
+			}
+
+			return (await response.json()) as BuildVersionResponse;
+		} catch (error) {
+			const buildKey = getBuildKey(request.tag);
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				state: 'failed',
+				buildKey,
+				status: 502,
+				error: `Bad Gateway. Artifact build failed for ${buildKey}: ${message}`,
+			};
+		}
+	}
+
+	async startBuild(request: BuildVersionRequest): Promise<BuildVersionStatus> {
+		const requestKey = getBuildRequestKey(request);
+		const failed = this.failedBuilds.get(requestKey);
+
+		if (failed) {
+			// Report the failure once; a later request can retry the cold build.
+			this.failedBuilds.delete(requestKey);
+			return failed;
 		}
 
-		return payload;
+		if (this.activeBuilds.has(requestKey)) {
+			return {
+				state: 'building',
+				buildKey: getBuildKey(request.tag),
+			};
+		}
+
+		// The pending container I/O keeps the Durable Object active after this RPC
+		// returns; the map makes later RPCs join the same logical build.
+		const build = this.buildVersion(request).then((result) => {
+			this.activeBuilds.delete(requestKey);
+			if (result.state === 'failed') {
+				this.failedBuilds.set(requestKey, result);
+			}
+			return result;
+		});
+		this.activeBuilds.set(requestKey, build);
+
+		return {
+			state: 'building',
+			buildKey: getBuildKey(request.tag),
+		};
 	}
 }

--- a/api/worker/worker/src/container/client.ts
+++ b/api/worker/worker/src/container/client.ts
@@ -1,10 +1,14 @@
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import {
 	type BuildFileRequest,
+	type BuildVersionFailure,
 	type BuildVersionRequest,
 	type BuildVersionRequestBase,
 	type BuildVersionResponse,
+	type BuildVersionResult,
+	type BuildVersionStatus,
 	getBuildKey,
 } from '../../../shared/build';
 import type { AppEnv } from '../env';
@@ -15,23 +19,31 @@ const buildVersion = async (
 	requestBody: BuildVersionRequest,
 ): Promise<BuildVersionResponse> => {
 	const buildKey = getBuildKey(requestBody.tag);
+	let result: BuildVersionResult;
+
 	try {
-		return await c.env.ARTIFACT_BUILDER.getByName(buildKey).buildVersion(
-			requestBody,
-		);
+		result =
+			await c.env.ARTIFACT_BUILDER.getByName(buildKey).buildVersion(
+				requestBody,
+			);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-
-		if (error instanceof HTTPException) {
-			throw new HTTPException(error.status, {
-				message,
-			});
-		}
-
 		throw new HTTPException(502, {
-			message: `Bad Gateway. Artifact build failed for ${buildKey}: ${message}`,
+			message: `Artifact builder request failed (${buildKey}): ${message}`,
 		});
 	}
+
+	if (result.state === 'failed') {
+		return throwBuildFailure(result);
+	}
+
+	return result;
+};
+
+const throwBuildFailure = (failure: BuildVersionFailure): never => {
+	throw new HTTPException(failure.status as ContentfulStatusCode, {
+		message: failure.error,
+	});
 };
 
 const buildRequestBase = (
@@ -57,6 +69,34 @@ export const ensureVersionBuilt = async (
 		...buildRequestBase(resolved),
 		mode: 'family',
 	});
+
+export const startVersionBuild = async (
+	c: Context<AppEnv>,
+	resolved: ResolvedFontRequest,
+): Promise<Exclude<BuildVersionStatus, BuildVersionFailure>> => {
+	const request = {
+		...buildRequestBase(resolved),
+		mode: 'family',
+	} satisfies BuildVersionRequest;
+	const buildKey = getBuildKey(request.tag);
+	let result: BuildVersionStatus;
+
+	try {
+		result =
+			await c.env.ARTIFACT_BUILDER.getByName(buildKey).startBuild(request);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new HTTPException(502, {
+			message: `Artifact builder request failed (${buildKey}): ${message}`,
+		});
+	}
+
+	if (result.state === 'failed') {
+		return throwBuildFailure(result);
+	}
+
+	return result;
+};
 
 export const ensureFileBuilt = async (
 	c: Context<AppEnv>,

--- a/api/worker/worker/src/features/cdn/handler.ts
+++ b/api/worker/worker/src/features/cdn/handler.ts
@@ -15,7 +15,11 @@ import {
 	UpstreamNotFoundError,
 } from '../../../../shared/upstream';
 import { CACHE_POLICIES, CONTENT_TYPES } from '../../constants';
-import { ensureFileBuilt, ensureVersionBuilt } from '../../container/client';
+import {
+	ensureFileBuilt,
+	ensureVersionBuilt,
+	startVersionBuild,
+} from '../../container/client';
 import type { AppEnv } from '../../env';
 import { toHttpDate } from '../../utils/cache';
 import { badGateway, badRequest, notFound } from '../../utils/errors';
@@ -255,6 +259,7 @@ export const getBinaryAsset = async (
 	c: Context<AppEnv>,
 	tag: string,
 	file: string,
+	options: { respondAsync?: boolean } = {},
 ): Promise<Response> => {
 	const contentType = getExtension(file);
 
@@ -359,7 +364,23 @@ export const getBinaryAsset = async (
 		return respond(built);
 	}
 
-	await ensureVersionBuilt(c, resolved);
+	if (options.respondAsync) {
+		const build = await startVersionBuild(c, resolved);
+		if (build.state === 'building') {
+			return Response.json(
+				{ state: 'building', version: resolved.tag.version },
+				{
+					status: 202,
+					headers: {
+						...CACHE_POLICIES.noStore,
+						'Retry-After': '3',
+					},
+				},
+			);
+		}
+	} else {
+		await ensureVersionBuilt(c, resolved);
+	}
 	const built = await readBuiltAsset();
 
 	if (!built) {

--- a/api/worker/worker/src/routes/compat.ts
+++ b/api/worker/worker/src/routes/compat.ts
@@ -12,6 +12,11 @@ import {
 
 type AppContext = Context<AppEnv>;
 
+const BuildInProgressSchema = z.object({
+	state: z.literal('building'),
+	version: z.string(),
+});
+
 export class DownloadFontRoute extends OpenAPIRoute {
 	schema = {
 		tags: ['Downloads'],
@@ -30,6 +35,10 @@ export class DownloadFontRoute extends OpenAPIRoute {
 					},
 				},
 			},
+			'202': {
+				description: 'Archive build accepted and still in progress',
+				...contentJson(BuildInProgressSchema),
+			},
 			'304': {
 				description: 'Not modified (conditional request)',
 			},
@@ -47,7 +56,9 @@ export class DownloadFontRoute extends OpenAPIRoute {
 	async handle(c: AppContext) {
 		const data = await this.getValidatedData<typeof this.schema>();
 		const { id } = data.params;
-		return getBinaryAsset(c, `${id}@latest`, 'download.zip');
+		return getBinaryAsset(c, `${id}@latest`, 'download.zip', {
+			respondAsync: true,
+		});
 	}
 }
 


### PR DESCRIPTION
Related: #1142

Returns `202 Accepted` with `Retry-After` while a cold download archive is built by the container. A named Durable Object coordinates one in-flight build per resolved font version, subsequent polls serve the R2 archive, and builder failures remain visible as raw API errors.