### PR TITLE
ci(registry): automate metadata refresh

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -8,13 +8,7 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: registry-sync
-  cancel-in-progress: false
-
-env:
-  NODE_VERSION: 24.18.0
-  PNPM_VERSION: 11.14.0
+concurrency: registry-sync
 
 jobs:
   sync:
@@ -26,20 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: main
           persist-credentials: false
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+      - name: Set up tools
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,7 +32,8 @@ jobs:
       - name: Checkout upstream repositories
         id: upstreams
         run: |
-          git clone --no-checkout --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
+          git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
+          git -C "$RUNNER_TEMP/google-fonts" sparse-checkout set ofl apache ufl axisregistry
           git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
           echo "google_revision=$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "nam_revision=$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -77,8 +63,6 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: fontsource
           permission-contents: write
           permission-pull-requests: write
 
@@ -90,7 +74,6 @@ jobs:
           commit-message: 'chore(registry): update metadata snapshot'
           branch: chore/registry-update
           delete-branch: true
-          base: ${{ github.event.repository.default_branch }}
           title: 'chore(registry): update metadata snapshot'
           body: |
             Updates the generated registry from pinned upstream revisions.

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -12,7 +12,6 @@ concurrency: registry-sync
 
 jobs:
   sync:
-    if: github.repository == 'fontsource/fontsource'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -37,22 +36,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Checkout upstream repositories
-        id: upstreams
+      - name: Generate registry
         run: |
           git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
           git -C "$RUNNER_TEMP/google-fonts" sparse-checkout set ofl apache ufl axisregistry
           git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
-          echo "google_revision=$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "nam_revision=$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate registry
-        run: >-
-          pnpm --filter '@fontsource-utils/registry' generate
-          "$RUNNER_TEMP/google-fonts"
-          "${{ steps.upstreams.outputs.google_revision }}"
-          "$RUNNER_TEMP/nam-files"
-          "${{ steps.upstreams.outputs.nam_revision }}"
+          pnpm --filter '@fontsource-utils/registry' generate \
+            "$RUNNER_TEMP/google-fonts" \
+            "$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" \
+            "$RUNNER_TEMP/nam-files" \
+            "$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)"
 
       - name: Validate registry
         run: |

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency: registry-sync
 
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
-          persist-credentials: false
 
       - name: Set up tools
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -46,37 +45,18 @@ jobs:
           "$RUNNER_TEMP/nam-files"
           "${{ steps.upstreams.outputs.nam_revision }}"
 
-      - name: Verify deterministic output
+      - name: Validate registry
         run: |
+          pnpm --filter '@fontsource-utils/registry' validate
           git diff --exit-code -- . ':(exclude)registry/data'
+
+      - name: Commit registry update
+        run: |
           git add registry/data
-          pnpm --filter '@fontsource-utils/registry' generate \
-            "$RUNNER_TEMP/google-fonts" \
-            "${{ steps.upstreams.outputs.google_revision }}" \
-            "$RUNNER_TEMP/nam-files" \
-            "${{ steps.upstreams.outputs.nam_revision }}"
-          git diff --exit-code -- registry/data
-
-      - name: Create pull request token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Create or update registry pull request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          add-paths: registry/data
-          commit-message: 'chore(registry): update metadata snapshot'
-          branch: chore/registry-update
-          delete-branch: true
-          title: 'chore(registry): update metadata snapshot'
-          body: |
-            Updates the generated registry from pinned upstream revisions.
-
-            - google/fonts: `${{ steps.upstreams.outputs.google_revision }}`
-            - googlefonts/nam-files: `${{ steps.upstreams.outputs.nam_revision }}`
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(registry): update metadata snapshot"
+          git push

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -60,16 +60,10 @@ jobs:
           git diff --exit-code -- . ':(exclude)registry/data'
 
       - name: Commit registry update
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BOT_NAME: '${{ steps.app-token.outputs.app-slug }}[bot]'
-        run: |
-          git add registry/data
-          if git diff --cached --quiet; then
-            exit 0
-          fi
-          BOT_ID=$(gh api "/users/$BOT_NAME" --jq .id)
-          git config user.name "$BOT_NAME"
-          git config user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
-          git commit -m "chore(registry): update metadata snapshot"
-          git push
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          commit_message: 'chore(registry): update metadata snapshot'
+          file_pattern: registry/data
+          commit_user_name: 'fontsource-release[bot]'
+          commit_user_email: '306564713+fontsource-release[bot]@users.noreply.github.com'
+          commit_author: 'fontsource-release[bot] <306564713+fontsource-release[bot]@users.noreply.github.com>'

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -1,4 +1,4 @@
-name: Registry sync
+name: Registry Sync
 
 on:
   schedule:
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Create release token
+      - name: Create Release Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -30,13 +30,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
 
-      - name: Set up tools
+      - name: Setup
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
-      - name: Install dependencies
+      - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Generate registry
+      - name: Generate
         run: |
           # Keep complete history for provenance while hydrating only adapter inputs.
           git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
@@ -49,13 +49,13 @@ jobs:
             "$RUNNER_TEMP/nam-files" \
             "$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)"
 
-      - name: Validate registry
+      - name: Validate
         run: |
           pnpm --filter '@fontsource-utils/registry' validate
           # Generation owns registry data only.
           git diff --exit-code -- . ':(exclude)registry/data'
 
-      - name: Commit registry update
+      - name: Commit
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: 'chore(registry): update metadata snapshot'

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -38,9 +38,11 @@ jobs:
 
       - name: Generate registry
         run: |
+          # Keep complete history for provenance while hydrating only adapter inputs.
           git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
           git -C "$RUNNER_TEMP/google-fonts" sparse-checkout set ofl apache ufl axisregistry
           git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
