### PR TITLE
fix(website): prevent variable axis control overlap

### DIFF
--- a/website/app/components/preview/VariableButtons.module.css
+++ b/website/app/components/preview/VariableButtons.module.css
@@ -3,7 +3,7 @@
 	margin-top: 2px;
 	padding: 8px 12px;
 	justify-content: space-between;
-	height: 94px;
+	min-height: 94px;
 
 	border-radius: 4px;
 
@@ -16,4 +16,9 @@
 			background-color: light-dark(var(--mantine-color-purple-hover), var(--mantine-color-background-3));
 		}
 	}
+}
+
+.label {
+	flex: 1;
+	min-width: 0;
 }

--- a/website/app/components/preview/VariableButtons.tsx
+++ b/website/app/components/preview/VariableButtons.tsx
@@ -47,8 +47,8 @@ const VariableButton = observer(
 
 		return (
 			<Box className={classes.button}>
-				<Group justify="space-between" mb={5}>
-					<Group align="center" gap={2}>
+				<Group justify="space-between" mb={5} align="flex-start" wrap="nowrap">
+					<Group align="center" gap={2} className={classes.label}>
 						<Text fz="sm" fw={400}>
 							{label} <span>({tag})</span>
 						</Text>


### PR DESCRIPTION
Tweak the variable font selector container to wrap better if the variable axis name is really long.

<img width="724" height="434" alt="image" src="https://github.com/user-attachments/assets/f08ecae0-904b-4264-9ed0-169e6fd41f80" />

<img width="1280" height="844" alt="image" src="https://github.com/user-attachments/assets/9e857a7d-3788-468c-849d-d03fdcb767a0" />
