### PR TITLE
perf(api): speed up cold download builds

### DIFF
--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -2,6 +2,7 @@ import { convertFont, createFontContext } from '@fontsource-utils/core';
 import { zipSync } from 'fflate';
 import { HTTPException } from 'hono/http-exception';
 import limitConcur from 'limit-concur';
+import { createGzipDecoder, unpackTar } from 'modern-tar';
 import type {
 	BuildDownloadRequest,
 	BuildFileRequest,
@@ -28,7 +29,7 @@ import {
 import {
 	fetchPackageAssetBytes,
 	fetchPackageFileList,
-	fetchPackageLicenseBytes,
+	fetchPackageTarball,
 	UpstreamNotFoundError,
 } from '../../shared/upstream';
 import { putObject } from './r2';
@@ -64,24 +65,31 @@ const createArtifact = (
 	extension,
 });
 
+const uploadArtifacts = (
+	artifacts: readonly BuiltArtifact[],
+): Promise<void>[] =>
+	artifacts.map(
+		limitConcur(8, async (artifact) => {
+			await putObject(artifact.key, artifact.bytes, {
+				cacheControl: IMMUTABLE_ASSET_CACHE_CONTROL,
+				contentType: BINARY_CONTENT_TYPES[artifact.extension],
+			});
+		}),
+	);
+
 const storeArtifacts = async (
 	artifacts: readonly BuiltArtifact[],
 ): Promise<void> => {
-	await Promise.all(
-		artifacts.map(
-			limitConcur(8, async (artifact) => {
-				await putObject(artifact.key, artifact.bytes, {
-					cacheControl: IMMUTABLE_ASSET_CACHE_CONTROL,
-					contentType: BINARY_CONTENT_TYPES[artifact.extension],
-				});
-			}),
-		),
-	);
+	await Promise.all(uploadArtifacts(artifacts));
 };
+
+type LoadAsset = (filename: string) => Promise<Uint8Array>;
 
 const buildStaticArtifacts = async (
 	tag: BuildVersionTag,
 	manifest: readonly StaticFontEntry[],
+	loadAsset: LoadAsset = (filename) =>
+		fetchPackageAssetBytes(tag.id, tag.version, filename),
 ): Promise<BuiltArtifact[]> => {
 	if (manifest.length === 0) {
 		return [];
@@ -96,7 +104,7 @@ const buildStaticArtifacts = async (
 			return existing;
 		}
 
-		const load = fetchPackageAssetBytes(tag.id, tag.version, filename);
+		const load = loadAsset(filename);
 		fetchCache.set(filename, load);
 		return load;
 	};
@@ -175,6 +183,8 @@ const buildStaticArtifacts = async (
 const buildVariableArtifacts = async (
 	tag: BuildVersionTag,
 	manifest: readonly VariableFontEntry[],
+	loadAsset: LoadAsset = (filename) =>
+		fetchPackageAssetBytes(tag.id, tag.version, filename, true),
 ): Promise<BuiltArtifact[]> => {
 	if (manifest.length === 0) {
 		return [];
@@ -191,12 +201,7 @@ const buildVariableArtifacts = async (
 						await ignoreUpstream404(async () =>
 							createArtifact(
 								getVariableAssetKey(tag.id, tag.version, item.filename),
-								await fetchPackageAssetBytes(
-									tag.id,
-									tag.version,
-									item.sourceFilename,
-									true,
-								),
+								await loadAsset(item.sourceFilename),
 								item.extension,
 							),
 						),
@@ -252,37 +257,105 @@ const buildSingleArtifact = async (
 	return built.length;
 };
 
+const readPackageArchive = async (
+	id: string,
+	version: string,
+	isVariable: boolean,
+): Promise<Map<string, Uint8Array>> => {
+	const assetPrefix = `package/files/${id}-`;
+	const entries = await unpackTar(
+		(await fetchPackageTarball(id, version, isVariable)).pipeThrough(
+			createGzipDecoder(),
+		),
+		{
+			strict: true,
+			filter: (header) =>
+				header.name === 'package/LICENSE' ||
+				header.name.startsWith(assetPrefix),
+		},
+	);
+
+	return new Map(
+		entries.flatMap((entry) =>
+			entry.data ? [[entry.header.name, entry.data]] : [],
+		),
+	);
+};
+
+const listPackageAssets = (
+	files: ReadonlyMap<string, Uint8Array>,
+	id: string,
+) => {
+	const prefix = `package/files/${id}-`;
+
+	return new Set(
+		[...files.keys()]
+			.filter((name) => name.startsWith(prefix))
+			.map((name) => name.slice(prefix.length)),
+	);
+};
+
+const readPackageFile = async (
+	files: ReadonlyMap<string, Uint8Array>,
+	path: string,
+): Promise<Uint8Array> => {
+	const bytes = files.get(path);
+	if (!bytes) {
+		throw new Error(`Expected npm package entry "${path}" was not found`);
+	}
+
+	return bytes;
+};
+
 const buildDownloadArtifacts = async (
 	request: BuildDownloadRequest,
 ): Promise<number> => {
 	const { id } = request.metadata;
 	const axes = request.metadata.variable || undefined;
+	if (axes && !request.variableVersion) {
+		throw new Error(`Variable package version required for ${id}`);
+	}
+
 	const variableVersion = request.variableVersion ?? request.staticVersion;
 	const staticTag = { id, version: request.staticVersion };
 	const variableTag = { id, version: variableVersion };
-	const [publishedStaticFiles, publishedVariableFiles] = await Promise.all([
-		fetchPackageFileList(id, request.staticVersion, false),
+	const [staticPackage, variablePackage] = await Promise.all([
+		readPackageArchive(id, request.staticVersion, false),
 		axes && request.variableVersion
-			? fetchPackageFileList(id, request.variableVersion, true)
+			? readPackageArchive(id, request.variableVersion, true)
 			: undefined,
 	]);
 	const { static: staticManifest, variable: variableManifest } =
 		filterPublishedManifest(
 			resolveFontPackageManifest(request.metadata, axes),
-			publishedStaticFiles,
-			publishedVariableFiles,
+			listPackageAssets(staticPackage, id),
+			variablePackage ? listPackageAssets(variablePackage, id) : undefined,
 		);
 
-	if (staticManifest.length === 0 && variableManifest.length === 0) {
+	if (staticManifest.length === 0) {
 		throw new Error(
-			`No artifacts published for ${id}@${request.staticVersion}`,
+			`No static artifacts published for ${id}@${request.staticVersion}`,
+		);
+	}
+	if (variablePackage && variableManifest.length === 0) {
+		throw new Error(
+			`No variable artifacts published for ${id}@${variableVersion}`,
 		);
 	}
 
 	const [staticArtifacts, variableArtifacts, license] = await Promise.all([
-		buildStaticArtifacts(staticTag, staticManifest),
-		buildVariableArtifacts(variableTag, variableManifest),
-		fetchPackageLicenseBytes(id, request.staticVersion, false),
+		buildStaticArtifacts(staticTag, staticManifest, (filename) =>
+			readPackageFile(staticPackage, `package/files/${id}-${filename}`),
+		),
+		buildVariableArtifacts(
+			variableTag,
+			variableManifest,
+			variablePackage
+				? (filename) =>
+						readPackageFile(variablePackage, `package/files/${id}-${filename}`)
+				: undefined,
+		),
+		readPackageFile(staticPackage, 'package/LICENSE'),
 	]);
 	const artifacts = [...staticArtifacts, ...variableArtifacts];
 	const builtByKey = new Map(
@@ -321,7 +394,6 @@ const buildDownloadArtifacts = async (
 		]),
 	);
 
-	await storeArtifacts(artifacts);
 	await putObject(
 		getDownloadKey(id, request.staticVersion, request.variableVersion),
 		archive,
@@ -330,8 +402,22 @@ const buildDownloadArtifacts = async (
 			contentType: BINARY_CONTENT_TYPES.zip,
 		},
 	);
+	console.log(
+		`[artifacts] download ready ${id}@${request.staticVersion} (${archive.byteLength} bytes)`,
+	);
 
-	return artifacts.length + 1;
+	const warmResults = await Promise.allSettled(uploadArtifacts(artifacts));
+	const warmFailures = warmResults.filter(
+		(result) => result.status === 'rejected',
+	);
+	if (warmFailures.length > 0) {
+		console.error(
+			`[artifacts] failed to warm ${warmFailures.length}/${artifacts.length} individual artifacts for ${id}@${request.staticVersion}`,
+			warmFailures.map((result) => result.reason),
+		);
+	}
+
+	return artifacts.length - warmFailures.length + 1;
 };
 
 export const buildArtifacts = async (

--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -65,6 +65,18 @@ const createArtifact = (
 	extension,
 });
 
+const getPackageFile = (
+	files: ReadonlyMap<string, Uint8Array>,
+	filename: string,
+): Uint8Array => {
+	const bytes = files.get(filename);
+	if (!bytes) {
+		throw new Error(`Expected npm package file "${filename}" was not found`);
+	}
+
+	return bytes;
+};
+
 const uploadArtifacts = (
 	artifacts: readonly BuiltArtifact[],
 ): Promise<void>[] =>
@@ -83,13 +95,10 @@ const storeArtifacts = async (
 	await Promise.all(uploadArtifacts(artifacts));
 };
 
-type LoadAsset = (filename: string) => Promise<Uint8Array>;
-
 const buildStaticArtifacts = async (
 	tag: BuildVersionTag,
 	manifest: readonly StaticFontEntry[],
-	loadAsset: LoadAsset = (filename) =>
-		fetchPackageAssetBytes(tag.id, tag.version, filename),
+	packageFiles?: ReadonlyMap<string, Uint8Array>,
 ): Promise<BuiltArtifact[]> => {
 	if (manifest.length === 0) {
 		return [];
@@ -104,7 +113,9 @@ const buildStaticArtifacts = async (
 			return existing;
 		}
 
-		const load = loadAsset(filename);
+		const load = packageFiles
+			? Promise.resolve(getPackageFile(packageFiles, filename))
+			: fetchPackageAssetBytes(tag.id, tag.version, filename);
 		fetchCache.set(filename, load);
 		return load;
 	};
@@ -183,8 +194,7 @@ const buildStaticArtifacts = async (
 const buildVariableArtifacts = async (
 	tag: BuildVersionTag,
 	manifest: readonly VariableFontEntry[],
-	loadAsset: LoadAsset = (filename) =>
-		fetchPackageAssetBytes(tag.id, tag.version, filename, true),
+	packageFiles?: ReadonlyMap<string, Uint8Array>,
 ): Promise<BuiltArtifact[]> => {
 	if (manifest.length === 0) {
 		return [];
@@ -198,13 +208,22 @@ const buildVariableArtifacts = async (
 				limitConcur(
 					8,
 					async (item) =>
-						await ignoreUpstream404(async () =>
-							createArtifact(
+						await ignoreUpstream404(async () => {
+							const bytes = packageFiles
+								? getPackageFile(packageFiles, item.sourceFilename)
+								: await fetchPackageAssetBytes(
+										tag.id,
+										tag.version,
+										item.sourceFilename,
+										true,
+									);
+
+							return createArtifact(
 								getVariableAssetKey(tag.id, tag.version, item.filename),
-								await loadAsset(item.sourceFilename),
+								bytes,
 								item.extension,
-							),
-						),
+							);
+						}),
 				),
 			),
 		)
@@ -276,35 +295,16 @@ const readPackageArchive = async (
 	);
 
 	return new Map(
-		entries.flatMap((entry) =>
-			entry.data ? [[entry.header.name, entry.data]] : [],
-		),
+		entries.flatMap((entry) => {
+			if (!entry.data) return [];
+
+			const filename =
+				entry.header.name === 'package/LICENSE'
+					? 'LICENSE'
+					: entry.header.name.slice(assetPrefix.length);
+			return [[filename, entry.data]];
+		}),
 	);
-};
-
-const listPackageAssets = (
-	files: ReadonlyMap<string, Uint8Array>,
-	id: string,
-) => {
-	const prefix = `package/files/${id}-`;
-
-	return new Set(
-		[...files.keys()]
-			.filter((name) => name.startsWith(prefix))
-			.map((name) => name.slice(prefix.length)),
-	);
-};
-
-const readPackageFile = async (
-	files: ReadonlyMap<string, Uint8Array>,
-	path: string,
-): Promise<Uint8Array> => {
-	const bytes = files.get(path);
-	if (!bytes) {
-		throw new Error(`Expected npm package entry "${path}" was not found`);
-	}
-
-	return bytes;
 };
 
 const buildDownloadArtifacts = async (
@@ -328,34 +328,20 @@ const buildDownloadArtifacts = async (
 	const { static: staticManifest, variable: variableManifest } =
 		filterPublishedManifest(
 			resolveFontPackageManifest(request.metadata, axes),
-			listPackageAssets(staticPackage, id),
-			variablePackage ? listPackageAssets(variablePackage, id) : undefined,
+			new Set(staticPackage.keys()),
+			variablePackage ? new Set(variablePackage.keys()) : undefined,
 		);
 
-	if (staticManifest.length === 0) {
+	if (staticManifest.length === 0 || (axes && variableManifest.length === 0)) {
 		throw new Error(
-			`No static artifacts published for ${id}@${request.staticVersion}`,
-		);
-	}
-	if (variablePackage && variableManifest.length === 0) {
-		throw new Error(
-			`No variable artifacts published for ${id}@${variableVersion}`,
+			`No artifacts published for ${id}@${request.staticVersion}`,
 		);
 	}
 
 	const [staticArtifacts, variableArtifacts, license] = await Promise.all([
-		buildStaticArtifacts(staticTag, staticManifest, (filename) =>
-			readPackageFile(staticPackage, `package/files/${id}-${filename}`),
-		),
-		buildVariableArtifacts(
-			variableTag,
-			variableManifest,
-			variablePackage
-				? (filename) =>
-						readPackageFile(variablePackage, `package/files/${id}-${filename}`)
-				: undefined,
-		),
-		readPackageFile(staticPackage, 'package/LICENSE'),
+		buildStaticArtifacts(staticTag, staticManifest, staticPackage),
+		buildVariableArtifacts(variableTag, variableManifest, variablePackage),
+		getPackageFile(staticPackage, 'LICENSE'),
 	]);
 	const artifacts = [...staticArtifacts, ...variableArtifacts];
 	const builtByKey = new Map(
@@ -402,10 +388,6 @@ const buildDownloadArtifacts = async (
 			contentType: BINARY_CONTENT_TYPES.zip,
 		},
 	);
-	console.log(
-		`[artifacts] download ready ${id}@${request.staticVersion} (${archive.byteLength} bytes)`,
-	);
-
 	const warmResults = await Promise.allSettled(uploadArtifacts(artifacts));
 	const warmFailures = warmResults.filter(
 		(result) => result.status === 'rejected',
@@ -417,7 +399,7 @@ const buildDownloadArtifacts = async (
 		);
 	}
 
-	return artifacts.length - warmFailures.length + 1;
+	return artifacts.length + 1;
 };
 
 export const buildArtifacts = async (

--- a/api/worker/package.json
+++ b/api/worker/package.json
@@ -26,6 +26,7 @@
 		"fflate": "^0.8.2",
 		"hono": "^4.12.18",
 		"limit-concur": "^4.0.0",
+		"modern-tar": "0.7.6",
 		"zod": "4.4.3"
 	},
 	"devDependencies": {

--- a/api/worker/shared/upstream.ts
+++ b/api/worker/shared/upstream.ts
@@ -33,6 +33,7 @@ export const UPSTREAM_URLS = {
 		jsdelivrTotal:
 			'https://raw.githubusercontent.com/fontsource/download-stat-aggregator/main/data/jsDelivrTotalPopular.json',
 	},
+	npmRegistry: 'https://registry.npmjs.org',
 	jsdelivrPackage: 'https://data.jsdelivr.com/v1/packages/npm',
 	jsdelivrNpm: 'https://cdn.jsdelivr.net/npm',
 	publicApi: 'https://api.fontsource.org',
@@ -70,17 +71,18 @@ const fetchWithCache = async (
 };
 
 /** Fetches an upstream binary with asset-specific cache policy. */
+const fetchBinary = (url: string): Promise<Response> =>
+	fetchWithCache(url, {
+		cacheEverything: true,
+		cacheTtlByStatus: {
+			'200-299': 86400,
+			404: 60,
+			'500-599': 0,
+		},
+	});
+
 const fetchBinaryBytes = async (url: string): Promise<Uint8Array> =>
-	(
-		await fetchWithCache(url, {
-			cacheEverything: true,
-			cacheTtlByStatus: {
-				'200-299': 86400,
-				404: 60,
-				'500-599': 0,
-			},
-		})
-	).bytes();
+	(await fetchBinary(url)).bytes();
 
 const packageScope = (isVariable: boolean): string =>
 	isVariable ? '@fontsource-variable' : '@fontsource';
@@ -131,6 +133,21 @@ export const fetchPackageFileList = async (
 	);
 };
 
+export const fetchPackageTarball = async (
+	id: string,
+	version: string,
+	isVariable = false,
+): Promise<ReadableStream<Uint8Array>> => {
+	const url = `${UPSTREAM_URLS.npmRegistry}/${packageName(id, isVariable)}/-/${id}-${version}.tgz`;
+	const response = await fetchBinary(url);
+
+	if (!response.body) {
+		throw new Error(`Upstream response body was empty: ${url}`);
+	}
+
+	return response.body;
+};
+
 export const fetchPackageAssetBytes = async (
 	id: string,
 	version: string,
@@ -139,13 +156,4 @@ export const fetchPackageAssetBytes = async (
 ): Promise<Uint8Array> =>
 	fetchBinaryBytes(
 		`${UPSTREAM_URLS.jsdelivrNpm}/${packageName(id, isVariable)}@${version}/files/${id}-${file}`,
-	);
-
-export const fetchPackageLicenseBytes = async (
-	id: string,
-	version: string,
-	isVariable = false,
-): Promise<Uint8Array> =>
-	fetchBinaryBytes(
-		`${UPSTREAM_URLS.jsdelivrNpm}/${packageName(id, isVariable)}@${version}/LICENSE`,
 	);

--- a/api/worker/shared/upstream.ts
+++ b/api/worker/shared/upstream.ts
@@ -71,18 +71,17 @@ const fetchWithCache = async (
 };
 
 /** Fetches an upstream binary with asset-specific cache policy. */
-const fetchBinary = (url: string): Promise<Response> =>
-	fetchWithCache(url, {
-		cacheEverything: true,
-		cacheTtlByStatus: {
-			'200-299': 86400,
-			404: 60,
-			'500-599': 0,
-		},
-	});
-
 const fetchBinaryBytes = async (url: string): Promise<Uint8Array> =>
-	(await fetchBinary(url)).bytes();
+	(
+		await fetchWithCache(url, {
+			cacheEverything: true,
+			cacheTtlByStatus: {
+				'200-299': 86400,
+				404: 60,
+				'500-599': 0,
+			},
+		})
+	).bytes();
 
 const packageScope = (isVariable: boolean): string =>
 	isVariable ? '@fontsource-variable' : '@fontsource';
@@ -139,7 +138,7 @@ export const fetchPackageTarball = async (
 	isVariable = false,
 ): Promise<ReadableStream<Uint8Array>> => {
 	const url = `${UPSTREAM_URLS.npmRegistry}/${packageName(id, isVariable)}/-/${id}-${version}.tgz`;
-	const response = await fetchBinary(url);
+	const response = await fetchWithCache(url);
 
 	if (!response.body) {
 		throw new Error(`Upstream response body was empty: ${url}`);

--- a/api/worker/tests/artifacts.test.ts
+++ b/api/worker/tests/artifacts.test.ts
@@ -1,4 +1,5 @@
-import { unzipSync } from 'fflate';
+import { gzipSync, unzipSync } from 'fflate';
+import { packTar } from 'modern-tar';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BuildVersionRequest } from '../shared/build';
 import { resolveFontPackageManifest } from '../shared/font-package-manifest';
@@ -17,7 +18,7 @@ const {
 	putObject,
 	fetchPackageAssetBytes,
 	fetchPackageFileList,
-	fetchPackageLicenseBytes,
+	fetchPackageTarball,
 	convertFont,
 	destroy,
 	createFontContext,
@@ -28,7 +29,7 @@ const {
 		putObject: vi.fn(),
 		fetchPackageAssetBytes: vi.fn(),
 		fetchPackageFileList: vi.fn(),
-		fetchPackageLicenseBytes: vi.fn(),
+		fetchPackageTarball: vi.fn(),
 		convertFont: vi.fn(),
 		destroy,
 		createFontContext: vi.fn(() => ({ destroy })),
@@ -49,7 +50,7 @@ vi.mock('../shared/upstream', async () => {
 		...actual,
 		fetchPackageAssetBytes,
 		fetchPackageFileList,
-		fetchPackageLicenseBytes,
+		fetchPackageTarball,
 	};
 });
 
@@ -66,11 +67,69 @@ vi.mock('@fontsource-utils/core', async () => {
 });
 
 describe('container artifact builder', () => {
+	const createPackageTarball = async (
+		id: string,
+		isVariable = false,
+		publishedFiles?: ReadonlySet<string>,
+	): Promise<Uint8Array> => {
+		const metadata = testCatalog[id];
+		if (!metadata) {
+			throw new Error(`Missing test metadata for ${id}`);
+		}
+
+		const manifest = resolveFontPackageManifest(
+			metadata,
+			isVariable ? metadata.variable || undefined : undefined,
+		);
+		const entries = isVariable ? manifest.variable : manifest.static;
+		const files: Array<[string, Uint8Array]> = [];
+
+		for (const filename of new Set(
+			entries.map((item) => item.sourceFilename),
+		)) {
+			if (publishedFiles && !publishedFiles.has(filename)) {
+				continue;
+			}
+
+			const bytes = isVariable
+				? variableWoff2Bytes
+				: filename.endsWith('.woff2')
+					? staticWoff2Bytes
+					: staticWoffBytes;
+			files.push([`package/files/${id}-${filename}`, bytes]);
+		}
+
+		if (!isVariable) {
+			files.push([
+				'package/LICENSE',
+				new TextEncoder().encode('Example License'),
+			]);
+		}
+
+		return gzipSync(
+			await packTar(
+				files.map(([name, body]) => ({
+					header: { name, size: body.byteLength, type: 'file' },
+					body,
+				})),
+			),
+		);
+	};
+
+	const tarballStream = (tarball: Uint8Array): ReadableStream<Uint8Array> => {
+		const body = new Response(tarball).body;
+		if (!body) {
+			throw new Error('Missing test tarball body');
+		}
+
+		return body;
+	};
+
 	beforeEach(() => {
 		putObject.mockReset();
 		fetchPackageAssetBytes.mockReset();
 		fetchPackageFileList.mockReset();
-		fetchPackageLicenseBytes.mockReset();
+		fetchPackageTarball.mockReset();
 		convertFont.mockReset();
 		destroy.mockReset();
 		createFontContext.mockClear();
@@ -101,8 +160,10 @@ describe('container artifact builder', () => {
 				);
 			},
 		);
-		fetchPackageLicenseBytes.mockResolvedValue(
-			new TextEncoder().encode('Example License'),
+		fetchPackageTarball.mockImplementation(
+			async (id: string, _version: string, isVariable = false) => {
+				return tarballStream(await createPackageTarball(id, isVariable));
+			},
 		);
 		fetchPackageAssetBytes.mockImplementation(
 			async (
@@ -150,7 +211,6 @@ describe('container artifact builder', () => {
 
 		await expect(buildArtifacts(request)).resolves.toBe(1);
 
-		expect(fetchPackageLicenseBytes).not.toHaveBeenCalled();
 		expect(convertFont).not.toHaveBeenCalled();
 		expect(putObject).toHaveBeenCalledTimes(1);
 		expect(putObject).toHaveBeenCalledWith(
@@ -179,7 +239,6 @@ describe('container artifact builder', () => {
 
 		await expect(buildArtifacts(request)).resolves.toBe(1);
 
-		expect(fetchPackageLicenseBytes).not.toHaveBeenCalled();
 		expect(convertFont).not.toHaveBeenCalled();
 		expect(putObject).toHaveBeenCalledTimes(1);
 		expect(putObject).toHaveBeenCalledWith(
@@ -215,7 +274,6 @@ describe('container artifact builder', () => {
 			'latin-400-normal.woff',
 		);
 		expect(convertFont).toHaveBeenCalledTimes(1);
-		expect(fetchPackageLicenseBytes).not.toHaveBeenCalled();
 		expect(putObject).toHaveBeenCalledTimes(1);
 		expect(putObject).toHaveBeenCalledWith(
 			'abel@1.0.0/latin-400-normal.ttf',
@@ -266,11 +324,55 @@ describe('container artifact builder', () => {
 		expect(archive['static/familypack-latin-700-normal.ttf']).toEqual(
 			staticTtfBytes,
 		);
+		expect(fetchPackageAssetBytes).not.toHaveBeenCalled();
+		expect(fetchPackageFileList).not.toHaveBeenCalled();
+		expect(fetchPackageTarball).toHaveBeenCalledWith(
+			'familypack',
+			'1.0.0',
+			false,
+		);
 	});
 
-	it('does not publish the family zip when an artifact upload fails', async () => {
+	it('combines exact static and variable package versions', async () => {
 		const { buildArtifacts } = await import('../container/src/artifacts');
-		putObject.mockRejectedValueOnce(new Error('artifact upload failed'));
+
+		await buildArtifacts({
+			mode: 'download',
+			staticVersion: '1.0.0',
+			variableVersion: '2.0.0',
+			metadata: variableMetadata,
+		});
+
+		expect(fetchPackageTarball).toHaveBeenCalledWith(
+			'recursive',
+			'1.0.0',
+			false,
+		);
+		expect(fetchPackageTarball).toHaveBeenCalledWith(
+			'recursive',
+			'2.0.0',
+			true,
+		);
+
+		const zipPut = putObject.mock.calls.find(
+			([key]) => key === 'recursive@1.0.0+vf@2.0.0/download.zip',
+		);
+		const archive = unzipSync(zipPut?.[1] as Uint8Array);
+		expect(Object.keys(archive)).toEqual(
+			expect.arrayContaining([
+				'static/recursive-latin-400-normal.woff2',
+				'variable/recursive-latin-full-normal.woff2',
+				'LICENSE',
+			]),
+		);
+	});
+
+	it('keeps the download available when an individual warm upload fails', async () => {
+		const { buildArtifacts } = await import('../container/src/artifacts');
+		const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+		putObject
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new Error('artifact upload failed'));
 
 		await expect(
 			buildArtifacts({
@@ -278,32 +380,69 @@ describe('container artifact builder', () => {
 				staticVersion: '1.0.0',
 				metadata: staticMetadata,
 			}),
-		).rejects.toThrow('artifact upload failed');
+		).resolves.toBeGreaterThan(1);
 
 		expect(
 			putObject.mock.calls.some(([key]) => key === 'abel@1.0.0/download.zip'),
-		).toBe(false);
+		).toBe(true);
+		expect(errorLog).toHaveBeenCalledWith(
+			expect.stringContaining('failed to warm 1/'),
+			expect.arrayContaining([expect.any(Error)]),
+		);
+		errorLog.mockRestore();
+	});
+
+	it('publishes the download before individual warming completes', async () => {
+		const { buildArtifacts } = await import('../container/src/artifacts');
+		const releaseUploads: Array<() => void> = [];
+		putObject.mockImplementation(async (key: string) => {
+			if (key === 'abel@1.0.0/download.zip') {
+				return;
+			}
+
+			await new Promise<void>((resolve) => {
+				releaseUploads.push(resolve);
+			});
+		});
+
+		let finished = false;
+		const build = buildArtifacts({
+			mode: 'download',
+			staticVersion: '1.0.0',
+			metadata: staticMetadata,
+		}).finally(() => {
+			finished = true;
+		});
+
+		await vi.waitFor(() => {
+			expect(
+				putObject.mock.calls.some(([key]) => key === 'abel@1.0.0/download.zip'),
+			).toBe(true);
+			expect(releaseUploads.length).toBeGreaterThan(0);
+		});
+		expect(finished).toBe(false);
+
+		for (const release of releaseUploads) {
+			release();
+		}
+		await expect(build).resolves.toBe(4);
 	});
 
 	it('filters download artifacts to files published for that version', async () => {
 		const { buildArtifacts } = await import('../container/src/artifacts');
-		fetchPackageFileList.mockImplementation(
-			async (id, _version, isVariable = false) => {
-				if (id === testCatalog.familypack.id && !isVariable) {
-					return new Set([
+		fetchPackageTarball.mockResolvedValueOnce(
+			tarballStream(
+				await createPackageTarball(
+					testCatalog.familypack.id,
+					false,
+					new Set([
 						'latin-400-normal.woff2',
 						'latin-400-normal.woff',
 						'latin-700-normal.woff2',
 						'latin-700-normal.woff',
-					]);
-				}
-
-				return new Set(
-					resolveFontPackageManifest(staticMetadata).static.map(
-						(item) => item.sourceFilename,
-					),
-				);
-			},
+					]),
+				),
+			),
 		);
 
 		const request: BuildVersionRequest = {

--- a/api/worker/tests/upstream.test.ts
+++ b/api/worker/tests/upstream.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	fetchPackageAssetBytes,
 	fetchPackageFileList,
-	fetchPackageLicenseBytes,
+	fetchPackageTarball,
 	UPSTREAM_URLS,
 	UpstreamNotFoundError,
 } from '../shared/upstream';
@@ -30,23 +30,6 @@ describe('upstream package fetches', () => {
 		);
 	});
 
-	it('propagates UpstreamNotFoundError when jsdelivr returns 404 for a package license', async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue(new Response('missing', { status: 404 }));
-		vi.stubGlobal('fetch', fetchMock);
-
-		await expect(
-			fetchPackageLicenseBytes('abel', '5.2.7'),
-		).rejects.toBeInstanceOf(UpstreamNotFoundError);
-
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(fetchMock).toHaveBeenCalledWith(
-			`${UPSTREAM_URLS.jsdelivrNpm}/@fontsource/abel@5.2.7/LICENSE`,
-			expect.anything(),
-		);
-	});
-
 	it('loads the published package file list from the jsDelivr flat endpoint', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(
@@ -66,6 +49,20 @@ describe('upstream package fetches', () => {
 			fetchPackageFileList('noto-sans-jp', '5.2.7'),
 		).resolves.toEqual(
 			new Set(['japanese-400-normal.woff2', 'latin-400-normal.woff2']),
+		);
+	});
+
+	it('loads exact npm package tarballs from the registry', async () => {
+		const tarball = new Uint8Array([1, 2, 3]);
+		const fetchMock = vi.fn().mockResolvedValue(new Response(tarball));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const stream = await fetchPackageTarball('recursive', '5.2.8', true);
+		await expect(new Response(stream).bytes()).resolves.toEqual(tarball);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			`${UPSTREAM_URLS.npmRegistry}/@fontsource-variable/recursive/-/recursive-5.2.8.tgz`,
+			expect.anything(),
 		);
 	});
 });

--- a/api/worker/tests/upstream.test.ts
+++ b/api/worker/tests/upstream.test.ts
@@ -62,7 +62,7 @@ describe('upstream package fetches', () => {
 
 		expect(fetchMock).toHaveBeenCalledWith(
 			`${UPSTREAM_URLS.npmRegistry}/@fontsource-variable/recursive/-/recursive-5.2.8.tgz`,
-			expect.anything(),
+			undefined,
 		);
 	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
         "fflate": "^0.8.2",
         "hono": "^4.12.18",
         "limit-concur": "^4.0.0",
+        "modern-tar": "0.7.6",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -1612,6 +1613,8 @@
     "mkdirp": ["mkdirp@0.3.0", "", {}, "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 


### PR DESCRIPTION
This significantly speeds up cold cache zipped downloads on the new API worker by instead downloading the NPM tarballs and restitching them vs making 2k+ requests and stitching that instead. It is more CPU intensive, but significantly better than network latecy.

This makes the UX a lot more positive and relies on our NPM tarballs which are stable contracts to rely on.