### PR TITLE
fix(scss): resolve variable axis bundles

### DIFF
--- a/packages/scss/src/mixins.scss
+++ b/packages/scss/src/mixins.scss
@@ -15,6 +15,55 @@ $weights: null !default;
 $styles: null !default;
 $axes: null !default;
 
+$-standard-axes: (wght, wdth, slnt, opsz);
+
+@function -normalize-axis($axis) {
+	@return string.to-lower-case($axis);
+}
+
+@function -select-variable-axis($metadata, $requested) {
+	$default: -normalize-axis(map.get($metadata, defaults, axis));
+
+	@if not $requested {
+		@return $default;
+	}
+
+	@if $requested == all or $requested == full {
+		$requested: map.keys(map.get($metadata, axes));
+	}
+
+	$active: ();
+	@each $axis in $requested {
+		$axis: -normalize-axis($axis);
+		@if $axis != ital {
+			$active: list.append($active, $axis);
+		}
+	}
+
+	@if list.length($active) == 0 {
+		@return $default;
+	}
+
+	@if list.length($active) == 1 {
+		@return list.nth($active, 1);
+	}
+
+	@if list.length($active) == 2 and list.index($active, wght) {
+		@if list.nth($active, 1) == wght {
+			@return list.nth($active, 2);
+		}
+		@return list.nth($active, 1);
+	}
+
+	@each $axis in $active {
+		@if not list.index($-standard-axes, $axis) {
+			@return full;
+		}
+	}
+
+	@return standard;
+}
+
 @mixin generator(
 	$metadata: $metadata,
 	$directory: $directory,
@@ -73,21 +122,9 @@ $axes: null !default;
 		$styles: $styles or map.get($metadata, defaults, style);
 	}
 
-	$axes-value: null;
-	@if $axes {
-		@if $axes == all {
-			$axes-value: full;
-		} @else {
-			$axes-value: $axes;
-		}
-	} @else if $isVariable {
-		@if map.has-key($metadata, axes, wght) {
-			$axes-value: wght;
-		} @else {
-			$axes-value: full;
-		}
+	@if $isVariable {
+		$axes: -select-variable-axis($metadata, $axes);
 	}
-	$axes: $axes-value;
 
 	@each $subset in $subsets {
 		@each $unicodeSubset, $unicodeRange in map.get($metadata, unicode) {
@@ -142,18 +179,24 @@ $axes: null !default;
 							}
 
 							$computed-font-style: $style;
-							@if (($axis == full) or ($axis == slnt)) and map.has-key($metadata, axes, slnt) {
+							@if list.index((full, standard, slnt), $axis) and map.has-key($metadata, axes, slnt) {
 								$computed-font-style: oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg;
 							}
 
 							$computed-font-weight: $weight;
-							@if (($axis == full) or ($axis == wght)) and map.has-key($metadata, axes, wght) {
-								$computed-font-weight: map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max);
+							@if $axis {
+								@if map.has-key($metadata, axes, wght) {
+									$computed-font-weight: map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max);
+								} @else {
+									$computed-font-weight: map.get($metadata, defaults, weight);
+								}
 							}
 
 							$computed-font-stretch: null;
-							@if (($axis == full) or ($axis == wdth)) and map.has-key($metadata, axes, wdth) {
-								$computed-font-stretch: '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%';
+							@if list.index((full, standard, wdth), $axis) and map.has-key($metadata, axes, wdth) {
+								$computed-font-stretch:
+									map.get($metadata, axes, wdth, min) * 1%
+									map.get($metadata, axes, wdth, max) * 1%;
 							}
 
 							@content ((

--- a/packages/scss/tests/__snapshots__/mixins.test.ts.snap
+++ b/packages/scss/tests/__snapshots__/mixins.test.ts.snap
@@ -1,5 +1,44 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`sass mixins > should compile (wdth, wght) axes successfully 1`] = `
+"/* test-font-latin-wdth-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/test-font/files/test-font-latin-wdth-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should compile all axes successfully 1`] = `
+"/* test-font-latin-wdth-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/test-font/files/test-font-latin-wdth-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should compile full axes successfully 1`] = `
+"/* test-font-latin-wdth-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/test-font/files/test-font-latin-wdth-normal.woff2") format("woff2-variations");
+}"
+`;
+
 exports[`sass mixins > should compile sass for non unicode range font successfully 1`] = `
 "/* carlito-cyrillic-400-normal */
 @font-face {
@@ -2289,5 +2328,68 @@ exports[`sass mixins > should compile sass for variable font successfully 1`] = 
   font-weight: 300 1000;
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   src: url("@fontsource-variable/recursive/files/recursive-latin-wght-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should compile standard axes successfully 1`] = `
+"/* test-font-latin-standard-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/test-font/files/test-font-latin-standard-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should compile wdth axes successfully 1`] = `
+"/* test-font-latin-wdth-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/test-font/files/test-font-latin-wdth-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should keep the full bundle for custom axes 1`] = `
+"/* recursive-latin-full-normal */
+@font-face {
+  font-family: "Recursive Variable";
+  font-style: oblique -15deg 0deg;
+  font-display: swap;
+  font-weight: 300 1000;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url("@fontsource-variable/recursive/files/recursive-latin-full-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should use the default weight for a variable font without wght 1`] = `
+"/* optical-font-latin-opsz-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/optical-font/files/optical-font-latin-opsz-normal.woff2") format("woff2-variations");
+}"
+`;
+
+exports[`sass mixins > should use the standard bundle for multiple standard axes 1`] = `
+"/* aggregate-font-latin-standard-normal */
+@font-face {
+  font-family: "Test Font Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300 800;
+  font-stretch: 75% 100%;
+  unicode-range: U+0000-00FF;
+  src: url("@fontsource-variable/aggregate-font/files/aggregate-font-latin-standard-normal.woff2") format("woff2-variations");
 }"
 `;