+          # Record immutable upstream commits instead of moving branch names.
           pnpm --filter '@fontsource-utils/registry' generate \
             "$RUNNER_TEMP/google-fonts" \
             "$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" \
@@ -50,6 +52,7 @@ jobs:
       - name: Validate registry
         run: |
           pnpm --filter '@fontsource-utils/registry' validate
+          # Generation owns registry data only.
           git diff --exit-code -- . ':(exclude)registry/data'
 
       - name: Commit registry update

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -1,0 +1,99 @@
+name: Registry sync
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: registry-sync
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: 24.18.0
+  PNPM_VERSION: 11.14.0
+
+jobs:
+  sync:
+    if: github.repository == 'fontsource/fontsource'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Checkout upstream repositories
+        id: upstreams
+        run: |
+          git clone --no-checkout --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
+          git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
+          echo "google_revision=$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "nam_revision=$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate registry
+        run: >-
+          pnpm --filter '@fontsource-utils/registry' generate
+          "$RUNNER_TEMP/google-fonts"
+          "${{ steps.upstreams.outputs.google_revision }}"
+          "$RUNNER_TEMP/nam-files"
+          "${{ steps.upstreams.outputs.nam_revision }}"
+
+      - name: Verify deterministic output
+        run: |
+          git diff --exit-code -- . ':(exclude)registry/data'
+          git add registry/data
+          pnpm --filter '@fontsource-utils/registry' generate \
+            "$RUNNER_TEMP/google-fonts" \
+            "${{ steps.upstreams.outputs.google_revision }}" \
+            "$RUNNER_TEMP/nam-files" \
+            "${{ steps.upstreams.outputs.nam_revision }}"
+          git diff --exit-code -- registry/data
+
+      - name: Create pull request token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: fontsource
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create or update registry pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: registry/data
+          commit-message: 'chore(registry): update metadata snapshot'
+          branch: chore/registry-update
+          delete-branch: true
+          base: ${{ github.event.repository.default_branch }}
+          title: 'chore(registry): update metadata snapshot'
+          body: |
+            Updates the generated registry from pinned upstream revisions.
+
+            - google/fonts: `${{ steps.upstreams.outputs.google_revision }}`
+            - googlefonts/nam-files: `${{ steps.upstreams.outputs.nam_revision }}`

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency: registry-sync
 
@@ -17,9 +17,18 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      - name: Create release token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
 
       - name: Set up tools
@@ -51,12 +60,16 @@ jobs:
           git diff --exit-code -- . ':(exclude)registry/data'
 
       - name: Commit registry update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BOT_NAME: '${{ steps.app-token.outputs.app-slug }}[bot]'
         run: |
           git add registry/data
           if git diff --cached --quiet; then
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BOT_ID=$(gh api "/users/$BOT_NAME" --jq .id)
+          git config user.name "$BOT_NAME"
+          git config user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
           git commit -m "chore(registry): update metadata snapshot"
           git push

--- a/registry/README.md
+++ b/registry/README.md
@@ -22,8 +22,8 @@ package policy. Registry data is written to `data/`.
 ## Updates
 
 The [registry sync workflow](../.github/workflows/registry-sync.yml) regenerates
-the complete registry weekly or on demand and opens or updates a pull request
-only when data changes. It never publishes fonts or modifies production services.
+the complete registry weekly or on demand, validates it, and commits changed data
+to `main`. It never publishes fonts or modifies production services.
 
 ## Structure
 

--- a/registry/README.md
+++ b/registry/README.md
@@ -21,10 +21,9 @@ package policy. Registry data is written to `data/`.
 
 ## Updates
 
-The [registry sync workflow](../.github/workflows/registry-sync.yml) runs weekly
-or manually. It regenerates the complete registry and opens or updates a pull
-request only when tracked data changes. It does not publish fonts or modify
-production services.
+The [registry sync workflow](../.github/workflows/registry-sync.yml) regenerates
+the complete registry weekly or on demand and opens or updates a pull request
+only when data changes. It never publishes fonts or modifies production services.
 
 ## Structure
 

--- a/registry/README.md
+++ b/registry/README.md
@@ -19,6 +19,13 @@ repositories are rejected.
 Generation validates existing `policy.json` files but never creates or changes
 package policy. Registry data is written to `data/`.
 
+## Updates
+
+The [registry sync workflow](../.github/workflows/registry-sync.yml) runs weekly
+or manually. It regenerates the complete registry and opens or updates a pull
+request only when tracked data changes. It does not publish fonts or modify
+production services.
+
 ## Structure
 
 - `scripts/generate.ts` coordinates one complete registry build and validation.

--- a/registry/README.md
+++ b/registry/README.md
@@ -17,13 +17,9 @@ Both source revisions must be exact 40-character commits. Generation also
 requires complete Git history so per-path provenance is accurate; shallow
 repositories are rejected.
 Generation validates existing `policy.json` files but never creates or changes
-package policy. Registry data is written to `data/`.
-
-## Updates
-
-The [registry sync workflow](../.github/workflows/registry-sync.yml) regenerates
-the complete registry weekly or on demand, validates it, and commits changed data
-to `main`. It never publishes fonts or modifies production services.
+package policy. Registry data is written to `data/` and refreshed weekly or on
+demand by the [registry sync workflow](../.github/workflows/registry-sync.yml),
+which validates changes before committing them to `main`.
 
 ## Structure
 


### PR DESCRIPTION
Adds a weekly and manual registry refresh from exact Google Fonts and NAM commits. The workflow generates and validates registry data, then commits changes directly to main using the Fontsource Release App identity. It does not publish packages, upload artifacts, or modify production services.