### PR TITLE
feat(worker): optimize placement and container idling

### DIFF
--- a/api/worker/worker/src/container/binding.ts
+++ b/api/worker/worker/src/container/binding.ts
@@ -39,7 +39,7 @@ export const readBuildErrorMessage = async (
  */
 export class ArtifactBuilder extends Container<Env> {
 	defaultPort = 3000;
-	sleepAfter = '2m';
+	sleepAfter = '1s';
 	enableInternet = true;
 	private activeBuilds = new Map<string, Promise<BuildVersionResult>>();
 	private failedBuilds = new Map<string, BuildVersionFailure>();

--- a/api/worker/wrangler.toml
+++ b/api/worker/wrangler.toml
@@ -12,6 +12,9 @@ r2_buckets = [
   { binding = "FONTS", bucket_name = "fontsource-artifacts" },
 ]
 
+[placement]
+mode = "smart"
+
 [[durable_objects.bindings]]
 name = "ARTIFACT_BUILDER"
 class_name = "ArtifactBuilder"

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -6,6 +6,9 @@ workers_dev = true
 compatibility_flags = ["nodejs_compat"]
 compatibility_date = "2025-08-15"
 
+[placement]
+mode = "smart"
+
 [cache]
 enabled = true
 


### PR DESCRIPTION
Sets the artifact builder sleep to one second since once the job is done, we don't need to do anything else and not waste idle quota. Also enables smart placement.