### PR TITLE
refactor(website): use built-in skeleton and navigation utilities

### DIFF
--- a/website/app/components/Skeleton.tsx
+++ b/website/app/components/Skeleton.tsx
@@ -1,16 +1,7 @@
-import {
-	normalizeBone,
-	type ResponsiveBones,
-	type SkeletonResult,
-} from 'boneyard-js';
+import { useMounted } from '@mantine/hooks';
+import { renderBones } from 'boneyard-js';
 import { Skeleton as BoneyardSkeleton } from 'boneyard-js/react';
-import {
-	type ReactNode,
-	useEffect,
-	useState,
-	useSyncExternalStore,
-} from 'react';
-import { useLocation } from 'react-router';
+import type { ReactNode } from 'react';
 import docsSearchResultsBones from '@/bones/docs-search-results.bones.json';
 import fontPreviewRowBones from '@/bones/font-preview-row.bones.json';
 import searchHitPreviewBones from '@/bones/search-hit-preview.bones.json';
@@ -34,156 +25,57 @@ interface SkeletonProps {
 	children: ReactNode;
 }
 
-const getSkeletonVariants = (bones: ResponsiveBones) =>
-	Object.entries(bones.breakpoints)
-		.sort(([left], [right]) => Number(left) - Number(right))
-		.map(([breakpoint, skeleton]) => ({ breakpoint, skeleton }));
-
-const viewportListeners = new Set<() => void>();
-const notifyViewportListeners = () => {
-	for (const listener of viewportListeners) listener();
-};
-const subscribeToViewport = (listener: () => void) => {
-	if (viewportListeners.size === 0) {
-		window.addEventListener('resize', notifyViewportListeners);
-	}
-
-	viewportListeners.add(listener);
-	return () => {
-		viewportListeners.delete(listener);
-		if (viewportListeners.size === 0) {
-			window.removeEventListener('resize', notifyViewportListeners);
-		}
-	};
-};
-const getViewportBreakpoint = () =>
-	window.innerWidth >= 1280 ? '1280' : window.innerWidth >= 768 ? '768' : '375';
-const getServerViewportBreakpoint = () => '375' as const;
-
-const useSkeletonLoading = (loading: boolean) => {
-	const [hydrated, setHydrated] = useState(false);
-
-	useEffect(() => {
-		setHydrated(true);
-	}, []);
-
-	return !hydrated || loading;
-};
-
-const FontPreviewSkeletonFixture = () => {
-	return (
-		<div className={classes['font-preview-fixture']}>
-			<span />
-		</div>
-	);
-};
-
-const SearchHitSkeletonFixture = () => {
-	return (
-		<div className={classes['search-hit-fixture']}>
-			<span />
-			<span />
-			<span />
-		</div>
-	);
-};
-
 const getFixture = (name: SkeletonName) => {
 	if (!import.meta.env.DEV) return undefined;
 
 	switch (name) {
 		case 'font-preview-row':
-			return <FontPreviewSkeletonFixture />;
+			return (
+				<div className={classes['font-preview-fixture']}>
+					<span />
+				</div>
+			);
 		case 'search-hit-preview':
-			return <SearchHitSkeletonFixture />;
+			return (
+				<div className={classes['search-hit-fixture']}>
+					<span />
+					<span />
+					<span />
+				</div>
+			);
 		default:
 			return undefined;
 	}
 };
 