--- a/packages/scss/tests/mixins.test.ts
+++ b/packages/scss/tests/mixins.test.ts
@@ -8,6 +8,49 @@ const mixins = fs.readFileSync(
 	'utf-8',
 );
 
+const variableMetadata = (
+	id: string,
+	axes: string,
+	defaultAxis: string,
+	weights = '(400)',
+) => `(
+	id: ${id},
+	family: 'Test Font',
+	subsets: (latin),
+	weights: ${weights},
+	styles: (normal),
+	axes: (${axes}),
+	defaults: (weight: 400, style: normal, axis: ${defaultAxis}),
+	unicode: (latin: (U+0000-00FF)),
+)`;
+
+const standardVariableMetadata = variableMetadata(
+	'test-font',
+	`
+		ital: true,
+		wdth: (min: 75, max: 100),
+		wght: (min: 300, max: 800),`,
+	'wght',
+	'(300, 400, 800)',
+);
+
+const opticalVariableMetadata = variableMetadata(
+	'optical-font',
+	'opsz: (min: 16, max: 72)',
+	'opsz',
+);
+
+const aggregateVariableMetadata = variableMetadata(
+	'aggregate-font',
+	`
+		ital: true,
+		opsz: true,
+		wdth: (min: 75, max: 100),
+		wght: (min: 300, max: 800),`,
+	'wght',
+	'(300, 400, 800)',
+);
+
 const compileSass = (family: string, params?: string[]) => {
 	const metadata = `@use 'pkg:${family}/scss' as font;`;
 
@@ -19,6 +62,12 @@ const compileSass = (family: string, params?: string[]) => {
 
 	return res.css.toString();
 };
+
+const compileMetadataSass = (metadata: string, axes: string) =>
+	compileString(
+		`${mixins}$fixture-metadata: ${metadata};
+		@include faces($metadata: $fixture-metadata, $axes: ${axes}, $weights: all)`,
+	).css.toString();
 
 describe('sass mixins', () => {
 	it('should compile sass for non unicode range font successfully', async () => {
@@ -44,6 +93,36 @@ describe('sass mixins', () => {
 	it('should compile sass for variable font successfully', async () => {
 		expect(
 			compileSass('@fontsource-variable/recursive', ['$subsets: latin']),
+		).toMatchSnapshot();
+	});
+
+	it.each(['all', 'full', 'wdth', '(wdth, wght)', 'standard'])(
+		'should compile %s axes successfully',
+		(axes) => {
+			expect(
+				compileMetadataSass(standardVariableMetadata, axes),
+			).toMatchSnapshot();
+		},
+	);
+
+	it('should use the default weight for a variable font without wght', () => {
+		expect(
+			compileMetadataSass(opticalVariableMetadata, 'all'),
+		).toMatchSnapshot();
+	});
+
+	it('should use the standard bundle for multiple standard axes', () => {
+		expect(
+			compileMetadataSass(aggregateVariableMetadata, 'all'),
+		).toMatchSnapshot();
+	});
+
+	it('should keep the full bundle for custom axes', () => {
+		expect(
+			compileSass('@fontsource-variable/recursive', [
+				'$subsets: latin',
+				'$axes: all',
+			]),
 		).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
Closes #738

Resolve selected variable axes to a single published bundle instead of emitting one file per axis or assuming every font has a `full` bundle. This also adds proper handling for our `standard` axis format.

Generated variable faces now also better handle fonts without `wght`.

