### PR TITLE
chore(release): prepare font packages 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ These will always contain changes from Fontsource's end.
 
 # 5.x Release
 
+## 5.3.x
+
+This update improves TypeScript support for Fontsource packages.
+
+### Features
+
+- Font packages now include a generated declaration for the default CSS entry point and expose it through the package manifest. This allows default imports such as `import "@fontsource/inter"` to work with TypeScript's [`noUncheckedSideEffectImports`](https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports) option. [#1172](https://github.com/fontsource/fontsource/pull/1172)
+
 ## 5.2.x
 
 This update primarily focuses on modernizing the SCSS integration with Fontsource.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fontsource",
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"packageManager": "pnpm@11.14.0",
 	"author": "Ayuhito <hello@ayuhito.com>",
 	"license": "MIT",

--- a/packages/cli/version.ts
+++ b/packages/cli/version.ts
@@ -1,3 +1,3 @@
-const BASE_VERSION = '5.2.0';
+const BASE_VERSION = '5.3.0';
 
 export default BASE_VERSION;


### PR DESCRIPTION
This updates the base CLI to create new packages with v5.3 and updates the relevant changelog.