-const Bone = ({
-	bone,
-	skeleton,
-}: {
-	bone: SkeletonResult['bones'][number];
-	skeleton: SkeletonResult;
-}) => {
-	const normalized = normalizeBone(bone);
-
-	if (normalized.c) return null;
-
-	const capturedPxWidth = (normalized.w / 100) * (skeleton.width ?? 0);
-	const isCircle =
-		normalized.r === '50%' && Math.abs(capturedPxWidth - normalized.h) < 4;
-
-	return (
-		<div
-			style={{
-				position: 'absolute',
-				left: `${normalized.x}%`,
-				top: normalized.y,
-				width: isCircle ? normalized.h : `${normalized.w}%`,
-				height: normalized.h,
-				borderRadius:
-					typeof normalized.r === 'string' ? normalized.r : `${normalized.r}px`,
-				backgroundColor: skeletonColor,
-			}}
-		/>
-	);
-};
-
 const Fallback = ({ name }: { name: SkeletonName }) => (
 	<div className={classes.fallback} aria-hidden="true">
-		{getSkeletonVariants(skeletons[name]).map(({ breakpoint, skeleton }) => (
-			<div
-				key={breakpoint}
-				data-boneyard-fallback-variant={breakpoint}
-				style={{
-					position: 'relative',
-					width: '100%',
-					height: skeleton.height,
-				}}
-			>
-				{skeleton.bones.map((bone, index) => (
-					<Bone
-						// biome-ignore lint/suspicious/noArrayIndexKey: Bones are static generated geometry.
-						key={index}
-						bone={bone}
-						skeleton={skeleton}
-					/>
-				))}
-			</div>
-		))}
+		{Object.entries(skeletons[name].breakpoints).map(
+			([breakpoint, skeleton]) => (
+				<div
+					key={breakpoint}
+					data-boneyard-fallback-variant={breakpoint}
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: Boneyard only receives committed skeleton JSON.
+					dangerouslySetInnerHTML={{
+						__html: renderBones(skeleton, skeletonColor, false),
+					}}
+				/>
+			),
+		)}
 	</div>
 );
 
 export const Skeleton = ({ name, loading, children }: SkeletonProps) => {
-	const showSkeleton = useSkeletonLoading(loading);
-	const location = useLocation();
-	const viewportBreakpoint = useSyncExternalStore(
-		subscribeToViewport,
-		getViewportBreakpoint,
-		getServerViewportBreakpoint,
-	);
-	const fixture = getFixture(name);
-	const isCaptureRoute =
-		import.meta.env.DEV && new URLSearchParams(location.search).has('boneyard');
-
-	if (isCaptureRoute) {
-		return (
-			<div data-boneyard={name} style={{ position: 'relative' }}>
-				<div>{fixture ?? children}</div>
-			</div>
-		);
-	}
+	const mounted = useMounted();
 
 	return (
 		<BoneyardSkeleton
 			name={name}
-			loading={showSkeleton}
-			initialBones={skeletons[name].breakpoints[viewportBreakpoint]}
+			loading={!mounted || loading}
+			initialBones={skeletons[name]}
+			select="viewport"
 			fallback={<Fallback name={name} />}
-			fixture={fixture}
+			fixture={getFixture(name)}
 			animate="pulse"
 			color={skeletonColor}
 		>

--- a/website/app/components/docs/LeftSidebar.tsx
+++ b/website/app/components/docs/LeftSidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from 'fumadocs-core/source/client';
 import { useMemo } from 'react';
 import { Link, useLocation, useMatches } from 'react-router';
+import { firstInternalPageUrl } from '@/utils/docs/navigation';
 
 import classes from './LeftSidebar.module.css';
 
@@ -55,17 +56,6 @@ const activeRootFolder = (tree: PageTree.Root, currentPath: string) => {
 		(node): node is PageTree.Folder =>
 			node.type === 'folder' && containsCurrentPage(node, currentPath),
 	);
-};
-
-const firstInternalPageUrl = (node: PageTree.Node): string | undefined => {
-	if (node.type === 'page') return node.external ? undefined : node.url;
-	if (node.type !== 'folder') return undefined;
-	if (node.index && !node.index.external) return node.index.url;
-
-	for (const child of node.children) {
-		const url = firstInternalPageUrl(child);
-		if (url) return url;
-	}
 };
 
 const PageLink = ({

--- a/website/app/utils/docs/navigation.ts
+++ b/website/app/utils/docs/navigation.ts
@@ -1,10 +1,9 @@
 import type * as PageTree from 'fumadocs-core/page-tree';
-import type { ReactNode } from 'react';
+import { findPath, flattenTree } from 'fumadocs-core/page-tree';
 
-export interface PageLink {
+interface PageLink {
 	name: string;
 	url: string;
-	external?: boolean;
 }
 
 export interface Pager {
@@ -17,99 +16,34 @@ export interface Breadcrumb {
 	url?: string;
 }
 
-const nodeName = (node: { name?: ReactNode }) => String(node.name ?? '');
-
-const isPage = (node: PageTree.Node): node is PageTree.Item =>
-	node.type === 'page';
-
-const isFolder = (node: PageTree.Node): node is PageTree.Folder =>
-	node.type === 'folder';
-
-const firstInternalPageUrl = (node: PageTree.Node): string | undefined => {
-	if (isPage(node)) return node.external ? undefined : node.url;
-	if (!isFolder(node)) return undefined;
-
-	if (node.index && !node.index.external) return node.index.url;
-
-	for (const child of node.children) {
-		const url = firstInternalPageUrl(child);
-		if (url) return url;
-	}
-};
-
-export const flattenPages = (tree: PageTree.Root): PageLink[] => {
-	const pages: PageLink[] = [];
-
-	const visit = (nodes: PageTree.Node[]) => {
-		for (const node of nodes) {
-			if (isPage(node)) {
-				pages.push({
-					name: nodeName(node),
-					url: node.url,
-					external: node.external,
-				});
-				continue;
-			}
-
-			if (isFolder(node)) {
-				if (node.index) {
-					pages.push({
-						name: nodeName(node.index),
-						url: node.index.url,
-						external: node.index.external,
-					});
-				}
-				visit(node.children);
-			}
-		}
-	};
-
-	visit(tree.children);
-	return pages;
-};
+export const firstInternalPageUrl = (node: PageTree.Folder) =>
+	flattenTree([node]).find((page) => !page.external)?.url;
 
 export const getPager = (tree: PageTree.Root, url: string): Pager => {
-	const pages = flattenPages(tree).filter((page) => !page.external);
+	const pages = flattenTree(tree.children)
+		.filter((page) => !page.external)
+		.map((page) => ({ name: String(page.name), url: page.url }));
 	const index = pages.findIndex((page) => page.url === url);
 
 	return {
-		previous: index > 0 ? pages[index - 1] : undefined,
-		next: index >= 0 && index < pages.length - 1 ? pages[index + 1] : undefined,
+		previous: pages[index - 1],
+		next: index >= 0 ? pages[index + 1] : undefined,
 	};
 };
 
 export const getBreadcrumbs = (
 	tree: PageTree.Root,
 	url: string,
-): Breadcrumb[] => {
-	const path: Breadcrumb[] = [];
-
-	const visit = (nodes: PageTree.Node[], parents: Breadcrumb[]): boolean => {
-		for (const node of nodes) {
-			if (isPage(node) && node.url === url) {
-				path.push(...parents, { name: nodeName(node), url: node.url });
-				return true;
-			}
-
-			if (isFolder(node)) {
-				const folderPath = [
-					...parents,
-					{ name: nodeName(node), url: firstInternalPageUrl(node) },
-				];
-				if (node.index?.url === url) {
-					path.push(...folderPath, {
-						name: nodeName(node.index),
-						url: node.index.url,
-					});
-					return true;
-				}
-				if (visit(node.children, folderPath)) return true;
-			}
-		}
-
-		return false;
-	};
-
-	visit(tree.children, []);
-	return path;
-};
+): Breadcrumb[] =>
+	(
+		findPath(
+			tree.children,
+			(node) => node.type === 'page' && node.url === url,
+			{ includeSeparator: false },
+		) ?? []
+	)
+		.filter((node) => node.type !== 'separator')
+		.map((node) => ({
+			name: String(node.name),
+			url: node.type === 'folder' ? firstInternalPageUrl(node) : node.url,
+		}));

--- a/website/boneyard.config.json
+++ b/website/boneyard.config.json
@@ -1,9 +1,5 @@
 {
 	"breakpoints": [375, 768, 1280],
 	"out": "./app/bones",
-	"routes": ["/?boneyard=1", "/fonts/inter?boneyard=1"],
-	"skeletons": {
-		"font-preview-row": { "route": "/fonts/inter?boneyard=1" },
-		"search-hit-preview": { "route": "/?boneyard=1" }
-	}
+	"routes": ["/", "/fonts/inter"]
 }


### PR DESCRIPTION
Use existing Fumadocs, Boneyard and Mantine utility functions to simplify our code burden.