### PR TITLE
chore(worker): raise container concurrency limit

### DIFF
--- a/api/worker/wrangler.toml
+++ b/api/worker/wrangler.toml
@@ -25,6 +25,7 @@ class_name = "ArtifactBuilder"
 image = "./container/Dockerfile"
 image_build_context = "../.."
 instance_type = "standard-1"
+max_instances = 150
 
 [cache]
 enabled = true


### PR DESCRIPTION
Raises the container concurrency limit for building font packages to handle more bursty workloads.