### PR TITLE
feat(website): pin cdn urls to package versions

### DIFF
--- a/website/app/components/preview/CDN.tsx
+++ b/website/app/components/preview/CDN.tsx
@@ -13,7 +13,11 @@ import { Link } from 'react-router';
 
 import { Code } from '@/components/code/Code';
 import { IconExternal } from '@/components/icons';
-import type { GetFontResponse, GetVariableFontResponse } from '@/generated/api';
+import type {
+	GetFontResponse,
+	GetFontVersionsResponse,
+	GetVariableFontResponse,
+} from '@/generated/api';
 import globalClasses from '@/styles/global.module.css';
 import { jsDelivrResolver } from '@/utils/cdn';
 
@@ -26,6 +30,7 @@ import { toggleKeyKeepOne, toggleVariableAxis } from './toggles';
 interface CDNProps {
 	metadata: GetFontResponse;
 	variable?: GetVariableFontResponse;
+	versions: GetFontVersionsResponse;
 	hits?: number;
 }
 
@@ -62,7 +67,7 @@ const BadgeGroup = ({ items, onClick, isActive }: BadgeGroupProps) => (
 	</Group>
 );
 
-const Variable = ({ metadata, variable }: CDNProps) => {
+const Variable = ({ metadata, variable, versions }: CDNProps) => {
 	const [isActive, setActive] = useState<ActiveVariants>({
 		axes: {
 			wght: true,
@@ -72,7 +77,7 @@ const Variable = ({ metadata, variable }: CDNProps) => {
 	});
 
 	// Return early if no variable data
-	if (!variable) return null;
+	if (!variable || !versions.latestVariable) return null;
 
 	const handleActiveSubset = (value: string) => {
 		// Return early if only one subset is selected and it is the current one
@@ -118,7 +123,7 @@ const Variable = ({ metadata, variable }: CDNProps) => {
 		subsets: isActive.subsets,
 		style: isItal ? 'italic' : 'normal',
 		display: isActive.display,
-		resolver: jsDelivrResolver(metadata.id, true),
+		resolver: jsDelivrResolver(metadata.id, true, versions.latestVariable),
 	});
 
 	return (
@@ -159,7 +164,7 @@ const Variable = ({ metadata, variable }: CDNProps) => {
 	);
 };
 
-const Static = ({ metadata }: CDNProps) => {
+const Static = ({ metadata, versions }: CDNProps) => {
 	// Active weights
 	const [isActiveWeight, setActiveWeight] = useState<Record<string, boolean>>({
 		400: true,
@@ -218,7 +223,7 @@ const Static = ({ metadata }: CDNProps) => {
 		style: isItal ? 'italic' : 'normal',
 		formats,
 		display: displayCurrent,
-		resolver: jsDelivrResolver(metadata.id),
+		resolver: jsDelivrResolver(metadata.id, false, versions.latest),
 	});
 
 	return (
@@ -290,7 +295,7 @@ const Static = ({ metadata }: CDNProps) => {
 	);
 };
 
-export const CDN = ({ metadata, variable, hits }: CDNProps) => {
+export const CDN = ({ metadata, variable, versions, hits }: CDNProps) => {
 	return (
 		<Grid className={globalClasses.container}>
 			<Grid.Col span={{ base: 12, md: 8 }}>
@@ -315,10 +320,14 @@ export const CDN = ({ metadata, variable, hits }: CDNProps) => {
 					</Tabs.List>
 
 					<Tabs.Panel value="variable">
-						<Variable metadata={metadata} variable={variable} />
+						<Variable
+							metadata={metadata}
+							variable={variable}
+							versions={versions}
+						/>
 					</Tabs.Panel>
 					<Tabs.Panel value="static">
-						<Static metadata={metadata} />
+						<Static metadata={metadata} versions={versions} />
 					</Tabs.Panel>
 				</Tabs>
 			</Grid.Col>

--- a/website/app/routes/fonts.$id.cdn.tsx
+++ b/website/app/routes/fonts.$id.cdn.tsx
@@ -5,10 +5,11 @@ import invariant from 'tiny-invariant';
 import { CDN } from '@/components/preview/CDN';
 import { TabsWrapper } from '@/components/preview/Tabs';
 import {
+	type GetFontResponse,
 	getFont,
 	getFontStats,
+	getFontVersions,
 	getVariableFont,
-	type GetFontResponse,
 } from '@/generated/api';
 import { cacheHeaders } from '@/utils/cache';
 import { ogMeta } from '@/utils/meta';
@@ -19,16 +20,23 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 	const parameters = { id };
 	const options = { signal: request.signal };
 
-	const [metadata, variable, stats] = await Promise.all([
+	const [metadata, variable, versions, stats] = await Promise.all([
 		getFont(parameters, options),
 		getVariableFont(parameters, options).catch(() => undefined), // Always try to load, fail gracefully
+		getFontVersions(parameters, options),
 		getFontStats(parameters, options),
 	]);
+	invariant(versions.latest, `Missing static package version for ${id}`);
+	invariant(
+		!variable || versions.latestVariable,
+		`Missing variable package version for ${id}`,
+	);
 
 	return data(
 		{
 			metadata,
 			variable,
+			versions,
 			hits: stats.total.jsDelivrHitsTotal,
 		},
 		{ headers: cacheHeaders.short },
@@ -63,11 +71,16 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
 };
 
 export default function CDNPage() {
-	const { metadata, variable, hits } = useLoaderData<typeof loader>();
+	const { metadata, variable, versions, hits } = useLoaderData<typeof loader>();
 
 	return (
 		<TabsWrapper metadata={metadata} tabsValue="cdn">
-			<CDN metadata={metadata} variable={variable} hits={hits} />
+			<CDN
+				metadata={metadata}
+				variable={variable}
+				versions={versions}
+				hits={hits}
+			/>
 		</TabsWrapper>
 	);
 }

--- a/website/app/utils/cdn.ts
+++ b/website/app/utils/cdn.ts
@@ -3,9 +3,10 @@ import type { UrlResolver } from '@fontsource-utils/core';
 export const jsDelivrResolver = (
 	fontId: string,
 	variable = false,
+	version = 'latest',
 ): UrlResolver => {
 	const prefix = `${fontId}-`;
-	const packageId = `${fontId}${variable ? ':vf' : ''}@latest`;
+	const packageId = `${fontId}${variable ? ':vf' : ''}@${version}`;
 
 	const baseUrl = `https://cdn.jsdelivr.net/fontsource/fonts/${packageId}`;
 

--- a/website/docs/getting-started/cdn.mdx
+++ b/website/docs/getting-started/cdn.mdx
@@ -5,7 +5,7 @@ description: Load versioned Fontsource stylesheets and font files through the js
 
 # CDN
 
-Fontsource has partnered with [jsDelivr](https://www.jsdelivr.com/) for a custom proxy for its stylesheets and font files, allowing for niche use cases where a stable asset link is required. All files are versioned according to [Semver](https://semver.org/), and using a specific version tag will give you longer lived caches.
+Fontsource has partnered with [jsDelivr](https://www.jsdelivr.com/) for a custom proxy for its stylesheets and font files, allowing for niche use cases where a stable asset link is required. All files are versioned according to [Semver](https://semver.org/).
 
 > **Note:** We recommend self-hosting your fonts if possible, but we understand there are suitable use cases for a CDN.
 
@@ -17,6 +17,12 @@ To leverage the Fontsource CDN for your project, you can use the import generato
 
 The Fontsource CDN serves generated CSS stylesheets and direct font files.
 
+### Choosing a Version
+
+Use an exact version such as `@5.2.7` in production. Exact versions are immutable and receive long-lived caching, making deployments reproducible without query-string cache busters. Update the version in the URL when you want to upgrade the font.
+
+Floating versions such as `@latest`, `@5`, or `@5.2` automatically resolve to a matching release. They use shorter caches and may not update immediately, so use them only when automatic upgrades are intentional. A floating stylesheet still contains exact-version font file URLs, keeping all files in that stylesheet on the same release.
+
 ### CSS Stylesheets
 
 Generated stylesheets include the matching `@font-face` declarations and font file URLs. Use `.min.css` instead of `.css` when you want the minified version.
@@ -27,19 +33,19 @@ Generated stylesheets include the matching `@font-face` declarations and font fi
 For example, load the default Open Sans stylesheet:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/open-sans@latest/index.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/open-sans@5.2.7/index.css" />
 ```
 
 Load only the minified Latin subset:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/open-sans@latest/latin.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/open-sans@5.2.7/latin.min.css" />
 ```
 
 Variable font stylesheets use the same `.min.css` suffix:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/roboto-flex:vf@latest/index.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/fontsource/css/roboto-flex:vf@5.0.8/index.min.css" />
 ```
 
 ### Static Font URLs
@@ -58,7 +64,7 @@ Variable fonts URLs have the format:
 
 Here are some example URLs that demonstrate how to use Fontsource's CDN with different fonts and configurations:
 
-- Variable URL for the latest version of Roboto Flex with Latin subset, wght axis, and normal style: `https://cdn.jsdelivr.net/fontsource/fonts/roboto-flex:vf@latest/latin-wght-normal.woff2`
+- Floating variable URL for the latest version of Roboto Flex with Latin subset, wght axis, and normal style: `https://cdn.jsdelivr.net/fontsource/fonts/roboto-flex:vf@latest/latin-wght-normal.woff2`
 
 - Variable URL for Roboto Flex version 5.0.8 with Cyrillic Extended subset, normal weight, and normal style: `https://cdn.jsdelivr.net/fontsource/fonts/roboto-flex:vf@5.0.8/cyrillic-ext-wdth-normal.woff2`
 


### PR DESCRIPTION
Closes #1042. This makes the default CDN copy paste blocks to use versioned URLs for long lived immutable caches as well as updating our documentation to avoid floating tags and naturally promote pinned URLs.

This ideally pushes better practices to rely on the immutable caches.