### PR TITLE
fix(api): throttle npm stats backfill

### DIFF
--- a/api/tests/stats.test.ts
+++ b/api/tests/stats.test.ts
@@ -9,7 +9,10 @@ import legacyFontIds from '../shared/legacy-fonts.json';
 import { STATS_CRON } from '../worker/src/constants';
 import type { StatsQueueMessage } from '../worker/src/features/metadata/stats/ingest';
 import { fetchNpmDownloads } from '../worker/src/features/metadata/stats/providers';
-import { seedStatsPackages } from '../worker/src/features/metadata/stats/repository';
+import {
+	getStatsPackageNamesToRefresh,
+	seedStatsPackages,
+} from '../worker/src/features/metadata/stats/repository';
 import worker from '../worker/src/index';
 import {
 	installUpstreamFetchMock,
@@ -63,6 +66,34 @@ describe('download stats ingestion', () => {
 			legacyFontIds.length;
 
 		expect(state).toEqual({ packages: packageCount, active: packageCount });
+	});
+
+	it('selects only unfinished packages until the initial backfill completes', async () => {
+		await seedStatsPackages(testEnv, testCatalog);
+		const active = await testEnv.STATS.prepare(
+			`SELECT package_name FROM stats_packages
+			WHERE active = 1 ORDER BY package_name`,
+		).all<{ package_name: string }>();
+		const activePackageNames = active.results.map(
+			({ package_name }) => package_name,
+		);
+		await testEnv.STATS.prepare(
+			`UPDATE stats_packages SET last_success_at = ? WHERE package_name = ?`,
+		)
+			.bind('2026-07-11T00:00:00.000Z', '@fontsource/abel')
+			.run();
+		const unfinished = await getStatsPackageNamesToRefresh(testEnv);
+		expect(unfinished).toEqual(
+			activePackageNames.filter((name) => name !== '@fontsource/abel'),
+		);
+
+		await testEnv.STATS.prepare(
+			`UPDATE stats_packages SET last_success_at = ? WHERE active = 1`,
+		)
+			.bind('2026-07-12T00:00:00.000Z')
+			.run();
+		const steadyState = await getStatsPackageNamesToRefresh(testEnv);
+		expect(steadyState).toEqual(activePackageNames);
 	});
 
 	it('stores a complete package refresh idempotently', async () => {
@@ -234,7 +265,7 @@ describe('download stats ingestion', () => {
 			fetchNpmDownloads('@fontsource/abel', 2026, '2026-07-12', '2026-07-12'),
 		).resolves.toBe(1);
 		expect(wait.mock.calls.map(([delay]) => delay)).toEqual([
-			500, 5000, 500, 7000, 500,
+			3000, 5000, 3000, 7000, 3000,
 		]);
 	});
 

--- a/api/worker/src/features/metadata/stats/ingest.ts
+++ b/api/worker/src/features/metadata/stats/ingest.ts
@@ -11,8 +11,8 @@ import {
 } from './providers';
 import {
 	commitStatsPackage,
-	getActiveStatsPackageNames,
 	getStatsPackage,
+	getStatsPackageNamesToRefresh,
 	markStatsPackageInactive,
 	prepareStatsBackfill,
 	recordStatsFailure,
@@ -135,7 +135,7 @@ export const scheduleStatsRefresh = async (env: Env): Promise<void> => {
 		(await env.METADATA.get<FontCatalog>(KV_KEYS.catalog, { type: 'json' })) ??
 		(await refreshCatalog(env));
 	await seedStatsPackages(env, catalog);
-	const packageNames = await getActiveStatsPackageNames(env);
+	const packageNames = await getStatsPackageNamesToRefresh(env);
 
 	for (let index = 0; index < packageNames.length; index += QUEUE_BATCH_SIZE) {
 		await env.STATS_QUEUE.sendBatch(

--- a/api/worker/src/features/metadata/stats/providers.ts
+++ b/api/worker/src/features/metadata/stats/providers.ts
@@ -1,7 +1,7 @@
 import { UPSTREAM_URLS } from '../../../constants';
 
 const NPM_STATS_START_DAY = '2015-01-10';
-const NPM_PACE_MS = 500;
+const NPM_PACE_MS = 3_000;
 const NPM_RETRY_DELAYS_MS = [5_000, 10_000, 20_000, 40_000, 80_000];
 // Keep sustained jsDelivr traffic below its 100 RPM coordination threshold.
 const JSDELIVR_PACE_MS = 650;

--- a/api/worker/src/features/metadata/stats/repository.ts
+++ b/api/worker/src/features/metadata/stats/repository.ts
@@ -92,13 +92,18 @@ export const seedStatsPackages = async (
 	await env.STATS.batch(statements);
 };
 
-export const getActiveStatsPackageNames = async (
+export const getStatsPackageNamesToRefresh = async (
 	env: Env,
 ): Promise<string[]> => {
 	const packages = await env.STATS.prepare(
 		`SELECT package_name
 		FROM stats_packages
-		WHERE active = 1
+		WHERE active = 1 AND (
+			last_success_at IS NULL OR NOT EXISTS (
+				SELECT 1 FROM stats_packages AS pending
+				WHERE pending.active = 1 AND pending.last_success_at IS NULL
+			)
+		)
 		ORDER BY package_name`,
 	).all<{ package_name: string }>();
 


### PR DESCRIPTION
We're still getting 429'd by NPM more than I like while backfilling, so this makes things more lenient.