### PR TITLE
fix(api): handle missing font packages

### DIFF
--- a/api/worker/container/server.ts
+++ b/api/worker/container/server.ts
@@ -1,5 +1,6 @@
 import { HTTPException } from 'hono/http-exception';
 import { type BuildVersionRequest, getBuildKey } from '../shared/build';
+import { UpstreamNotFoundError } from '../shared/upstream';
 import { buildArtifacts } from './src/artifacts';
 
 const PORT = 3000;
@@ -15,7 +16,11 @@ const resp404 = (): Response =>
 	);
 
 const errorStatus = (error: unknown): number =>
-	error instanceof HTTPException ? error.status : 500;
+	error instanceof HTTPException
+		? error.status
+		: error instanceof UpstreamNotFoundError
+			? 404
+			: 500;
 
 const respError = (error: unknown, request?: BuildVersionRequest): Response => {
 	const message = error instanceof Error ? error.message : String(error);

--- a/api/worker/container/src/artifacts.ts
+++ b/api/worker/container/src/artifacts.ts
@@ -203,31 +203,39 @@ const buildDownloadArtifacts = async (
 	request: BuildDownloadRequest,
 ): Promise<number> => {
 	const { id } = request.metadata;
-	const axes = request.metadata.variable || undefined;
-	if (axes && !request.variableVersion) {
-		throw new Error(`Variable package version required for ${id}`);
-	}
-
-	const variableVersion = request.variableVersion ?? request.staticVersion;
-	const staticTag = { id, version: request.staticVersion };
-	const variableTag = { id, version: variableVersion };
 	const [staticPackage, variablePackage] = await Promise.all([
-		readPackageArchive(id, request.staticVersion, false),
-		axes && request.variableVersion
+		request.staticVersion
+			? readPackageArchive(id, request.staticVersion, false)
+			: undefined,
+		request.variableVersion
 			? readPackageArchive(id, request.variableVersion, true)
 			: undefined,
 	]);
-	const license = getPackageFile(staticPackage, 'LICENSE');
-	const staticArtifacts = await buildStaticArtifacts(staticTag, staticPackage);
-	const variableArtifacts = variablePackage
-		? buildVariableArtifacts(variableTag, variablePackage)
-		: [];
-	if (staticArtifacts.length === 0) {
+	const packageWithLicense = staticPackage ?? variablePackage;
+	if (!packageWithLicense) {
+		throw new Error(`No package versions provided for ${id}`);
+	}
+	const license = getPackageFile(packageWithLicense, 'LICENSE');
+	const staticArtifacts =
+		request.staticVersion && staticPackage
+			? await buildStaticArtifacts(
+					{ id, version: request.staticVersion },
+					staticPackage,
+				)
+			: [];
+	const variableArtifacts =
+		request.variableVersion && variablePackage
+			? buildVariableArtifacts(
+					{ id, version: request.variableVersion },
+					variablePackage,
+				)
+			: [];
+	if (request.staticVersion && staticArtifacts.length === 0) {
 		throw new Error(
 			`No static artifacts published for ${id}@${request.staticVersion}`,
 		);
 	}
-	if (axes && variableArtifacts.length === 0) {
+	if (request.variableVersion && variableArtifacts.length === 0) {
 		throw new Error(
 			`No variable artifacts published for ${id}@${request.variableVersion}`,
 		);
@@ -263,8 +271,9 @@ const buildDownloadArtifacts = async (
 		(result) => result.status === 'rejected',
 	);
 	if (warmFailures.length > 0) {
+		const version = request.staticVersion ?? `vf@${request.variableVersion}`;
 		console.error(
-			`[artifacts] failed to warm ${warmFailures.length}/${artifacts.length} individual artifacts for ${id}@${request.staticVersion}`,
+			`[artifacts] failed to warm ${warmFailures.length}/${artifacts.length} individual artifacts for ${id}@${version}`,
 			warmFailures.map((result) => result.reason),
 		);
 	}

--- a/api/worker/shared/build.ts
+++ b/api/worker/shared/build.ts
@@ -15,7 +15,7 @@ export interface BuildPackageRequest {
 
 export interface BuildDownloadRequest {
 	mode: 'download';
-	staticVersion: string;
+	staticVersion?: string;
 	variableVersion?: string;
 	metadata: SourceFontMetadata;
 }
@@ -44,5 +44,7 @@ export type BuildVersionStatus = BuildVersionBuilding | BuildVersionFailure;
 
 export const getBuildKey = (request: BuildVersionRequest): string =>
 	request.mode === 'download'
-		? `build:${request.metadata.id}@${request.staticVersion}${request.variableVersion && request.variableVersion !== request.staticVersion ? `+vf@${request.variableVersion}` : ''}:download`
+		? request.staticVersion
+			? `build:${request.metadata.id}@${request.staticVersion}${request.variableVersion && request.variableVersion !== request.staticVersion ? `+vf@${request.variableVersion}` : ''}:download`
+			: `build:${request.metadata.id}:vf@${request.variableVersion}:download`
 		: `build:${request.tag.id}@${request.tag.version}:${request.mode}`;

--- a/api/worker/shared/storage.ts
+++ b/api/worker/shared/storage.ts
@@ -6,12 +6,20 @@ interface FontBinaryTag {
 
 export const getDownloadKey = (
 	id: string,
-	staticVersion: string,
+	staticVersion?: string,
 	variableVersion?: string,
-): string =>
-	variableVersion && variableVersion !== staticVersion
+): string => {
+	if (!staticVersion) {
+		if (!variableVersion) {
+			throw new Error(`Download version required for ${id}`);
+		}
+		return `${id}:vf@${variableVersion}/download.zip`;
+	}
+
+	return variableVersion && variableVersion !== staticVersion
 		? `${id}@${staticVersion}+vf@${variableVersion}/download.zip`
 		: `${id}@${staticVersion}/download.zip`;
+};
 
 /**
  * Static binaries live directly under `<id>@<version>/...`.

--- a/api/worker/shared/upstream.ts
+++ b/api/worker/shared/upstream.ts
@@ -107,10 +107,18 @@ export const fetchPackageVersions = async (
 	cacheTtl: number,
 	isVariable = false,
 ): Promise<string[]> => {
-	const payload = await fetchCachedJson<JsDelivrPackageResponse>(
-		`${UPSTREAM_URLS.jsdelivrPackage}/${packageName(id, isVariable)}`,
-		cacheTtl,
-	);
+	let payload: JsDelivrPackageResponse;
+	try {
+		payload = await fetchCachedJson<JsDelivrPackageResponse>(
+			`${UPSTREAM_URLS.jsdelivrPackage}/${packageName(id, isVariable)}`,
+			cacheTtl,
+		);
+	} catch (error) {
+		if (error instanceof UpstreamNotFoundError) {
+			return [];
+		}
+		throw error;
+	}
 
 	return (payload.versions ?? []).map((item) => item.version);
 };
@@ -132,6 +140,33 @@ export const fetchPackageFileList = async (
 			.filter((name) => name.startsWith(prefix))
 			.map((name) => name.slice(prefix.length)),
 	);
+};
+
+export const isPackageVersionPublished = async (
+	id: string,
+	version: string,
+	isVariable = false,
+): Promise<boolean> => {
+	try {
+		const response = await fetchWithCache(
+			`${UPSTREAM_URLS.npmRegistry}/${packageName(id, isVariable)}/${version}`,
+			{
+				cacheEverything: true,
+				cacheTtlByStatus: {
+					'200-299': 86400,
+					404: 60,
+					'500-599': 0,
+				},
+			},
+		);
+		await response.body?.cancel();
+		return true;
+	} catch (error) {
+		if (error instanceof UpstreamNotFoundError) {
+			return false;
+		}
+		throw error;
+	}
 };
 
 export const fetchPackageTarball = async (

--- a/api/worker/tests/artifacts.test.ts
+++ b/api/worker/tests/artifacts.test.ts
@@ -92,12 +92,10 @@ describe('container artifact builder', () => {
 			files.push([`package/files/${id}-${filename}`, bytes]);
 		}
 
-		if (!isVariable) {
-			files.push([
-				'package/LICENSE',
-				new TextEncoder().encode('Example License'),
-			]);
-		}
+		files.push([
+			'package/LICENSE',
+			new TextEncoder().encode('Example License'),
+		]);
 
 		return gzipSync(
 			await packTar(
@@ -308,6 +306,28 @@ describe('container artifact builder', () => {
 				'LICENSE',
 			]),
 		);
+	});
+
+	it('builds downloads from a variable package without a static package', async () => {
+		const { buildArtifacts } = await import('../container/src/artifacts');
+
+		await buildArtifacts({
+			mode: 'download',
+			variableVersion: '2.0.0',
+			metadata: variableMetadata,
+		});
+
+		const zipPut = putObject.mock.calls.find(
+			([key]) => key === 'recursive:vf@2.0.0/download.zip',
+		);
+		const archive = unzipSync(zipPut?.[1] as Uint8Array);
+		expect(Object.keys(archive)).toContain('LICENSE');
+		expect(Object.keys(archive).some((key) => key.startsWith('static/'))).toBe(
+			false,
+		);
+		expect(
+			Object.keys(archive).some((key) => key.startsWith('variable/')),
+		).toBe(true);
 	});
 
 	it('keeps the download available when an individual warm upload fails', async () => {

--- a/api/worker/tests/cdn.test.ts
+++ b/api/worker/tests/cdn.test.ts
@@ -491,6 +491,56 @@ describe('cdn routes', () => {
 		);
 	});
 
+	it('serves version metadata and downloads for variable-only packages', async () => {
+		vi.restoreAllMocks();
+		installArtifactBuilderMock(testEnv);
+		installUpstreamFetchMock({
+			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/recursive`]: new Response(
+				'not found',
+				{ status: 404 },
+			),
+			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource-variable/recursive`]:
+				new Response(JSON.stringify({ versions: [{ version: '1.1.0' }] })),
+		});
+		clearMetadataCachesForTest();
+
+		const versionResult = await dispatch(
+			'https://fontsource.test/v1/version/recursive',
+		);
+		expect(await versionResult.response.json()).toEqual({
+			latest: '',
+			static: [],
+			latestVariable: '1.1.0',
+			variable: ['1.1.0'],
+		});
+		await versionResult.settle();
+
+		const accepted = await dispatch(
+			'https://fontsource.test/v1/download/recursive',
+		);
+		expect(accepted.response.status).toBe(202);
+		expect(await accepted.response.json()).toEqual({
+			state: 'building',
+			version: '1.1.0',
+		});
+		await accepted.settle();
+
+		for (let attempts = 0; attempts < 100; attempts += 1) {
+			if (await testEnv.FONTS.head('recursive:vf@1.1.0/download.zip')) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+
+		const download = await dispatch(
+			'https://fontsource.test/v1/download/recursive',
+		);
+		await download.response.arrayBuffer();
+		await download.settle();
+
+		expect(download.response.status).toBe(200);
+	});
+
 	it('returns a failed asynchronous download build on the next poll', async () => {
 		const builder = installArtifactBuilderMock(testEnv, {
 			failBuildKeys: ['build:abel@5.0.0:download'],
@@ -668,12 +718,41 @@ describe('cdn routes', () => {
 		expect(builder.calls).not.toHaveBeenCalled();
 	});
 
-	it('falls back to the builder when the published-file preflight fails', async () => {
+	it('rejects missing exact package versions before the builder runs', async () => {
 		vi.restoreAllMocks();
 		const builder = installArtifactBuilderMock(testEnv);
 		installUpstreamFetchMock({
+			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@9.9.9?structure=flat`]:
+				new Response('not found', { status: 404 }),
+			[`${UPSTREAM_URLS.npmRegistry}/@fontsource/abel/9.9.9`]: new Response(
+				'not found',
+				{ status: 404 },
+			),
+		});
+
+		const result = await dispatch(
+			'https://fontsource.test/fonts/abel@9.9.9/latin-400-normal.woff2',
+		);
+		const payload = (await result.response.json()) as {
+			status: number;
+			error: string;
+		};
+		await result.settle();
+
+		expect(result.response.status).toBe(404);
+		expect(payload.error).toBe('Unable to resolve version "9.9.9"');
+		expect(builder.calls).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the builder while jsdelivr is behind npm', async () => {
+		vi.restoreAllMocks();
+		installArtifactBuilderMock(testEnv);
+		installUpstreamFetchMock({
 			[`${UPSTREAM_URLS.jsdelivrPackage}/@fontsource/abel@5.0.0?structure=flat`]:
-				new Response('boom', { status: 500 }),
+				new Response('not found', { status: 404 }),
+			[`${UPSTREAM_URLS.npmRegistry}/@fontsource/abel/5.0.0`]: new Response(
+				JSON.stringify({ version: '5.0.0' }),
+			),
 		});
 
 		const result = await dispatch(
@@ -684,7 +763,6 @@ describe('cdn routes', () => {
 
 		expect(result.response.status).toBe(200);
 		expect(bytes.byteLength).toBe(staticWoff2Bytes.byteLength);
-		expect(builder.calls).toHaveBeenCalledTimes(1);
 	});
 
 	it('returns 502 when version lookup upstream fails', async () => {

--- a/api/worker/tests/helpers.ts
+++ b/api/worker/tests/helpers.ts
@@ -489,12 +489,9 @@ const putDownloadArtifacts = async (
 	const { metadata } = request;
 	const axes = metadata.variable || undefined;
 	const zipFiles: Zippable = {};
-	let artifactCount = await putStaticArtifacts(
-		env,
-		metadata,
-		request.staticVersion,
-		zipFiles,
-	);
+	let artifactCount = request.staticVersion
+		? await putStaticArtifacts(env, metadata, request.staticVersion, zipFiles)
+		: 0;
 
 	if (axes && request.variableVersion) {
 		artifactCount += await putVariableArtifacts(
@@ -507,8 +504,9 @@ const putDownloadArtifacts = async (
 	}
 
 	if (artifactCount === 0) {
+		const version = request.staticVersion ?? `vf@${request.variableVersion}`;
 		throw new Error(
-			`Mocked build produced no artifacts for ${metadata.id}@${request.staticVersion}`,
+			`Mocked build produced no artifacts for ${metadata.id}@${version}`,
 		);
 	}
 

--- a/api/worker/worker/src/features/cdn/handler.ts
+++ b/api/worker/worker/src/features/cdn/handler.ts
@@ -9,7 +9,11 @@ import {
 	resolveFontPackageManifest,
 } from '../../../../shared/font-package-manifest';
 import { getBinaryKey, getDownloadKey } from '../../../../shared/storage';
-import { fetchPackageFileList } from '../../../../shared/upstream';
+import {
+	fetchPackageFileList,
+	isPackageVersionPublished,
+	UpstreamNotFoundError,
+} from '../../../../shared/upstream';
 import { CACHE_POLICIES, CONTENT_TYPES } from '../../constants';
 import { ensurePackageBuilt, startDownloadBuild } from '../../container/client';
 import type { AppEnv } from '../../env';
@@ -186,6 +190,17 @@ const ensurePublishedPinnedAsset = async (
 			);
 		}
 	} catch (error) {
+		if (
+			error instanceof UpstreamNotFoundError &&
+			!(await isPackageVersionPublished(
+				resolved.tag.id,
+				resolved.tag.version,
+				resolved.tag.isVariable,
+			))
+		) {
+			throw notFound(`Unable to resolve version "${resolved.tag.version}"`);
+		}
+
 		if (error instanceof HTTPException && error.status === 404) {
 			throw error;
 		}
@@ -246,11 +261,28 @@ export const getDownloadAsset = async (
 		getPublishedVersions(id, false),
 		axes ? getPublishedVersions(id, true) : undefined,
 	]);
-	const staticVersion = resolveVersionTag('latest', staticVersions);
-	const variableVersion = variableVersions
+	const staticVersion =
+		staticVersions.length > 0
+			? resolveVersionTag('latest', staticVersions)
+			: undefined;
+	const variableVersion = variableVersions?.length
 		? resolveVersionTag('latest', variableVersions)
 		: undefined;
-	const downloadKey = getDownloadKey(id, staticVersion, variableVersion);
+	const versions = staticVersion
+		? { staticVersion, variableVersion }
+		: variableVersion
+			? { variableVersion }
+			: undefined;
+	if (!versions) {
+		throw notFound(
+			'Unable to resolve download: no published versions available',
+		);
+	}
+	const downloadKey = getDownloadKey(
+		id,
+		versions.staticVersion,
+		versions.variableVersion,
+	);
 	const readDownload = () =>
 		getStoredBinaryObject(c, downloadKey, c.req.raw.headers);
 	const respond = (asset: StoredBinaryAsset) =>
@@ -270,13 +302,15 @@ export const getDownloadAsset = async (
 
 	const build = await startDownloadBuild(c, {
 		mode: 'download',
-		staticVersion,
-		variableVersion,
+		...versions,
 		metadata,
 	});
 	if (build.state === 'building') {
 		return Response.json(
-			{ state: 'building', version: staticVersion },
+			{
+				state: 'building',
+				version: versions.staticVersion ?? versions.variableVersion,
+			},
 			{
 				status: 202,
 				headers: {

--- a/api/worker/worker/src/routes/compat.ts
+++ b/api/worker/worker/src/routes/compat.ts
@@ -23,7 +23,7 @@ export class DownloadFontRoute extends OpenAPIRoute {
 		operationId: 'downloadFont',
 		summary: 'Download latest font family',
 		description:
-			'Serves a zip archive containing the latest static and variable packages for a font family.',
+			'Serves a zip archive containing the latest available static and variable packages for a font family.',
 		request: {
 			params: IdParamSchema,
 		},


### PR DESCRIPTION
This PR handles missing or variable-only font packages without repeatedly starting failing artifact containers. Additionally, invalid pinned versions now return 404, while valid variable-only downloads continue to work.