### PR TITLE
fix(api): build artifacts from published package files

### DIFF
--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -9,12 +9,6 @@ import type {
 	BuildVersionTag,
 } from '../../shared/build';
 import {
-	filterPublishedManifest,
-	resolveFontPackageManifest,
-	type StaticFontEntry,
-	type VariableFontEntry,
-} from '../../shared/font-package-manifest';
-import {
 	BINARY_CONTENT_TYPES,
 	IMMUTABLE_ASSET_CACHE_CONTROL,
 } from '../../shared/http-metadata';
@@ -28,16 +22,19 @@ import { putObject } from './r2';
 
 interface BuiltArtifact {
 	key: string;
+	filename: string;
 	bytes: Uint8Array;
-	extension: StaticFontEntry['extension'] | VariableFontEntry['extension'];
+	extension: 'woff2' | 'woff' | 'ttf';
 }
 
 const createArtifact = (
 	key: string,
+	filename: string,
 	bytes: Uint8Array,
 	extension: BuiltArtifact['extension'],
 ): BuiltArtifact => ({
 	key,
+	filename,
 	bytes,
 	extension,
 });
@@ -68,23 +65,25 @@ const uploadArtifacts = (
 
 const buildStaticArtifacts = async (
 	tag: BuildVersionTag,
-	manifest: readonly StaticFontEntry[],
 	packageFiles: ReadonlyMap<string, Uint8Array>,
 ): Promise<BuiltArtifact[]> => {
-	const copyPlan = manifest.filter((item) => item.buildMode === 'copy');
-	const convertPlan = manifest.filter(
-		(item) => item.buildMode === 'convert-woff-to-ttf',
+	const copyPlan = [...packageFiles].filter(
+		([filename]) => filename.endsWith('.woff2') || filename.endsWith('.woff'),
+	);
+	const convertPlan = copyPlan.filter(([filename]) =>
+		filename.endsWith('.woff2'),
 	);
 
 	console.log(
 		`[artifacts] static build plan: copy=${copyPlan.length}, convert=${convertPlan.length}`,
 	);
 
-	const copied = copyPlan.map((item) =>
+	const copied = copyPlan.map(([filename, bytes]) =>
 		createArtifact(
-			getStaticAssetKey(tag.id, tag.version, item.filename),
-			getPackageFile(packageFiles, item.sourceFilename),
-			item.extension,
+			getStaticAssetKey(tag.id, tag.version, filename),
+			filename,
+			bytes,
+			filename.endsWith('.woff2') ? 'woff2' : 'woff',
 		),
 	);
 
@@ -96,18 +95,20 @@ const buildStaticArtifacts = async (
 	try {
 		const converted = await Promise.all(
 			convertPlan.map(
-				limitConcur(8, async (item) => {
+				limitConcur(8, async ([sourceFilename, bytes]) => {
+					const filename = sourceFilename.replace(/\.woff2$/, '.ttf');
 					const [{ data }] = await convertFont(
 						ctx,
-						getPackageFile(packageFiles, item.sourceFilename),
+						bytes,
 						['ttf'],
-						`${tag.id}-${item.sourceFilename}`,
+						`${tag.id}-${sourceFilename}`,
 					);
 
 					return createArtifact(
-						getStaticAssetKey(tag.id, tag.version, item.filename),
+						getStaticAssetKey(tag.id, tag.version, filename),
+						filename,
 						data,
-						item.extension,
+						'ttf',
 					);
 				}),
 			),
@@ -121,16 +122,19 @@ const buildStaticArtifacts = async (
 
 const buildVariableArtifacts = (
 	tag: BuildVersionTag,
-	manifest: readonly VariableFontEntry[],
 	packageFiles: ReadonlyMap<string, Uint8Array>,
 ): BuiltArtifact[] => {
-	console.log(`[artifacts] variable build plan: files=${manifest.length}`);
+	const sources = [...packageFiles].filter(([filename]) =>
+		filename.endsWith('.woff2'),
+	);
+	console.log(`[artifacts] variable build plan: files=${sources.length}`);
 
-	return manifest.map((item) =>
+	return sources.map(([filename, bytes]) =>
 		createArtifact(
-			getVariableAssetKey(tag.id, tag.version, item.filename),
-			getPackageFile(packageFiles, item.sourceFilename),
-			item.extension,
+			getVariableAssetKey(tag.id, tag.version, filename),
+			filename,
+			bytes,
+			'woff2',
 		),
 	);
 };
@@ -174,27 +178,11 @@ const buildPackageArtifacts = async (
 		request.tag.version,
 		request.mode === 'variable',
 	);
-	const manifest = resolveFontPackageManifest(
-		request.metadata,
-		request.metadata.variable || undefined,
-	);
 
 	const built =
 		request.mode === 'variable'
-			? buildVariableArtifacts(
-					request.tag,
-					manifest.variable.filter((item) =>
-						packageFiles.has(item.sourceFilename),
-					),
-					packageFiles,
-				)
-			: await buildStaticArtifacts(
-					request.tag,
-					manifest.static.filter((item) =>
-						packageFiles.has(item.sourceFilename),
-					),
-					packageFiles,
-				);
+			? buildVariableArtifacts(request.tag, packageFiles)
+			: await buildStaticArtifacts(request.tag, packageFiles);
 
 	if (built.length === 0) {
 		throw new Error(
@@ -229,60 +217,34 @@ const buildDownloadArtifacts = async (
 			? readPackageArchive(id, request.variableVersion, true)
 			: undefined,
 	]);
-	const { static: staticManifest, variable: variableManifest } =
-		filterPublishedManifest(
-			resolveFontPackageManifest(request.metadata, axes),
-			new Set(staticPackage.keys()),
-			variablePackage ? new Set(variablePackage.keys()) : undefined,
-		);
-
-	if (staticManifest.length === 0 || (axes && variableManifest.length === 0)) {
+	const license = getPackageFile(staticPackage, 'LICENSE');
+	const staticArtifacts = await buildStaticArtifacts(staticTag, staticPackage);
+	const variableArtifacts = variablePackage
+		? buildVariableArtifacts(variableTag, variablePackage)
+		: [];
+	if (staticArtifacts.length === 0) {
 		throw new Error(
-			`No artifacts published for ${id}@${request.staticVersion}`,
+			`No static artifacts published for ${id}@${request.staticVersion}`,
+		);
+	}
+	if (axes && variableArtifacts.length === 0) {
+		throw new Error(
+			`No variable artifacts published for ${id}@${request.variableVersion}`,
 		);
 	}
 
-	const license = getPackageFile(staticPackage, 'LICENSE');
-	const staticArtifacts = await buildStaticArtifacts(
-		staticTag,
-		staticManifest,
-		staticPackage,
-	);
-	const variableArtifacts = variablePackage
-		? buildVariableArtifacts(variableTag, variableManifest, variablePackage)
-		: [];
 	const artifacts = [...staticArtifacts, ...variableArtifacts];
-	const builtByKey = new Map(
-		artifacts.map((artifact) => [artifact.key, artifact.bytes]),
-	);
-	const archiveEntries = [
-		...staticManifest.map((item) => ({
-			item,
-			key: getStaticAssetKey(id, request.staticVersion, item.filename),
-			directory: 'static',
-		})),
-		...variableManifest.map((item) => ({
-			item,
-			key: getVariableAssetKey(id, variableVersion, item.filename),
-			directory: 'variable',
-		})),
-	].map(({ item, key, directory }) => {
-		const bytes = builtByKey.get(key);
-		if (!bytes) {
-			throw new Error(`Expected artifact ${key} was not built`);
-		}
-
-		return {
-			path: `${directory}/${id}-${item.filename}`,
-			bytes,
-			compress: item.buildMode === 'copy',
-		};
-	});
 	const archive = zipSync(
 		Object.fromEntries([
-			...archiveEntries.map((entry) => [
-				entry.path,
-				entry.compress ? [entry.bytes, { level: 0 }] : entry.bytes,
+			...staticArtifacts.map((artifact) => [
+				`static/${id}-${artifact.filename}`,
+				artifact.extension === 'ttf'
+					? artifact.bytes
+					: [artifact.bytes, { level: 0 }],
+			]),
+			...variableArtifacts.map((artifact) => [
+				`variable/${id}-${artifact.filename}`,
+				[artifact.bytes, { level: 0 }],
 			]),
 			['LICENSE', license],
 		]),

--- a/api/worker/shared/font-package-manifest.ts
+++ b/api/worker/shared/font-package-manifest.ts
@@ -2,12 +2,9 @@ import { resolveFontFaces } from '@fontsource-utils/core';
 import type { SourceFontMetadata, VariableAxes } from './catalog';
 import { buildFontConfig } from './font-config';
 
-type FontBuildMode = 'copy' | 'convert-woff-to-ttf';
-
 interface FontEntry {
 	filename: string;
 	sourceFilename: string;
-	buildMode: FontBuildMode;
 	subset: string;
 	style: string;
 }
@@ -73,10 +70,8 @@ const buildStaticPlan = (metadata: SourceFontMetadata): StaticFontEntry[] => {
 				filename: source.publicFilename,
 				sourceFilename:
 					source.format === 'ttf'
-						? source.publicFilename.replace(/\.ttf$/, '.woff')
+						? source.publicFilename.replace(/\.ttf$/, '.woff2')
 						: source.publicFilename,
-				buildMode:
-					source.format === 'ttf' ? 'convert-woff-to-ttf' : ('copy' as const),
 				subset: face.subset,
 				weight,
 				style: face.style,
@@ -108,7 +103,6 @@ const buildVariablePlan = (
 			return {
 				filename: source.publicFilename,
 				sourceFilename: source.publicFilename,
-				buildMode: 'copy' as const,
 				subset: face.subset,
 				axisKey,
 				style: face.style,
@@ -132,18 +126,3 @@ export const findFontPackageEntry = (
 	target.isVariable
 		? manifest.variable.find((item) => item.filename === target.file)
 		: manifest.static.find((item) => item.filename === target.file);
-
-export const filterPublishedManifest = (
-	manifest: FontPackageManifest,
-	publishedStaticFiles: ReadonlySet<string>,
-	publishedVariableFiles?: ReadonlySet<string>,
-): FontPackageManifest => ({
-	static: manifest.static.filter((item) =>
-		publishedStaticFiles.has(item.sourceFilename),
-	),
-	variable: manifest.variable.filter((item) =>
-		publishedVariableFiles
-			? publishedVariableFiles.has(item.sourceFilename)
-			: false,
-	),
-});

--- a/api/worker/tests/__snapshots__/manifest.test.ts.snap
+++ b/api/worker/tests/__snapshots__/manifest.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`generates static manifest entries 1`] = `
 [
   {
-    "buildMode": "copy",
     "extension": "woff2",
     "filename": "latin-400-normal.woff2",
     "sourceFilename": "latin-400-normal.woff2",
@@ -12,7 +11,6 @@ exports[`generates static manifest entries 1`] = `
     "weight": 400,
   },
   {
-    "buildMode": "copy",
     "extension": "woff",
     "filename": "latin-400-normal.woff",
     "sourceFilename": "latin-400-normal.woff",
@@ -21,10 +19,9 @@ exports[`generates static manifest entries 1`] = `
     "weight": 400,
   },
   {
-    "buildMode": "convert-woff-to-ttf",
     "extension": "ttf",
     "filename": "latin-400-normal.ttf",
-    "sourceFilename": "latin-400-normal.woff",
+    "sourceFilename": "latin-400-normal.woff2",
     "style": "normal",
     "subset": "latin",
     "weight": 400,
@@ -36,7 +33,6 @@ exports[`generates variable manifest entries 1`] = `
 [
   {
     "axisKey": "MONO",
-    "buildMode": "copy",
     "extension": "woff2",
     "filename": "latin-mono-normal.woff2",
     "sourceFilename": "latin-mono-normal.woff2",
@@ -45,7 +41,6 @@ exports[`generates variable manifest entries 1`] = `
   },
   {
     "axisKey": "full",
-    "buildMode": "copy",
     "extension": "woff2",
     "filename": "latin-full-normal.woff2",
     "sourceFilename": "latin-full-normal.woff2",

--- a/api/worker/tests/artifacts.test.ts
+++ b/api/worker/tests/artifacts.test.ts
@@ -160,6 +160,12 @@ describe('container artifact builder', () => {
 		await expect(buildArtifacts(request)).resolves.toBe(3);
 
 		expect(convertFont).toHaveBeenCalledTimes(1);
+		expect(convertFont).toHaveBeenCalledWith(
+			expect.anything(),
+			staticWoff2Bytes,
+			['ttf'],
+			'familypack-latin-400-normal.woff2',
+		);
 		expect(putObject.mock.calls.map(([key]) => key).sort()).toEqual([
 			'familypack@1.0.0/latin-400-normal.ttf',
 			'familypack@1.0.0/latin-400-normal.woff',
@@ -251,8 +257,27 @@ describe('container artifact builder', () => {
 		);
 	});
 
-	it('combines exact static and variable package versions', async () => {
+	it('combines exact package versions using published variable filenames', async () => {
 		const { buildArtifacts } = await import('../container/src/artifacts');
+		const fallbackFilename = 'fallback-mono-normal.woff2';
+		const variableTarball = gzipSync(
+			await packTar([
+				{
+					header: {
+						name: `package/files/recursive-${fallbackFilename}`,
+						size: variableWoff2Bytes.byteLength,
+						type: 'file',
+					},
+					body: variableWoff2Bytes,
+				},
+			]),
+		);
+		fetchPackageTarball.mockImplementation(
+			async (id: string, _version: string, isVariable = false) =>
+				tarballStream(
+					isVariable ? variableTarball : await createPackageTarball(id, false),
+				),
+		);
 
 		await buildArtifacts({
 			mode: 'download',
@@ -279,7 +304,7 @@ describe('container artifact builder', () => {
 		expect(Object.keys(archive)).toEqual(
 			expect.arrayContaining([
 				'static/recursive-latin-400-normal.woff2',
-				'variable/recursive-latin-full-normal.woff2',
+				`variable/recursive-${fallbackFilename}`,
 				'LICENSE',
 			]),
 		);

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -428,7 +428,7 @@ const putStaticArtifacts = async (
 	for (const item of resolveFontPackageManifest(metadata).static) {
 		const bytes = await putStaticArtifact(env, metadata, version, item);
 		zipFiles[`static/${metadata.id}-${item.filename}`] =
-			item.buildMode === 'copy' ? [bytes, { level: 0 }] : bytes;
+			item.extension === 'ttf' ? bytes : [bytes, { level: 0 }];
 		artifactCount += 1;
 	}
 


### PR DESCRIPTION
Remove manifest logic and instead rely on the NPM tarball contents which simplifies any issues if our build CLI and API differ in logic (which it did for `playwrite-us-modern`).