### PR TITLE
fix(api): remove versioned support on zip downloads

### DIFF
--- a/api/worker/container/server.ts
+++ b/api/worker/container/server.ts
@@ -1,9 +1,5 @@
 import { HTTPException } from 'hono/http-exception';
-import {
-	type BuildVersionRequest,
-	type BuildVersionTag,
-	getBuildKey,
-} from '../shared/build';
+import { type BuildVersionRequest, getBuildKey } from '../shared/build';
 import { ensureBuilt } from './src/builder';
 
 const PORT = 3000;
@@ -20,13 +16,13 @@ const resp404 = (): Response =>
 const errorStatus = (error: unknown): number =>
 	error instanceof HTTPException ? error.status : 500;
 
-const respError = (error: unknown, tag?: BuildVersionTag): Response => {
+const respError = (error: unknown, request?: BuildVersionRequest): Response => {
 	const message = error instanceof Error ? error.message : String(error);
 
 	return Response.json(
 		{
 			state: 'failed',
-			buildKey: tag ? getBuildKey(tag) : 'unknown',
+			buildKey: request ? getBuildKey(request) : 'unknown',
 			error: message,
 			builtAt: new Date().toISOString(),
 		},
@@ -53,7 +49,7 @@ Bun.serve({
 					}
 
 					console.log(
-						`[container] POST /build-version ${payload.mode} ${payload.tag.id}@${payload.tag.version}`,
+						`[container] POST /build-version ${payload.mode} ${getBuildKey(payload)}`,
 					);
 
 					const snapshot = await ensureBuilt(payload);
@@ -66,14 +62,12 @@ Bun.serve({
 				} catch (error) {
 					console.error(
 						`[container] build failed`,
-						payload
-							? `${payload.tag.id}@${payload.tag.version}`
-							: '(no payload)',
+						payload ? getBuildKey(payload) : '(no payload)',
 						error,
 					);
 
 					if (payload) {
-						return respError(error, payload.tag);
+						return respError(error, payload);
 					}
 
 					return respError(error);

--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -1,16 +1,15 @@
 import { convertFont, createFontContext } from '@fontsource-utils/core';
-import { type Zippable, zipSync } from 'fflate';
+import { zipSync } from 'fflate';
 import { HTTPException } from 'hono/http-exception';
 import limitConcur from 'limit-concur';
 import type {
-	BuildFamilyRequest,
+	BuildDownloadRequest,
 	BuildFileRequest,
 	BuildVersionRequest,
 	BuildVersionTag,
 } from '../../shared/build';
 import {
 	type FontPackageEntry,
-	type FontPackageManifest,
 	filterPublishedManifest,
 	findFontPackageEntry,
 	resolveFontPackageManifest,
@@ -19,7 +18,6 @@ import {
 } from '../../shared/font-package-manifest';
 import {
 	BINARY_CONTENT_TYPES,
-	getDownloadContentDisposition,
 	IMMUTABLE_ASSET_CACHE_CONTROL,
 } from '../../shared/http-metadata';
 import {
@@ -33,7 +31,7 @@ import {
 	fetchPackageLicenseBytes,
 	UpstreamNotFoundError,
 } from '../../shared/upstream';
-import { getObjectBytes, listKeys, putObject } from './r2';
+import { putObject } from './r2';
 
 interface BuiltArtifact {
 	key: string;
@@ -211,27 +209,22 @@ const buildVariableArtifacts = async (
 const isStaticEntry = (item: FontPackageEntry): item is StaticFontEntry =>
 	!('axisKey' in item);
 
-const getPublishedManifest = async (
-	request: BuildVersionRequest,
-): Promise<FontPackageManifest> => {
-	const [publishedStaticFiles, publishedVariableFiles] = await Promise.all([
-		fetchPackageFileList(request.tag.id, request.tag.version, false),
-		request.axes
-			? fetchPackageFileList(request.tag.id, request.tag.version, true)
-			: Promise.resolve(undefined),
-	]);
-
-	return filterPublishedManifest(
-		resolveFontPackageManifest(request.metadata, request.axes),
-		publishedStaticFiles,
-		publishedVariableFiles,
-	);
-};
-
 const buildSingleArtifact = async (
 	request: BuildFileRequest,
 ): Promise<number> => {
-	const manifest = await getPublishedManifest(request);
+	const publishedFiles = await fetchPackageFileList(
+		request.tag.id,
+		request.tag.version,
+		request.target.isVariable,
+	);
+	const manifest = filterPublishedManifest(
+		resolveFontPackageManifest(
+			request.metadata,
+			request.metadata.variable || undefined,
+		),
+		request.target.isVariable ? new Set() : publishedFiles,
+		request.target.isVariable ? publishedFiles : undefined,
+	);
 	const entry = findFontPackageEntry(manifest, request.target);
 
 	if (!entry) {
@@ -259,193 +252,86 @@ const buildSingleArtifact = async (
 	return built.length;
 };
 
-/**
- * Builds the exact-version artifact set, skipping anything that already exists
- * in R2 and creating the combined family zip only when it is missing.
- */
-const buildFamilyArtifacts = async (
-	request: BuildFamilyRequest,
+const buildDownloadArtifacts = async (
+	request: BuildDownloadRequest,
 ): Promise<number> => {
-	const { tag } = request;
-	const [manifest, existing] = await Promise.all([
-		getPublishedManifest(request),
-		listKeys(`${tag.id}@${tag.version}/`),
+	const { id } = request.metadata;
+	const axes = request.metadata.variable || undefined;
+	const variableVersion = request.variableVersion ?? request.staticVersion;
+	const staticTag = { id, version: request.staticVersion };
+	const variableTag = { id, version: variableVersion };
+	const [publishedStaticFiles, publishedVariableFiles] = await Promise.all([
+		fetchPackageFileList(id, request.staticVersion, false),
+		axes && request.variableVersion
+			? fetchPackageFileList(id, request.variableVersion, true)
+			: undefined,
 	]);
-	const { static: staticManifest, variable: variableManifest } = manifest;
-
-	console.log(
-		`[artifacts] family manifest ${tag.id}@${tag.version}: static=${staticManifest.length}, variable=${variableManifest.length}`,
-	);
-
-	// Resolve R2 keys for every individual artifact and the download zip.
-	const staticKeys = staticManifest.map((item) =>
-		getStaticAssetKey(tag.id, tag.version, item.filename),
-	);
-	const variableKeys = variableManifest.map((item) =>
-		getVariableAssetKey(tag.id, tag.version, item.filename),
-	);
-	const downloadKey = getDownloadKey(tag.id, tag.version);
-
-	const totalCount = staticKeys.length + variableKeys.length + 1;
-
-	// If every artifact exists already, no build work is needed.
-	if (
-		existing.has(downloadKey) &&
-		staticKeys.every((k) => existing.has(k)) &&
-		variableKeys.every((k) => existing.has(k))
-	) {
-		console.log(
-			`[artifacts] family build skipped: all ${totalCount} artifacts already exist in R2`,
+	const { static: staticManifest, variable: variableManifest } =
+		filterPublishedManifest(
+			resolveFontPackageManifest(request.metadata, axes),
+			publishedStaticFiles,
+			publishedVariableFiles,
 		);
-		return totalCount;
+
+	if (staticManifest.length === 0 && variableManifest.length === 0) {
+		throw new Error(
+			`No artifacts published for ${id}@${request.staticVersion}`,
+		);
 	}
 
-	// Build only the missing individual artifacts.
-	const missingStatic = staticManifest.filter(
-		(_, i) => !existing.has(staticKeys[i]),
+	const [staticArtifacts, variableArtifacts, license] = await Promise.all([
+		buildStaticArtifacts(staticTag, staticManifest),
+		buildVariableArtifacts(variableTag, variableManifest),
+		fetchPackageLicenseBytes(id, request.staticVersion, false),
+	]);
+	const artifacts = [...staticArtifacts, ...variableArtifacts];
+	const builtByKey = new Map(
+		artifacts.map((artifact) => [artifact.key, artifact.bytes]),
 	);
-	const missingVariable = variableManifest.filter(
-		(_, i) => !existing.has(variableKeys[i]),
-	);
-
-	console.log(
-		`[artifacts] missing: ${missingStatic.length} static, ${missingVariable.length} variable, zip=${!existing.has(downloadKey) ? 'yes' : 'no'}`,
-	);
-	const zipMissing = !existing.has(downloadKey);
-	const allManifestEntries = [
-		...staticManifest.map((item, i) => ({
+	const archiveEntries = [
+		...staticManifest.map((item) => ({
 			item,
-			key: staticKeys[i],
+			key: getStaticAssetKey(id, request.staticVersion, item.filename),
 			directory: 'static',
 		})),
-		...variableManifest.map((item, i) => ({
+		...variableManifest.map((item) => ({
 			item,
-			key: variableKeys[i],
+			key: getVariableAssetKey(id, variableVersion, item.filename),
 			directory: 'variable',
 		})),
-	];
-	const storedBytesPromise = zipMissing
-		? Promise.all(
-				allManifestEntries
-					.filter(({ key }) => existing.has(key))
-					.map(
-						limitConcur(16, async ({ key }) => {
-							const bytes = await getObjectBytes(key);
-							if (!bytes) {
-								throw new Error(`Expected artifact ${key} not found in R2`);
-							}
-							return [key, bytes] as const;
-						}),
-					),
-			).then((entries) => new Map(entries))
-		: undefined;
-	const licensePromise = zipMissing
-		? (async () =>
-				(staticManifest.length > 0
-					? await ignoreUpstream404(
-							fetchPackageLicenseBytes(tag.id, tag.version, false),
-						)
-					: undefined) ??
-				(variableManifest.length > 0
-					? await ignoreUpstream404(
-							fetchPackageLicenseBytes(tag.id, tag.version, true),
-						)
-					: undefined))()
-		: undefined;
-
-	const [maybeStaticArtifacts, maybeVariableArtifacts, storedBytes, license] =
-		await Promise.all([
-			ignoreUpstream404(buildStaticArtifacts(tag, missingStatic)),
-			ignoreUpstream404(buildVariableArtifacts(tag, missingVariable)),
-			storedBytesPromise,
-			licensePromise,
-		]);
-	const newArtifacts = [
-		...(maybeStaticArtifacts ?? []),
-		...(maybeVariableArtifacts ?? []),
-	];
-
-	console.log(`[artifacts] built ${newArtifacts.length} new artifacts`);
-
-	if (
-		newArtifacts.length === 0 &&
-		missingStatic.length + missingVariable.length > 0
-	) {
-		throw new Error(`No artifacts published for ${tag.id}@${tag.version}`);
-	}
-	const individualUploads = storeArtifacts(newArtifacts).then(
-		() => ({ ok: true as const }),
-		(error: unknown) => ({ ok: false as const, error }),
-	);
-	let archive: Uint8Array | undefined;
-
-	// Assemble the download zip while individual artifact uploads are running.
-	if (zipMissing) {
-		console.log(`[artifacts] assembling download zip`);
-
-		// Index freshly-built bytes by R2 key for quick lookup.
-		const builtByKey = new Map(
-			newArtifacts.map((artifact) => [artifact.key, artifact] as const),
-		);
-
-		const allArtifactEntries = allManifestEntries.map(
-			({ item, key, directory }) => {
-				const bytes = builtByKey.get(key)?.bytes ?? storedBytes?.get(key);
-				if (!bytes) {
-					throw new Error(`Expected artifact ${key} not found in R2`);
-				}
-
-				return {
-					archivePath: `${directory}/${tag.id}-${item.filename}`,
-					bytes,
-					compress: item.buildMode === 'copy',
-				};
-			},
-		);
-
-		if (storedBytes && storedBytes.size > 0) {
-			console.log(
-				`[artifacts] fetched ${storedBytes.size} existing artifacts from R2 for zip`,
-			);
+	].map(({ item, key, directory }) => {
+		const bytes = builtByKey.get(key);
+		if (!bytes) {
+			throw new Error(`Expected artifact ${key} was not built`);
 		}
 
-		if (allArtifactEntries.length === 0) {
-			throw new Error(`No artifacts for zip: ${tag.id}@${tag.version}`);
-		}
-
-		if (!license) {
-			throw new Error(`Missing LICENSE for ${tag.id}@${tag.version}`);
-		}
-
-		const archiveFiles: Zippable = Object.fromEntries([
-			...allArtifactEntries.map((artifact) => [
-				artifact.archivePath,
-				artifact.compress ? [artifact.bytes, { level: 0 }] : artifact.bytes,
+		return {
+			path: `${directory}/${id}-${item.filename}`,
+			bytes,
+			compress: item.buildMode === 'copy',
+		};
+	});
+	const archive = zipSync(
+		Object.fromEntries([
+			...archiveEntries.map((entry) => [
+				entry.path,
+				entry.compress ? [entry.bytes, { level: 0 }] : entry.bytes,
 			]),
 			['LICENSE', license],
-		]);
-		archive = zipSync(archiveFiles);
-	}
+		]),
+	);
 
-	const uploadResult = await individualUploads;
-	if (!uploadResult.ok) {
-		throw uploadResult.error;
-	}
-
-	if (archive) {
-		// A stored zip is the completion marker for the whole family build.
-		await putObject(downloadKey, archive, {
+	await storeArtifacts(artifacts);
+	await putObject(
+		getDownloadKey(id, request.staticVersion, request.variableVersion),
+		archive,
+		{
 			cacheControl: IMMUTABLE_ASSET_CACHE_CONTROL,
-			contentDisposition: getDownloadContentDisposition(tag.id, tag.version),
 			contentType: BINARY_CONTENT_TYPES.zip,
-		});
+		},
+	);
 
-		console.log(
-			`[artifacts] zip uploaded (${allManifestEntries.length} entries + LICENSE)`,
-		);
-	}
-
-	return totalCount;
+	return artifacts.length + 1;
 };
 
 export const buildArtifacts = async (
@@ -453,4 +339,4 @@ export const buildArtifacts = async (
 ): Promise<number> =>
 	request.mode === 'file'
 		? await buildSingleArtifact(request)
-		: await buildFamilyArtifacts(request);
+		: await buildDownloadArtifacts(request);

--- a/api/worker/container/src/builder.ts
+++ b/api/worker/container/src/builder.ts
@@ -2,36 +2,19 @@ import type {
 	BuildVersionRequest,
 	BuildVersionResponse,
 } from '../../shared/build';
-import {
-	getBuildKey,
-	getBuildRequestKey,
-	getFamilyBuildRequestKey,
-} from '../../shared/build';
+import { getBuildKey, getBuildRequestKey } from '../../shared/build';
 import { buildArtifacts } from './artifacts';
 
 type BuildSnapshot = BuildVersionResponse & {
 	builtAt: string;
 };
 
-/**
- * Each container is mapped to a specific font/version. Family builds can satisfy
- * file requests, but family requests must not join a narrower file build.
- */
 const activeBuilds = new Map<string, Promise<BuildSnapshot>>();
 
 export const ensureBuilt = async (
 	request: BuildVersionRequest,
 ): Promise<BuildSnapshot> => {
-	const buildKey = getBuildKey(request.tag);
-	const activeFamilyBuild = activeBuilds.get(
-		getFamilyBuildRequestKey(request.tag),
-	);
-
-	if (request.mode === 'file' && activeFamilyBuild) {
-		console.log(`[builder] joined active family build for ${buildKey}`);
-		return await activeFamilyBuild;
-	}
-
+	const buildKey = getBuildKey(request);
 	const requestKey = getBuildRequestKey(request);
 	const activeBuild = activeBuilds.get(requestKey);
 
@@ -58,7 +41,7 @@ const executeBuild = async (
 	request: BuildVersionRequest,
 ): Promise<BuildSnapshot> => {
 	const startedAt = Date.now();
-	const buildKey = getBuildKey(request.tag);
+	const buildKey = getBuildKey(request);
 	const artifactCount = await buildArtifacts(request);
 	const durationMs = Date.now() - startedAt;
 

--- a/api/worker/container/src/r2.ts
+++ b/api/worker/container/src/r2.ts
@@ -29,7 +29,6 @@ const buildObjectUrl = (key: string): string =>
 
 interface PutObjectMetadata {
 	cacheControl?: string;
-	contentDisposition?: string;
 	contentType?: string;
 }
 
@@ -47,10 +46,6 @@ export const putObject = async (
 
 	if (metadata.cacheControl) {
 		headers['Cache-Control'] = metadata.cacheControl;
-	}
-
-	if (metadata.contentDisposition) {
-		headers['Content-Disposition'] = metadata.contentDisposition;
 	}
 
 	if (metadata.contentType) {
@@ -71,71 +66,4 @@ export const putObject = async (
 	}
 
 	console.log(`[r2] PUT ${key} (${body.byteLength} bytes)`);
-};
-
-/**
- * Lists all object keys under a given prefix via S3 ListObjectsV2.
- * Handles pagination automatically.
- */
-export const listKeys = async (prefix: string): Promise<Set<string>> => {
-	const keys = new Set<string>();
-	let token: string | undefined;
-	let pages = 0;
-
-	do {
-		const url = new URL(`${client.endpoint}/${client.bucket}`);
-		url.searchParams.set('list-type', '2');
-		url.searchParams.set('prefix', prefix);
-		if (token) {
-			url.searchParams.set('continuation-token', token);
-		}
-
-		const response = await client.client.fetch(url.toString());
-		if (!response.ok) {
-			const text = await response.text();
-			throw new Error(
-				`Failed to list R2 objects for prefix "${prefix}": ${response.status} ${text || response.statusText}`,
-			);
-		}
-
-		pages++;
-		const xml = await response.text();
-		for (const [, key] of xml.matchAll(/<Key>([^<]+)<\/Key>/g)) {
-			keys.add(key);
-		}
-
-		token = /<IsTruncated>true<\/IsTruncated>/.test(xml)
-			? xml.match(
-					/<NextContinuationToken>([^<]+)<\/NextContinuationToken>/,
-				)?.[1]
-			: undefined;
-	} while (token);
-
-	console.log(
-		`[r2] LIST prefix="${prefix}" found ${keys.size} keys (${pages} page${pages !== 1 ? 's' : ''})`,
-	);
-
-	return keys;
-};
-
-/**
- * Downloads an object's bytes from R2. Returns null when the key does not exist.
- */
-export const getObjectBytes = async (
-	key: string,
-): Promise<Uint8Array | null> => {
-	const response = await client.client.fetch(buildObjectUrl(key));
-	if (response.status === 404) {
-		console.log(`[r2] GET ${key} - not found`);
-		return null;
-	}
-	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(
-			`Failed to download ${key}: ${response.status} ${text || response.statusText}`,
-		);
-	}
-	const bytes = new Uint8Array(await response.arrayBuffer());
-	console.log(`[r2] GET ${key} (${bytes.byteLength} bytes)`);
-	return bytes;
 };

--- a/api/worker/shared/build.ts
+++ b/api/worker/shared/build.ts
@@ -1,4 +1,4 @@
-import type { SourceFontMetadata, VariableAxes } from './catalog';
+import type { SourceFontMetadata } from './catalog';
 import type { FontPackageTarget } from './font-package-manifest';
 
 /**
@@ -9,25 +9,21 @@ export interface BuildVersionTag {
 	version: string;
 }
 
-/**
- * Worker-to-container build request.
- */
-export interface BuildVersionRequestBase {
+export interface BuildFileRequest {
+	mode: 'file';
 	tag: BuildVersionTag;
 	metadata: SourceFontMetadata;
-	axes?: VariableAxes;
-}
-
-export interface BuildFamilyRequest extends BuildVersionRequestBase {
-	mode: 'family';
-}
-
-export interface BuildFileRequest extends BuildVersionRequestBase {
-	mode: 'file';
 	target: FontPackageTarget;
 }
 
-export type BuildVersionRequest = BuildFamilyRequest | BuildFileRequest;
+export interface BuildDownloadRequest {
+	mode: 'download';
+	staticVersion: string;
+	variableVersion?: string;
+	metadata: SourceFontMetadata;
+}
+
+export type BuildVersionRequest = BuildDownloadRequest | BuildFileRequest;
 
 export interface BuildVersionResponse {
 	state: 'ready';
@@ -52,21 +48,16 @@ export interface BuildVersionBuilding {
 export type BuildVersionResult = BuildVersionResponse | BuildVersionFailure;
 export type BuildVersionStatus = BuildVersionBuilding | BuildVersionFailure;
 
-/**
- * Exact version cache key. This is also the named container identity, so the
- * format must stay stable across both runtimes.
- */
-export const getBuildKey = (tag: BuildVersionTag): string =>
-	`build:${tag.id}@${tag.version}`;
-
-export const getFamilyBuildRequestKey = (tag: BuildVersionTag): string =>
-	`${getBuildKey(tag)}:family`;
+export const getBuildKey = (request: BuildVersionRequest): string =>
+	request.mode === 'download'
+		? `build:${request.metadata.id}@${request.staticVersion}${request.variableVersion && request.variableVersion !== request.staticVersion ? `+vf@${request.variableVersion}` : ''}`
+		: `build:${request.tag.id}@${request.tag.version}`;
 
 export const getBuildRequestKey = (request: BuildVersionRequest): string =>
-	request.mode === 'family'
-		? getFamilyBuildRequestKey(request.tag)
+	request.mode === 'download'
+		? `${getBuildKey(request)}:download`
 		: [
-				getBuildKey(request.tag),
+				getBuildKey(request),
 				'file',
 				request.target.isVariable ? 'variable' : 'static',
 				request.target.file,

--- a/api/worker/shared/http-metadata.ts
+++ b/api/worker/shared/http-metadata.ts
@@ -7,14 +7,3 @@ export const BINARY_CONTENT_TYPES = {
 	ttf: 'font/ttf',
 	zip: 'application/zip',
 } as const;
-
-export const getDownloadAttachmentFilename = (
-	id: string,
-	version: string,
-): string => `${id}_${version}.zip`;
-
-export const getDownloadContentDisposition = (
-	id: string,
-	version: string,
-): string =>
-	`attachment; filename="${getDownloadAttachmentFilename(id, version)}"`;

--- a/api/worker/shared/storage.ts
+++ b/api/worker/shared/storage.ts
@@ -4,8 +4,14 @@ interface FontBinaryTag {
 	version: string;
 }
 
-export const getDownloadKey = (id: string, version: string): string =>
-	`${id}@${version}/download.zip`;
+export const getDownloadKey = (
+	id: string,
+	staticVersion: string,
+	variableVersion?: string,
+): string =>
+	variableVersion && variableVersion !== staticVersion
+		? `${id}@${staticVersion}+vf@${variableVersion}/download.zip`
+		: `${id}@${staticVersion}/download.zip`;
 
 /**
  * Static binaries live directly under `<id>@<version>/...`.
@@ -30,8 +36,6 @@ export const getVariableAssetKey = (
  * Resolves the final R2 key for any published binary artifact.
  */
 export const getBinaryKey = (tag: FontBinaryTag, file: string): string =>
-	file === 'download.zip'
-		? getDownloadKey(tag.id, tag.version)
-		: tag.isVariable
-			? getVariableAssetKey(tag.id, tag.version, file)
-			: getStaticAssetKey(tag.id, tag.version, file);
+	tag.isVariable
+		? getVariableAssetKey(tag.id, tag.version, file)
+		: getStaticAssetKey(tag.id, tag.version, file);

--- a/api/worker/tests/__snapshots__/cdn.test.ts.snap
+++ b/api/worker/tests/__snapshots__/cdn.test.ts.snap
@@ -24,49 +24,6 @@ exports[`cdn routes > public asset outputs > generates correct CSS output 1`] = 
 }
 `;
 
-exports[`cdn routes > public asset outputs > serves zip archives with correct file listings 1`] = `
-{
-  "abel": {
-    "files": [
-      "LICENSE",
-      "static/abel-latin-400-normal.ttf",
-      "static/abel-latin-400-normal.woff",
-      "static/abel-latin-400-normal.woff2",
-    ],
-    "headers": {
-      "cacheControl": "public, max-age=31536000, immutable",
-      "cdnCacheControl": "public, max-age=31536000, immutable",
-      "contentDisposition": "attachment; filename="abel_5.0.0.zip"",
-      "contentType": "application/zip",
-      "edgeCacheControl": "public, max-age=31536000, immutable",
-      "etag": "<etag>",
-      "lastModified": "<last-modified>",
-    },
-    "status": 200,
-  },
-  "recursive": {
-    "files": [
-      "LICENSE",
-      "static/recursive-latin-400-normal.ttf",
-      "static/recursive-latin-400-normal.woff",
-      "static/recursive-latin-400-normal.woff2",
-      "variable/recursive-latin-full-normal.woff2",
-      "variable/recursive-latin-mono-normal.woff2",
-    ],
-    "headers": {
-      "cacheControl": "public, max-age=31536000, immutable",
-      "cdnCacheControl": "public, max-age=31536000, immutable",
-      "contentDisposition": "attachment; filename="recursive_5.0.0.zip"",
-      "contentType": "application/zip",
-      "edgeCacheControl": "public, max-age=31536000, immutable",
-      "etag": "<etag>",
-      "lastModified": "<last-modified>",
-    },
-    "status": 200,
-  },
-}
-`;
-
 exports[`cdn routes > returns 502 when the artifact builder fails 1`] = `
 {
   "body": {
@@ -97,26 +54,5 @@ exports[`cdn routes > returns 502 when version lookup upstream fails 1`] = `
     "etag": "<etag>",
   },
   "status": 502,
-}
-`;
-
-exports[`cdn routes > stores HTTP metadata on built binaries and download archives 1`] = `
-{
-  "buildCalls": 1,
-  "static": {
-    "cacheControl": "public, max-age=31536000, immutable",
-    "contentDisposition": "",
-    "contentType": "font/woff2",
-  },
-  "variable": {
-    "cacheControl": "public, max-age=31536000, immutable",
-    "contentDisposition": "",
-    "contentType": "font/woff2",
-  },
-  "zip": {
-    "cacheControl": "public, max-age=31536000, immutable",
-    "contentDisposition": "attachment; filename="recursive_5.0.0.zip"",
-    "contentType": "application/zip",
-  },
 }
 `;

--- a/api/worker/tests/artifacts.test.ts
+++ b/api/worker/tests/artifacts.test.ts
@@ -15,8 +15,6 @@ import {
 
 const {
 	putObject,
-	listKeys,
-	getObjectBytes,
 	fetchPackageAssetBytes,
 	fetchPackageFileList,
 	fetchPackageLicenseBytes,
@@ -28,8 +26,6 @@ const {
 
 	return {
 		putObject: vi.fn(),
-		listKeys: vi.fn(),
-		getObjectBytes: vi.fn(),
 		fetchPackageAssetBytes: vi.fn(),
 		fetchPackageFileList: vi.fn(),
 		fetchPackageLicenseBytes: vi.fn(),
@@ -40,8 +36,6 @@ const {
 });
 
 vi.mock('../container/src/r2', () => ({
-	getObjectBytes,
-	listKeys,
 	putObject,
 }));
 
@@ -74,8 +68,6 @@ vi.mock('@fontsource-utils/core', async () => {
 describe('container artifact builder', () => {
 	beforeEach(() => {
 		putObject.mockReset();
-		listKeys.mockReset();
-		getObjectBytes.mockReset();
 		fetchPackageAssetBytes.mockReset();
 		fetchPackageFileList.mockReset();
 		fetchPackageLicenseBytes.mockReset();
@@ -83,8 +75,6 @@ describe('container artifact builder', () => {
 		destroy.mockReset();
 		createFontContext.mockClear();
 
-		listKeys.mockResolvedValue(new Set<string>());
-		getObjectBytes.mockResolvedValue(null);
 		fetchPackageFileList.mockImplementation(
 			async (id, _version, isVariable = false) => {
 				if (id === variableMetadata.id && isVariable) {
@@ -160,7 +150,6 @@ describe('container artifact builder', () => {
 
 		await expect(buildArtifacts(request)).resolves.toBe(1);
 
-		expect(listKeys).not.toHaveBeenCalled();
 		expect(fetchPackageLicenseBytes).not.toHaveBeenCalled();
 		expect(convertFont).not.toHaveBeenCalled();
 		expect(putObject).toHaveBeenCalledTimes(1);
@@ -182,7 +171,6 @@ describe('container artifact builder', () => {
 				version: '1.0.0',
 			},
 			metadata: variableMetadata,
-			axes: variableAxes,
 			target: {
 				file: 'latin-full-normal.woff2',
 				isVariable: true,
@@ -191,7 +179,6 @@ describe('container artifact builder', () => {
 
 		await expect(buildArtifacts(request)).resolves.toBe(1);
 
-		expect(listKeys).not.toHaveBeenCalled();
 		expect(fetchPackageLicenseBytes).not.toHaveBeenCalled();
 		expect(convertFont).not.toHaveBeenCalled();
 		expect(putObject).toHaveBeenCalledTimes(1);
@@ -239,14 +226,11 @@ describe('container artifact builder', () => {
 		);
 	});
 
-	it('assembles family zip entries from the correct built artifacts', async () => {
+	it('assembles download entries from the correct built artifacts', async () => {
 		const { buildArtifacts } = await import('../container/src/artifacts');
 		const request: BuildVersionRequest = {
-			mode: 'family',
-			tag: {
-				id: testCatalog.familypack.id,
-				version: '1.0.0',
-			},
+			mode: 'download',
+			staticVersion: '1.0.0',
 			metadata: testCatalog.familypack,
 		};
 
@@ -290,11 +274,8 @@ describe('container artifact builder', () => {
 
 		await expect(
 			buildArtifacts({
-				mode: 'family',
-				tag: {
-					id: staticMetadata.id,
-					version: '1.0.0',
-				},
+				mode: 'download',
+				staticVersion: '1.0.0',
 				metadata: staticMetadata,
 			}),
 		).rejects.toThrow('artifact upload failed');
@@ -304,7 +285,7 @@ describe('container artifact builder', () => {
 		).toBe(false);
 	});
 
-	it('filters family artifacts to the files actually published for that version', async () => {
+	it('filters download artifacts to files published for that version', async () => {
 		const { buildArtifacts } = await import('../container/src/artifacts');
 		fetchPackageFileList.mockImplementation(
 			async (id, _version, isVariable = false) => {
@@ -326,11 +307,8 @@ describe('container artifact builder', () => {
 		);
 
 		const request: BuildVersionRequest = {
-			mode: 'family',
-			tag: {
-				id: testCatalog.familypack.id,
-				version: '1.0.0',
-			},
+			mode: 'download',
+			staticVersion: '1.0.0',
 			metadata: testCatalog.familypack,
 		};
 

--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -8,7 +8,6 @@ import {
 	installArtifactBuilderMock,
 	installUpstreamFetchMock,
 	jsonSnapshot,
-	serializeHeaders,
 	setupWorkerTest,
 	staticTtfBytes,
 	staticWoff2Bytes,
@@ -272,43 +271,6 @@ describe('cdn routes', () => {
 			);
 		});
 
-		it('builds canonical download zips for slanted variable families', async () => {
-			const builder = installArtifactBuilderMock(testEnv);
-			await testEnv.METADATA.put(
-				KV_KEYS.catalog,
-				JSON.stringify({
-					...testCatalog,
-					slanted: slantedMetadata,
-				}),
-			);
-			clearMetadataCachesForTest();
-
-			const result = await dispatch(
-				'https://fontsource.test/fonts/slanted@5.0.0/download.zip',
-			);
-			const archive = unzipSync(
-				new Uint8Array(await result.response.arrayBuffer()),
-			);
-			await result.settle();
-
-			expect(result.response.status).toBe(200);
-			expect(builder.calls).toHaveBeenCalledTimes(1);
-			expect(Object.keys(archive)).toEqual(
-				expect.arrayContaining([
-					'static/slanted-latin-400-normal.woff2',
-					'variable/slanted-latin-mono-normal.woff2',
-					'variable/slanted-latin-wght-normal.woff2',
-					'variable/slanted-latin-slnt-normal.woff2',
-					'variable/slanted-latin-standard-normal.woff2',
-					'variable/slanted-latin-full-normal.woff2',
-					'LICENSE',
-				]),
-			);
-			expect(Object.keys(archive).some((key) => key.includes('oblique'))).toBe(
-				false,
-			);
-		});
-
 		it('serves static font assets with immutable caching', async () => {
 			const url =
 				'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.woff2';
@@ -365,51 +327,47 @@ describe('cdn routes', () => {
 			expect(bytes.byteLength).toBe(variableWoff2Bytes.byteLength);
 			expect(result.response.headers.get('Content-Type')).toBe('font/woff2');
 		});
-
-		it('serves zip archives with correct file listings', async () => {
-			const recursiveResult = await dispatch(
-				'https://fontsource.test/fonts/recursive@5.0.0/download.zip',
-			);
-			const recursiveArchive = unzipSync(
-				new Uint8Array(await recursiveResult.response.arrayBuffer()),
-			);
-			await recursiveResult.settle();
-
-			const abelResult = await dispatch(
-				'https://fontsource.test/fonts/abel@5.0.0/download.zip',
-			);
-			const abelArchive = unzipSync(
-				new Uint8Array(await abelResult.response.arrayBuffer()),
-			);
-			await abelResult.settle();
-
-			expect({
-				recursive: {
-					status: recursiveResult.response.status,
-					headers: serializeHeaders(recursiveResult.response),
-					files: Object.keys(recursiveArchive).sort(),
-				},
-				abel: {
-					status: abelResult.response.status,
-					headers: serializeHeaders(abelResult.response),
-					files: Object.keys(abelArchive).sort(),
-				},
-			}).toMatchSnapshot();
-		});
 	});
 
-	it('produces correct download archive from builder', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
+	it('builds a download asynchronously and serves the archive when ready', async () => {
+		const builder = installArtifactBuilderMock(testEnv, { buildDelayMs: 25 });
+		const url = 'https://fontsource.test/v1/download/recursive';
 
-		const result = await dispatch(
-			'https://fontsource.test/fonts/recursive@5.0.0/download.zip',
-		);
+		const [accepted, duplicate] = await Promise.all([
+			dispatch(url),
+			dispatch(url),
+		]);
+		expect(accepted.response.status).toBe(202);
+		expect(await accepted.response.json()).toEqual({
+			state: 'building',
+			version: '5.0.0',
+		});
+		expect(duplicate.response.status).toBe(202);
+		await duplicate.response.json();
+		await Promise.all([accepted.settle(), duplicate.settle()]);
+
+		for (let attempts = 0; attempts < 100; attempts += 1) {
+			if (await testEnv.FONTS.head('recursive@5.0.0/download.zip')) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+
+		const result = await dispatch(url);
 		const archive = unzipSync(
 			new Uint8Array(await result.response.arrayBuffer()),
 		);
 		await result.settle();
 
 		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get('Content-Disposition')).toBe(
+			'attachment; filename="recursive.zip"',
+		);
+		expect(result.response.headers.get('Cache-Control')).toBe(
+			'public, no-cache',
+		);
+		const etag = result.response.headers.get('ETag');
+		expect(etag).toBeTruthy();
 		expect(builder.calls).toHaveBeenCalledTimes(1);
 
 		// Archive should contain static + variable files + LICENSE
@@ -436,84 +394,33 @@ describe('cdn routes', () => {
 
 		// LICENSE should be present and non-empty
 		expect(new TextDecoder().decode(archive.LICENSE)).toBe('Example License');
+
+		const conditional = await dispatch(
+			new Request(url, { headers: { 'If-None-Match': etag ?? '' } }),
+		);
+		await conditional.settle();
+		expect(conditional.response.status).toBe(304);
+		expect(conditional.response.headers.get('Cache-Control')).toBe(
+			'public, no-cache',
+		);
 	});
 
-	it('redirects exact variable zip aliases to the shared exact-version archive', async () => {
+	it('does not expose exact-version download aliases', async () => {
 		const builder = installArtifactBuilderMock(testEnv);
 		const [staticZipResult, variableZipResult] = await Promise.all([
 			dispatch('https://fontsource.test/fonts/recursive@5.0.0/download.zip'),
-			dispatch(
-				new Request(
-					'https://fontsource.test/fonts/recursive:vf@5.0.0/download.zip',
-					{ redirect: 'manual' },
-				),
-			),
+			dispatch('https://fontsource.test/fonts/recursive:vf@5.0.0/download.zip'),
 		]);
-
-		const staticZipArchive = unzipSync(
-			new Uint8Array(await staticZipResult.response.arrayBuffer()),
-		);
 		await Promise.all([staticZipResult.settle(), variableZipResult.settle()]);
 
-		// Static zip served directly with built artifacts
-		expect(staticZipResult.response.status).toBe(200);
-		expect(Object.keys(staticZipArchive)).toContain('LICENSE');
-
-		// Variable zip alias redirects to the shared archive
-		expect(variableZipResult.response.status).toBe(302);
-		expect(variableZipResult.response.headers.get('Location')).toBe(
-			'/fonts/recursive@5.0.0/download.zip',
-		);
-
-		// Only one build was triggered
-		expect(builder.calls).toHaveBeenCalledTimes(1);
+		expect(staticZipResult.response.status).toBe(404);
+		expect(variableZipResult.response.status).toBe(404);
+		expect(builder.calls).not.toHaveBeenCalled();
 	});
 
-	it('redirects exact variable zip aliases for static families to the shared archive route', async () => {
-		const { response, settle } = await dispatch(
-			new Request('https://fontsource.test/fonts/abel:vf@5.0.0/download.zip', {
-				redirect: 'manual',
-			}),
-		);
-		await settle();
-
-		expect(response.status).toBe(302);
-		expect(response.headers.get('Location')).toBe(
-			'/fonts/abel@5.0.0/download.zip',
-		);
-		expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
-	});
-
-	it('stores HTTP metadata on built binaries and download archives', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
-		const zipResult = await dispatch(
-			'https://fontsource.test/fonts/recursive@5.0.0/download.zip',
-		);
-		await zipResult.response.arrayBuffer();
-		await zipResult.settle();
-
-		const pick = (obj: R2Object | null) => ({
-			cacheControl: obj?.httpMetadata?.cacheControl ?? '',
-			contentDisposition: obj?.httpMetadata?.contentDisposition ?? '',
-			contentType: obj?.httpMetadata?.contentType ?? '',
-		});
-
-		expect({
-			buildCalls: builder.calls.mock.calls.length,
-			zip: pick(await testEnv.FONTS.head('recursive@5.0.0/download.zip')),
-			static: pick(
-				await testEnv.FONTS.head('recursive@5.0.0/latin-400-normal.woff2'),
-			),
-			variable: pick(
-				await testEnv.FONTS.head(
-					'recursive@5.0.0/variable/latin-full-normal.woff2',
-				),
-			),
-		}).toMatchSnapshot();
-	});
-
-	it('serves canonical family zips directly and redirects floating variable zip aliases', async () => {
+	it('combines independent latest package versions in the canonical download', async () => {
 		vi.restoreAllMocks();
+		installArtifactBuilderMock(testEnv);
 		installUpstreamFetchMock({
 			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/recursive`]: new Response(
 				JSON.stringify({
@@ -528,29 +435,28 @@ describe('cdn routes', () => {
 				),
 		});
 		clearMetadataCachesForTest();
-		await testEnv.FONTS.put(
-			'recursive@5.0.0/download.zip',
-			zipSync({
-				'static/recursive-latin-400-normal.woff2': staticWoff2Bytes,
-				LICENSE: new TextEncoder().encode('static latest'),
-			}),
-		);
-		await testEnv.FONTS.put(
-			'recursive@1.1.0/download.zip',
-			zipSync({
-				'variable/recursive-latin-full-normal.woff2': variableWoff2Bytes,
-				LICENSE: new TextEncoder().encode('variable latest'),
-			}),
-		);
 
-		const staticLatest = await dispatch(
+		const accepted = await dispatch(
 			'https://fontsource.test/v1/download/recursive',
 		);
-		const staticLatestResponse = staticLatest.response;
-		const staticLatestArchive = unzipSync(
-			new Uint8Array(await staticLatestResponse.arrayBuffer()),
+		expect(accepted.response.status).toBe(202);
+		await accepted.response.json();
+		await accepted.settle();
+
+		for (let attempts = 0; attempts < 100; attempts += 1) {
+			if (await testEnv.FONTS.head('recursive@5.0.0+vf@1.1.0/download.zip')) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+
+		const download = await dispatch(
+			'https://fontsource.test/v1/download/recursive',
 		);
-		await staticLatest.settle();
+		const archive = unzipSync(
+			new Uint8Array(await download.response.arrayBuffer()),
+		);
+		await download.settle();
 
 		const variableLatest = await dispatch(
 			new Request(
@@ -561,18 +467,49 @@ describe('cdn routes', () => {
 		const variableLatestResponse = variableLatest.response;
 		await variableLatest.settle();
 
-		expect(staticLatestResponse.status).toBe(200);
-		expect(staticLatestResponse.headers.get('Content-Type')).toBe(
+		expect(download.response.status).toBe(200);
+		expect(download.response.headers.get('Content-Type')).toBe(
 			'application/zip',
 		);
-		expect(new TextDecoder().decode(staticLatestArchive.LICENSE)).toBe(
-			'static latest',
+		expect(download.response.headers.get('Content-Disposition')).toBe(
+			'attachment; filename="recursive.zip"',
 		);
+		expect(Object.keys(archive)).toEqual(
+			expect.arrayContaining([
+				'static/recursive-latin-400-normal.woff2',
+				'variable/recursive-latin-full-normal.woff2',
+				'LICENSE',
+			]),
+		);
+		expect(
+			await testEnv.FONTS.head('recursive@5.0.0+vf@1.1.0/download.zip'),
+		).not.toBeNull();
 
 		expect(variableLatestResponse.status).toBe(302);
 		expect(variableLatestResponse.headers.get('Location')).toBe(
 			'/v1/download/recursive',
 		);
+	});
+
+	it('returns a failed asynchronous download build on the next poll', async () => {
+		const builder = installArtifactBuilderMock(testEnv, {
+			failBuildKeys: ['build:abel@5.0.0'],
+		});
+		const url = 'https://fontsource.test/v1/download/abel';
+
+		const accepted = await dispatch(url);
+		await accepted.response.json();
+		await accepted.settle();
+		expect(accepted.response.status).toBe(202);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const failed = await dispatch(url);
+		const body = (await failed.response.json()) as { error: string };
+		await failed.settle();
+
+		expect(failed.response.status).toBe(502);
+		expect(body.error).toContain('Mocked builder failure for build:abel@5.0.0');
+		expect(builder.calls).toHaveBeenCalledTimes(1);
 	});
 
 	it('redirects variable latest CDN zip aliases to the canonical download endpoint', async () => {
@@ -602,70 +539,7 @@ describe('cdn routes', () => {
 		expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
 	});
 
-	it('deduplicates cold download builds and returns 202 until the archive is ready', async () => {
-		const builder = installArtifactBuilderMock(testEnv, { buildDelayMs: 25 });
-		const url = 'https://fontsource.test/v1/download/abel';
-
-		const [first, second] = await Promise.all([dispatch(url), dispatch(url)]);
-		const [firstBody, secondBody] = await Promise.all([
-			first.response.json(),
-			second.response.json(),
-		]);
-		await Promise.all([first.settle(), second.settle()]);
-
-		expect(first.response.status).toBe(202);
-		expect(second.response.status).toBe(202);
-		expect(firstBody).toEqual({ state: 'building', version: '5.0.0' });
-		expect(secondBody).toEqual(firstBody);
-		expect(first.response.headers.get('Retry-After')).toBe('3');
-		expect(first.response.headers.get('Cache-Control')).toBe('no-store');
-		expect(first.response.headers.get('CDN-Cache-Control')).toBe('no-store');
-		expect(first.response.headers.get('Cloudflare-CDN-Cache-Control')).toBe(
-			'no-store',
-		);
-		expect(builder.calls).toHaveBeenCalledTimes(1);
-
-		for (let attempts = 0; attempts < 100; attempts += 1) {
-			if (await testEnv.FONTS.head('abel@5.0.0/download.zip')) {
-				break;
-			}
-			await new Promise((resolve) => setTimeout(resolve, 1));
-		}
-		expect(await testEnv.FONTS.head('abel@5.0.0/download.zip')).not.toBeNull();
-
-		const ready = await dispatch(url);
-		const archive = await ready.response.arrayBuffer();
-		await ready.settle();
-
-		expect(ready.response.status).toBe(200);
-		expect(archive.byteLength).toBeGreaterThan(0);
-		expect(builder.calls).toHaveBeenCalledTimes(1);
-	});
-
-	it('returns the raw builder error when polling a failed download build', async () => {
-		const builder = installArtifactBuilderMock(testEnv, {
-			failBuildKeys: ['build:abel@5.0.0'],
-		});
-		const url = 'https://fontsource.test/v1/download/abel';
-
-		const accepted = await dispatch(url);
-		await accepted.response.json();
-		await accepted.settle();
-		expect(accepted.response.status).toBe(202);
-
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		const failed = await dispatch(url);
-		const body = (await failed.response.json()) as { error: string };
-		await failed.settle();
-
-		expect(failed.response.status).toBe(502);
-		expect(body.error).toBe(
-			'Bad Gateway. Artifact build failed for build:abel@5.0.0: Mocked builder failure for build:abel@5.0.0',
-		);
-		expect(builder.calls).toHaveBeenCalledTimes(1);
-	});
-
-	it('triggers one version build on cold ttf miss and serves cached files afterwards', async () => {
+	it('builds a cold file once and serves it from R2 afterwards', async () => {
 		const builder = installArtifactBuilderMock(testEnv);
 		const ttfUrl =
 			'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.ttf';
@@ -697,12 +571,10 @@ describe('cdn routes', () => {
 		await notModified.settle();
 		expect(notModified.response.status).toBe(304);
 
-		// Cold file request builds the file, then warms the family in background.
-		expect(builder.calls).toHaveBeenCalledTimes(2);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
+		expect(builder.calls).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: 'file' }),
+		);
 	});
 
 	it('joins concurrent cold requests for the same build key', async () => {
@@ -718,123 +590,7 @@ describe('cdn routes', () => {
 		expect(second.response.status).toBe(200);
 		expect(firstBytes.byteLength).toBe(staticTtfBytes.byteLength);
 		expect(secondBytes.byteLength).toBe(staticTtfBytes.byteLength);
-		expect(builder.calls).toHaveBeenCalledTimes(2);
-	});
-
-	it('builds cold static file misses synchronously then warms the family in background', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
-		const url =
-			'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.woff2';
-
-		const cold = await dispatch(url);
-		const coldBytes = await cold.response.arrayBuffer();
-		await cold.settle();
-
-		expect(cold.response.status).toBe(200);
-		expect(coldBytes.byteLength).toBe(staticWoff2Bytes.byteLength);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
-		expect(await testEnv.FONTS.head('abel@5.0.0/download.zip')).not.toBeNull();
-	});
-
-	it('builds cold variable file misses synchronously then warms the family in background', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
-		const url =
-			'https://fontsource.test/fonts/recursive:vf@5.0.0/latin-full-normal.woff2';
-
-		const cold = await dispatch(url);
-		const coldBytes = await cold.response.arrayBuffer();
-		await cold.settle();
-
-		expect(cold.response.status).toBe(200);
-		expect(coldBytes.byteLength).toBe(variableWoff2Bytes.byteLength);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
-		expect(
-			await testEnv.FONTS.head('recursive@5.0.0/download.zip'),
-		).not.toBeNull();
-	});
-
-	it('does not schedule additional family warming on warm binary hits', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
-		const url =
-			'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.woff2';
-
-		const cold = await dispatch(url);
-		await cold.response.arrayBuffer();
-		await cold.settle();
-		expect(builder.calls).toHaveBeenCalledTimes(2);
-
-		const warm = await dispatch(url);
-		await warm.response.arrayBuffer();
-		await warm.settle();
-
-		expect(warm.response.status).toBe(200);
-		expect(builder.calls).toHaveBeenCalledTimes(2);
-	});
-
-	it('swallows background family warm failures after serving a cold file request', async () => {
-		const builder = installArtifactBuilderMock(testEnv, {
-			failBuilds: [{ buildKey: 'build:abel@5.0.0', mode: 'family' }],
-		});
-		const url =
-			'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.woff2';
-
-		const result = await dispatch(url);
-		const bytes = await result.response.arrayBuffer();
-		await result.settle();
-
-		expect(result.response.status).toBe(200);
-		expect(bytes.byteLength).toBe(staticWoff2Bytes.byteLength);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
-		expect(await testEnv.FONTS.head('abel@5.0.0/download.zip')).toBeNull();
-	});
-
-	it('builds canonical zips while a single-file build is active', async () => {
-		const builder = installArtifactBuilderMock(testEnv, {
-			buildDelayMs: 25,
-		});
-		const fileUrl =
-			'https://fontsource.test/fonts/abel@5.0.0/latin-400-normal.woff2';
-		const zipUrl = 'https://fontsource.test/fonts/abel@5.0.0/download.zip';
-
-		const fileRequest = dispatch(fileUrl);
-		for (let attempts = 0; attempts < 100; attempts += 1) {
-			if (builder.calls.mock.calls.length > 0) {
-				break;
-			}
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		}
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-		]);
-		const zipRequest = dispatch(zipUrl);
-
-		const [fileResult, zipResult] = await Promise.all([
-			fileRequest,
-			zipRequest,
-		]);
-		const [fileBytes, zipBytes] = await Promise.all([
-			fileResult.response.arrayBuffer(),
-			zipResult.response.arrayBuffer(),
-		]);
-		await Promise.all([fileResult.settle(), zipResult.settle()]);
-
-		expect(fileResult.response.status).toBe(200);
-		expect(zipResult.response.status).toBe(200);
-		expect(fileBytes.byteLength).toBe(staticWoff2Bytes.byteLength);
-		expect(zipBytes.byteLength).toBeGreaterThan(0);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
 	});
 
 	it('returns 502 when the artifact builder fails', async () => {
@@ -903,17 +659,6 @@ describe('cdn routes', () => {
 		expect(builder.calls).not.toHaveBeenCalled();
 	});
 
-	it('short-circuits unpublished exact-version downloads before the builder runs', async () => {
-		const builder = installArtifactBuilderMock(testEnv);
-		const result = await dispatch(
-			'https://fontsource.test/fonts/abel@9.9.9/download.zip',
-		);
-		await result.settle();
-
-		expect(result.response.status).toBe(404);
-		expect(builder.calls).not.toHaveBeenCalled();
-	});
-
 	it('falls back to the builder when the published-file preflight fails', async () => {
 		vi.restoreAllMocks();
 		const builder = installArtifactBuilderMock(testEnv);
@@ -930,10 +675,7 @@ describe('cdn routes', () => {
 
 		expect(result.response.status).toBe(200);
 		expect(bytes.byteLength).toBe(staticWoff2Bytes.byteLength);
-		expect(builder.calls.mock.calls.map(([request]) => request.mode)).toEqual([
-			'file',
-			'family',
-		]);
+		expect(builder.calls).toHaveBeenCalledTimes(1);
 	});
 
 	it('returns 502 when version lookup upstream fails', async () => {

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -16,7 +16,6 @@ import {
 	type BuildVersionStatus,
 	getBuildKey,
 	getBuildRequestKey,
-	getFamilyBuildRequestKey,
 } from '../shared/build';
 import type {
 	FontCatalog,
@@ -30,7 +29,6 @@ import {
 } from '../shared/font-package-manifest';
 import {
 	BINARY_CONTENT_TYPES,
-	getDownloadContentDisposition,
 	IMMUTABLE_ASSET_CACHE_CONTROL,
 } from '../shared/http-metadata';
 import type { StatsResponse } from '../shared/stats';
@@ -375,14 +373,12 @@ const putBuiltObject = async (
 	key: string,
 	body: Uint8Array,
 	options: {
-		contentDisposition?: string;
 		contentType: keyof typeof BINARY_CONTENT_TYPES;
 	},
 ): Promise<void> => {
 	await env.FONTS.put(key, body, {
 		httpMetadata: {
 			cacheControl: IMMUTABLE_ASSET_CACHE_CONTROL,
-			contentDisposition: options.contentDisposition,
 			contentType: BINARY_CONTENT_TYPES[options.contentType],
 		},
 	});
@@ -470,45 +466,46 @@ const putVariableArtifacts = async (
 	return artifactCount;
 };
 
-const putCombinedArtifacts = async (
+const putDownloadArtifacts = async (
 	env: Env,
 	request: BuildVersionRequest,
 ): Promise<number> => {
-	const { metadata, tag, axes } = request;
+	if (request.mode !== 'download') {
+		throw new Error('Expected a download build request.');
+	}
+
+	const { metadata } = request;
+	const axes = metadata.variable || undefined;
 	const zipFiles: Zippable = {};
 	let artifactCount = await putStaticArtifacts(
 		env,
 		metadata,
-		tag.version,
+		request.staticVersion,
 		zipFiles,
 	);
 
-	if (axes) {
+	if (axes && request.variableVersion) {
 		artifactCount += await putVariableArtifacts(
 			env,
 			metadata,
 			axes,
-			tag.version,
+			request.variableVersion,
 			zipFiles,
 		);
 	}
 
 	if (artifactCount === 0) {
 		throw new Error(
-			`Mocked build produced no artifacts for ${tag.id}@${tag.version}`,
+			`Mocked build produced no artifacts for ${metadata.id}@${request.staticVersion}`,
 		);
 	}
 
 	zipFiles.LICENSE = new TextEncoder().encode('Example License');
 	await putBuiltObject(
 		env,
-		getDownloadKey(metadata.id, tag.version),
+		getDownloadKey(metadata.id, request.staticVersion, request.variableVersion),
 		zipSync(zipFiles),
 		{
-			contentDisposition: getDownloadContentDisposition(
-				metadata.id,
-				tag.version,
-			),
 			contentType: 'zip',
 		},
 	);
@@ -521,10 +518,13 @@ const putRequestedArtifact = async (
 	request: BuildVersionRequest,
 ): Promise<number> => {
 	if (request.mode !== 'file') {
-		return await putCombinedArtifacts(env, request);
+		return await putDownloadArtifacts(env, request);
 	}
 
-	const manifest = resolveFontPackageManifest(request.metadata, request.axes);
+	const manifest = resolveFontPackageManifest(
+		request.metadata,
+		request.metadata.variable || undefined,
+	);
 	const entry = findFontPackageEntry(manifest, request.target);
 
 	if (!entry) {
@@ -582,15 +582,7 @@ export const installArtifactBuilderMock = (
 	const ensureBuilt = async (
 		request: BuildVersionRequest,
 	): Promise<BuildVersionResponse> => {
-		const buildKey = getBuildKey(request.tag);
-		const activeFamilyBuild = activeBuilds.get(
-			getFamilyBuildRequestKey(request.tag),
-		);
-
-		if (request.mode === 'file' && activeFamilyBuild) {
-			return await activeFamilyBuild;
-		}
-
+		const buildKey = getBuildKey(request);
 		const requestKey = getBuildRequestKey(request);
 		const activeBuild = activeBuilds.get(requestKey);
 
@@ -653,7 +645,7 @@ export const installArtifactBuilderMock = (
 		try {
 			return await ensureBuilt(request);
 		} catch (error) {
-			const buildKey = getBuildKey(request.tag);
+			const buildKey = getBuildKey(request);
 			return {
 				state: 'failed',
 				buildKey,
@@ -679,7 +671,7 @@ export const installArtifactBuilderMock = (
 		if (asyncBuilds.has(requestKey)) {
 			return {
 				state: 'building',
-				buildKey: getBuildKey(request.tag),
+				buildKey: getBuildKey(request),
 			};
 		}
 
@@ -694,7 +686,7 @@ export const installArtifactBuilderMock = (
 
 		return {
 			state: 'building',
-			buildKey: getBuildKey(request.tag),
+			buildKey: getBuildKey(request),
 		};
 	};
 

--- a/api/worker/worker/src/container/binding.ts
+++ b/api/worker/worker/src/container/binding.ts
@@ -71,7 +71,7 @@ export class ArtifactBuilder extends Container<Env> {
 			if (!response.ok) {
 				return {
 					state: 'failed',
-					buildKey: getBuildKey(request.tag),
+					buildKey: getBuildKey(request),
 					status: response.status,
 					error: await readBuildErrorMessage(response),
 				};
@@ -79,7 +79,7 @@ export class ArtifactBuilder extends Container<Env> {
 
 			return (await response.json()) as BuildVersionResponse;
 		} catch (error) {
-			const buildKey = getBuildKey(request.tag);
+			const buildKey = getBuildKey(request);
 			const message = error instanceof Error ? error.message : String(error);
 			return {
 				state: 'failed',
@@ -103,7 +103,7 @@ export class ArtifactBuilder extends Container<Env> {
 		if (this.activeBuilds.has(requestKey)) {
 			return {
 				state: 'building',
-				buildKey: getBuildKey(request.tag),
+				buildKey: getBuildKey(request),
 			};
 		}
 
@@ -120,7 +120,7 @@ export class ArtifactBuilder extends Container<Env> {
 
 		return {
 			state: 'building',
-			buildKey: getBuildKey(request.tag),
+			buildKey: getBuildKey(request),
 		};
 	}
 }

--- a/api/worker/worker/src/container/client.ts
+++ b/api/worker/worker/src/container/client.ts
@@ -2,10 +2,10 @@ import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import {
+	type BuildDownloadRequest,
 	type BuildFileRequest,
 	type BuildVersionFailure,
 	type BuildVersionRequest,
-	type BuildVersionRequestBase,
 	type BuildVersionResponse,
 	type BuildVersionResult,
 	type BuildVersionStatus,
@@ -18,7 +18,7 @@ const buildVersion = async (
 	c: Context<AppEnv>,
 	requestBody: BuildVersionRequest,
 ): Promise<BuildVersionResponse> => {
-	const buildKey = getBuildKey(requestBody.tag);
+	const buildKey = getBuildKey(requestBody);
 	let result: BuildVersionResult;
 
 	try {
@@ -46,39 +46,11 @@ const throwBuildFailure = (failure: BuildVersionFailure): never => {
 	});
 };
 
-const buildRequestBase = (
-	resolved: ResolvedFontRequest,
-): BuildVersionRequestBase => ({
-	tag: {
-		id: resolved.tag.id,
-		version: resolved.tag.version,
-	},
-	metadata: resolved.metadata,
-	axes: resolved.axes,
-});
-
-/**
- * Ensures the resolved exact-version package exists by delegating to the
- * private container for that build key.
- */
-export const ensureVersionBuilt = async (
+export const startDownloadBuild = async (
 	c: Context<AppEnv>,
-	resolved: ResolvedFontRequest,
-): Promise<BuildVersionResponse> =>
-	buildVersion(c, {
-		...buildRequestBase(resolved),
-		mode: 'family',
-	});
-
-export const startVersionBuild = async (
-	c: Context<AppEnv>,
-	resolved: ResolvedFontRequest,
+	request: BuildDownloadRequest,
 ): Promise<Exclude<BuildVersionStatus, BuildVersionFailure>> => {
-	const request = {
-		...buildRequestBase(resolved),
-		mode: 'family',
-	} satisfies BuildVersionRequest;
-	const buildKey = getBuildKey(request.tag);
+	const buildKey = getBuildKey(request);
 	let result: BuildVersionStatus;
 
 	try {
@@ -104,8 +76,12 @@ export const ensureFileBuilt = async (
 	file: string,
 ): Promise<BuildVersionResponse> =>
 	buildVersion(c, {
-		...buildRequestBase(resolved),
 		mode: 'file',
+		tag: {
+			id: resolved.tag.id,
+			version: resolved.tag.version,
+		},
+		metadata: resolved.metadata,
 		target: {
 			file,
 			isVariable: resolved.tag.isVariable,

--- a/api/worker/worker/src/features/cdn/handler.ts
+++ b/api/worker/worker/src/features/cdn/handler.ts
@@ -8,18 +8,10 @@ import {
 	findFontPackageEntry,
 	resolveFontPackageManifest,
 } from '../../../../shared/font-package-manifest';
-import { getDownloadAttachmentFilename } from '../../../../shared/http-metadata';
-import { getBinaryKey } from '../../../../shared/storage';
-import {
-	fetchPackageFileList,
-	UpstreamNotFoundError,
-} from '../../../../shared/upstream';
+import { getBinaryKey, getDownloadKey } from '../../../../shared/storage';
+import { fetchPackageFileList } from '../../../../shared/upstream';
 import { CACHE_POLICIES, CONTENT_TYPES } from '../../constants';
-import {
-	ensureFileBuilt,
-	ensureVersionBuilt,
-	startVersionBuild,
-} from '../../container/client';
+import { ensureFileBuilt, startDownloadBuild } from '../../container/client';
 import type { AppEnv } from '../../env';
 import { toHttpDate } from '../../utils/cache';
 import { badGateway, badRequest, notFound } from '../../utils/errors';
@@ -124,6 +116,13 @@ export const getStoredBinaryAsset = async (
 	tag: Pick<ParsedFontTag, 'id' | 'isVariable' | 'version'>,
 	file: string,
 	requestHeaders?: Headers,
+): Promise<StoredBinaryAsset | undefined> =>
+	getStoredBinaryObject(c, getBinaryKey(tag, file), requestHeaders);
+
+const getStoredBinaryObject = async (
+	c: Context<AppEnv>,
+	key: string,
+	requestHeaders?: Headers,
 ): Promise<StoredBinaryAsset | undefined> => {
 	const onlyIf =
 		requestHeaders &&
@@ -131,10 +130,7 @@ export const getStoredBinaryAsset = async (
 			requestHeaders.has('If-Modified-Since'))
 			? requestHeaders
 			: undefined;
-	const existing = await c.env.FONTS.get(
-		getBinaryKey(tag, file),
-		onlyIf ? { onlyIf } : undefined,
-	);
+	const existing = await c.env.FONTS.get(key, onlyIf ? { onlyIf } : undefined);
 
 	return existing
 		? existing.body === undefined
@@ -170,47 +166,32 @@ const toAttachmentFilename = (
 	id: string,
 	version: string,
 	file: string,
-): string =>
-	file === 'download.zip'
-		? getDownloadAttachmentFilename(id, version)
-		: `${id}_${version}_${file}`;
+): string => `${id}_${version}_${file}`;
 
 const ensurePublishedPinnedAsset = async (
 	resolved: ResolvedFontRequest,
 	file: string,
-	sourceFilename?: string,
+	sourceFilename: string,
 ): Promise<void> => {
 	try {
-		if (sourceFilename) {
-			const publishedFiles = await fetchPackageFileList(
-				resolved.tag.id,
-				resolved.tag.version,
-				resolved.tag.isVariable,
-			);
-
-			if (!publishedFiles.has(sourceFilename)) {
-				throw notFound(
-					`Requested file ${file} not found for ${resolved.tag.id}@${resolved.tag.version}`,
-				);
-			}
-			return;
-		}
-
-		resolveVersionTag(
+		const publishedFiles = await fetchPackageFileList(
+			resolved.tag.id,
 			resolved.tag.version,
-			await getPublishedVersions(resolved.tag.id, resolved.tag.isVariable),
+			resolved.tag.isVariable,
 		);
-	} catch (error) {
-		if (!sourceFilename && error instanceof UpstreamNotFoundError) {
-			throw notFound(`Unable to resolve version "${resolved.tag.version}"`);
-		}
 
+		if (!publishedFiles.has(sourceFilename)) {
+			throw notFound(
+				`Requested file ${file} not found for ${resolved.tag.id}@${resolved.tag.version}`,
+			);
+		}
+	} catch (error) {
 		if (error instanceof HTTPException && error.status === 404) {
 			throw error;
 		}
 
 		console.warn(
-			`[cdn] published-${sourceFilename ? 'file' : 'version'} preflight skipped for ${resolved.tag.id}${resolved.tag.isVariable ? ':vf' : ''}@${resolved.tag.version}/${file}`,
+			`[cdn] published-file preflight skipped for ${resolved.tag.id}${resolved.tag.isVariable ? ':vf' : ''}@${resolved.tag.version}/${file}`,
 			error,
 		);
 	}
@@ -251,6 +232,71 @@ const respondWithBinary = (
 	return new Response(body.body, { status: 200, headers });
 };
 
+export const getDownloadAsset = async (
+	c: Context<AppEnv>,
+	id: string,
+): Promise<Response> => {
+	const metadata = await getFontById(c, id);
+	if (!metadata) {
+		throw notFound('Not Found. Font does not exist.');
+	}
+
+	const axes = metadata.variable || undefined;
+	const [staticVersions, variableVersions] = await Promise.all([
+		getPublishedVersions(id, false),
+		axes ? getPublishedVersions(id, true) : undefined,
+	]);
+	const staticVersion = resolveVersionTag('latest', staticVersions);
+	const variableVersion = variableVersions
+		? resolveVersionTag('latest', variableVersions)
+		: undefined;
+	const downloadKey = getDownloadKey(id, staticVersion, variableVersion);
+	const readDownload = () =>
+		getStoredBinaryObject(c, downloadKey, c.req.raw.headers);
+	const respond = (asset: StoredBinaryAsset) =>
+		respondWithBinary(asset, {
+			cachePolicy: {
+				...CACHE_POLICIES.floating,
+				'Cache-Control': 'public, no-cache',
+			},
+			contentType: 'zip',
+			filename: `${id}.zip`,
+		});
+
+	const existing = await readDownload();
+	if (existing) {
+		return respond(existing);
+	}
+
+	const build = await startDownloadBuild(c, {
+		mode: 'download',
+		staticVersion,
+		variableVersion,
+		metadata,
+	});
+	if (build.state === 'building') {
+		return Response.json(
+			{ state: 'building', version: staticVersion },
+			{
+				status: 202,
+				headers: {
+					...CACHE_POLICIES.noStore,
+					'Retry-After': '3',
+				},
+			},
+		);
+	}
+
+	const built = await readDownload();
+	if (!built) {
+		throw badGateway(
+			`Bad Gateway. Artifact build completed without persisting "${downloadKey}".`,
+		);
+	}
+
+	return respond(built);
+};
+
 /**
  * Serves public binary assets from R2, building the exact version on demand if
  * the requested file has not been warmed yet.
@@ -259,7 +305,6 @@ export const getBinaryAsset = async (
 	c: Context<AppEnv>,
 	tag: string,
 	file: string,
-	options: { respondAsync?: boolean } = {},
 ): Promise<Response> => {
 	const contentType = getExtension(file);
 
@@ -268,7 +313,6 @@ export const getBinaryAsset = async (
 	}
 
 	const parsedTag = parseFontTag(tag);
-	const isDownload = file === 'download.zip';
 	const pinnedVersion = isPinnedVersion(parsedTag.version);
 
 	// Fast-path: pinned version already in R2
@@ -288,17 +332,15 @@ export const getBinaryAsset = async (
 
 	// Resolve version (for floating) or validate font exists (for pinned)
 	const resolved = await resolveFontRequest(c, parsedTag);
-	const requestedEntry = isDownload
-		? undefined
-		: findFontPackageEntry(
-				resolveFontPackageManifest(resolved.metadata, resolved.axes),
-				{
-					file,
-					isVariable: resolved.tag.isVariable,
-				},
-			);
+	const requestedEntry = findFontPackageEntry(
+		resolveFontPackageManifest(resolved.metadata, resolved.axes),
+		{
+			file,
+			isVariable: resolved.tag.isVariable,
+		},
+	);
 
-	if (!isDownload && !requestedEntry) {
+	if (!requestedEntry) {
 		throw notFound('Not Found. File does not exist.');
 	}
 
@@ -306,7 +348,7 @@ export const getBinaryAsset = async (
 		await ensurePublishedPinnedAsset(
 			resolved,
 			file,
-			requestedEntry?.sourceFilename,
+			requestedEntry.sourceFilename,
 		);
 	}
 
@@ -336,59 +378,17 @@ export const getBinaryAsset = async (
 		}
 	}
 
-	const readBuiltAsset = async () =>
-		await getStoredBinaryAsset(c, resolved.tag, file, c.req.raw.headers);
-	const scheduleFamilyWarm = () => {
-		c.executionCtx.waitUntil(
-			ensureVersionBuilt(c, resolved).catch((error) => {
-				console.error(
-					`[cdn] background family warm failed for ${resolved.tag.id}${resolved.tag.isVariable ? ':vf' : ''}@${resolved.tag.version}`,
-					error,
-				);
-			}),
-		);
-	};
-
-	if (!isDownload) {
-		const build = await ensureFileBuilt(c, resolved, file);
-		const built = await readBuiltAsset();
-
-		if (!built) {
-			throw notFound('Not Found. File does not exist.');
-		}
-
-		if (build.mode === 'file') {
-			scheduleFamilyWarm();
-		}
-
-		return respond(built);
-	}
-
-	if (options.respondAsync) {
-		const build = await startVersionBuild(c, resolved);
-		if (build.state === 'building') {
-			return Response.json(
-				{ state: 'building', version: resolved.tag.version },
-				{
-					status: 202,
-					headers: {
-						...CACHE_POLICIES.noStore,
-						'Retry-After': '3',
-					},
-				},
-			);
-		}
-	} else {
-		await ensureVersionBuilt(c, resolved);
-	}
-	const built = await readBuiltAsset();
+	await ensureFileBuilt(c, resolved, file);
+	const built = await getStoredBinaryAsset(
+		c,
+		resolved.tag,
+		file,
+		c.req.raw.headers,
+	);
 
 	if (!built) {
-		throw badGateway(
-			`Bad Gateway. Artifact build completed without persisting "${resolved.tag.id}${resolved.tag.isVariable ? ':vf' : ''}@${resolved.tag.version}/${file}".`,
-		);
+		throw notFound('Not Found. File does not exist.');
 	}
-
 	return respond(built);
 };
 

--- a/api/worker/worker/src/routes/cdn.ts
+++ b/api/worker/worker/src/routes/cdn.ts
@@ -5,6 +5,7 @@ import type { AppEnv } from '../env';
 import { getBinaryAsset, getCssFile } from '../features/cdn/handler';
 import { parseFontTag } from '../features/font-tag';
 import { ErrorResponseSchema, TagFileParamSchema } from '../schemas/common';
+import { notFound } from '../utils/errors';
 
 type AppContext = Context<AppEnv>;
 
@@ -14,9 +15,8 @@ export class GetBinaryAssetRoute extends OpenAPIRoute {
 		operationId: 'getBinaryAsset',
 		summary: 'Get binary font asset',
 		description:
-			'Serves binary font files (woff2, woff, ttf) and download zips from the CDN. ' +
-			'Supports pinned and floating version tags. ' +
-			'Requests for download.zip on floating or variable tags may redirect to the canonical download endpoint.',
+			'Serves binary font files (woff2, woff, ttf) from the CDN. ' +
+			'Supports pinned and floating version tags. Latest download aliases redirect to the download endpoint.',
 		request: {
 			params: TagFileParamSchema,
 		},
@@ -33,14 +33,11 @@ export class GetBinaryAssetRoute extends OpenAPIRoute {
 					'font/ttf': {
 						schema: z.string(),
 					},
-					'application/zip': {
-						schema: z.string(),
-					},
 				},
 			},
 			'302': {
 				description:
-					'Redirect to canonical download endpoint for floating/variable download.zip requests',
+					'Redirect a latest download alias to the download endpoint',
 			},
 			'304': {
 				description: 'Not modified (conditional request)',
@@ -64,23 +61,13 @@ export class GetBinaryAssetRoute extends OpenAPIRoute {
 		const data = await this.getValidatedData<typeof this.schema>();
 		const { tag, file } = data.params;
 
-		// Route floating zip aliases through the canonical download endpoint so
-		// they share one cached archive.
 		if (file === 'download.zip') {
 			const parsedTag = parseFontTag(tag);
-
-			if (parsedTag.isVariable) {
-				return c.redirect(
-					parsedTag.version === 'latest'
-						? `/v1/download/${parsedTag.id}`
-						: `/fonts/${parsedTag.id}@${parsedTag.version}/download.zip`,
-					302,
-				);
-			}
-
 			if (parsedTag.version === 'latest') {
 				return c.redirect(`/v1/download/${parsedTag.id}`, 302);
 			}
+
+			throw notFound('Not Found. Versioned downloads are not supported.');
 		}
 
 		return getBinaryAsset(c, tag, file);

--- a/api/worker/worker/src/routes/compat.ts
+++ b/api/worker/worker/src/routes/compat.ts
@@ -3,7 +3,7 @@ import type { Context } from 'hono';
 import { z } from 'zod';
 import { UPSTREAM_URLS } from '../constants';
 import type { AppEnv } from '../env';
-import { getBinaryAsset } from '../features/cdn/handler';
+import { getDownloadAsset } from '../features/cdn/handler';
 import {
 	ErrorResponseSchema,
 	FileRedirectParamSchema,
@@ -21,14 +21,15 @@ export class DownloadFontRoute extends OpenAPIRoute {
 	schema = {
 		tags: ['Downloads'],
 		operationId: 'downloadFont',
-		summary: 'Download latest font package',
-		description: 'Serves the latest pre-built zip archive for a font family.',
+		summary: 'Download latest font family',
+		description:
+			'Serves a zip archive containing the latest static and variable packages for a font family.',
 		request: {
 			params: IdParamSchema,
 		},
 		responses: {
 			'200': {
-				description: 'Zip archive of the latest font package',
+				description: 'Zip archive of the latest font family',
 				content: {
 					'application/zip': {
 						schema: z.string(),
@@ -56,9 +57,7 @@ export class DownloadFontRoute extends OpenAPIRoute {
 	async handle(c: AppContext) {
 		const data = await this.getValidatedData<typeof this.schema>();
 		const { id } = data.params;
-		return getBinaryAsset(c, `${id}@latest`, 'download.zip', {
-			respondAsync: true,
-		});
+		return getDownloadAsset(c, id);
 	}
 }
 

--- a/api/worker/worker/src/schemas/common.ts
+++ b/api/worker/worker/src/schemas/common.ts
@@ -23,7 +23,7 @@ export const TagFileParamSchema = z.object({
 	file: z
 		.string()
 		.min(1)
-		.describe('Asset filename (e.g. "latin-400-normal.woff2", "download.zip")'),
+		.describe('Binary asset filename (e.g. "latin-400-normal.woff2")'),
 });
 
 /** Path parameters for the legacy file redirect endpoint. */


### PR DESCRIPTION
Hugely simplifies our download endpoint logic in the new API worker by removing versioning on the zipped endpoint (which is an undocumented endpoint so I'm fine with breaking it).

Static and variable font packages can be completely different in versioning e.g. 

```
/fonts/cormorant-garamond@5.2.11/download.zip
/fonts/cormorant-garamond:vf@5.2.6/download.zip
```

Because variable font support might have been added later by an upstream provider.

This makes versioning on the combined zip file to effectively be incorrect and I don't believe we need to have versioned support for this specific edge case. So let's remove it.