### PR TITLE
feat(website): add font discovery pages

### DIFF
--- a/website/app/components/layout/Footer.tsx
+++ b/website/app/components/layout/Footer.tsx
@@ -68,6 +68,7 @@ export const Footer = ({ ...other }: ContainerProps) => {
 					<Tooltip.Group openDelay={600} closeDelay={100}>
 						<Group gap="md" justify="right">
 							<FooterNavLink label="Fonts" to="/" />
+							<FooterNavLink label="Browse" to="/browse" />
 							<FooterNavLink label="Documentation" to="/docs" />
 							<ThemeButton stroke="white" />
 							<Icon

--- a/website/app/features/discovery/loader.server.ts
+++ b/website/app/features/discovery/loader.server.ts
@@ -1,0 +1,24 @@
+import type { LoaderFunctionArgs } from 'react-router';
+
+import { loadSearch } from '@/routes/_index';
+import { cacheHeaders } from '@/utils/cache';
+import { loadDiscoveryPages } from '@/utils/discovery.server';
+
+export const loader = async (args: LoaderFunctionArgs) => {
+	const pathname = args.params.language
+		? `/languages/${args.params.language}`
+		: args.params.category
+			? `/categories/${args.params.category}`
+			: '/variable-fonts';
+	const page = (await loadDiscoveryPages(args.request.signal)).find(
+		(item) => item.path === pathname,
+	);
+	if (!page) {
+		throw new Response('Not found', {
+			status: 404,
+			headers: cacheHeaders.noStore,
+		});
+	}
+
+	return loadSearch(args, page);
+};

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -52,7 +52,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, location }) => {
 					{
 						'@type': 'ListItem',
 						position: 2,
-						name: page.heading,
+						name: page.label,
 						item: getCanonicalUrl(page.path),
 					},
 				],

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -52,7 +52,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, location }) => {
 					{
 						'@type': 'ListItem',
 						position: 2,
-						name: 'Browse Fonts',
+						name: 'Browse',
 						item: getCanonicalUrl('/browse'),
 					},
 					{

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -1,0 +1,66 @@
+import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+
+import { CatalogSearchPage, links, loadSearch } from '@/routes/_index';
+import { cacheHeaders } from '@/utils/cache';
+import { loadDiscoveryPages } from '@/utils/discovery.server';
+import { getCanonicalUrl, ogMeta } from '@/utils/meta';
+
+export { links };
+
+export const loader = async (args: LoaderFunctionArgs) => {
+	const pathname = new URL(args.request.url).pathname.replace(/\/+$/, '');
+	const page = (await loadDiscoveryPages(args.request.signal)).find(
+		(item) => item.path === pathname,
+	);
+	if (!page) {
+		throw new Response('Not found', {
+			status: 404,
+			headers: cacheHeaders.noStore,
+		});
+	}
+
+	return loadSearch(args, page);
+};
+
+export const meta: MetaFunction<typeof loader> = ({ loaderData, location }) => {
+	const page = loaderData?.discovery;
+	if (!page) return ogMeta({});
+
+	return [
+		...ogMeta({
+			title: `${page.heading} | Fontsource`,
+			description: page.description,
+		}),
+		...(location.search
+			? [{ name: 'robots', content: 'noindex, follow' }]
+			: []),
+		{
+			'script:ld+json': {
+				'@context': 'https://schema.org',
+				'@type': 'BreadcrumbList',
+				itemListElement: [
+					{
+						'@type': 'ListItem',
+						position: 1,
+						name: 'Fonts',
+						item: getCanonicalUrl('/'),
+					},
+					{
+						'@type': 'ListItem',
+						position: 2,
+						name: 'Browse Fonts',
+						item: getCanonicalUrl('/browse'),
+					},
+					{
+						'@type': 'ListItem',
+						position: 3,
+						name: page.heading,
+						item: getCanonicalUrl(page.path),
+					},
+				],
+			},
+		},
+	];
+};
+
+export default CatalogSearchPage;

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -46,18 +46,12 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, location }) => {
 					{
 						'@type': 'ListItem',
 						position: 1,
-						name: 'Fonts',
-						item: getCanonicalUrl('/'),
-					},
-					{
-						'@type': 'ListItem',
-						position: 2,
 						name: 'Browse',
 						item: getCanonicalUrl('/browse'),
 					},
 					{
 						'@type': 'ListItem',
-						position: 3,
+						position: 2,
 						name: page.heading,
 						item: getCanonicalUrl(page.path),
 					},

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -8,7 +8,11 @@ import { getCanonicalUrl, ogMeta } from '@/utils/meta';
 export { links };
 
 export const loader = async (args: LoaderFunctionArgs) => {
-	const pathname = new URL(args.request.url).pathname.replace(/\/+$/, '');
+	const pathname = args.params.language
+		? `/languages/${args.params.language}`
+		: args.params.category
+			? `/categories/${args.params.category}`
+			: '/variable-fonts';
 	const page = (await loadDiscoveryPages(args.request.signal)).find(
 		(item) => item.path === pathname,
 	);

--- a/website/app/features/discovery/route.tsx
+++ b/website/app/features/discovery/route.tsx
@@ -1,30 +1,10 @@
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+import type { MetaFunction } from 'react-router';
 
-import { CatalogSearchPage, links, loadSearch } from '@/routes/_index';
-import { cacheHeaders } from '@/utils/cache';
-import { loadDiscoveryPages } from '@/utils/discovery.server';
+import { CatalogSearchPage, links } from '@/routes/_index';
 import { getCanonicalUrl, ogMeta } from '@/utils/meta';
+import type { loader } from './loader.server';
 
 export { links };
-
-export const loader = async (args: LoaderFunctionArgs) => {
-	const pathname = args.params.language
-		? `/languages/${args.params.language}`
-		: args.params.category
-			? `/categories/${args.params.category}`
-			: '/variable-fonts';
-	const page = (await loadDiscoveryPages(args.request.signal)).find(
-		(item) => item.path === pathname,
-	);
-	if (!page) {
-		throw new Response('Not found', {
-			status: 404,
-			headers: cacheHeaders.noStore,
-		});
-	}
-
-	return loadSearch(args, page);
-};
 
 export const meta: MetaFunction<typeof loader> = ({ loaderData, location }) => {
 	const page = loaderData?.discovery;

--- a/website/app/routes.ts
+++ b/website/app/routes.ts
@@ -1,15 +1,4 @@
-import { type RouteConfig, route } from '@react-router/dev/routes';
+import type { RouteConfig } from '@react-router/dev/routes';
 import { flatRoutes } from '@react-router/fs-routes';
 
-export default [
-	...(await flatRoutes()),
-	route('languages/:language', './features/discovery/route.tsx', {
-		id: 'discovery-language',
-	}),
-	route('categories/:category', './features/discovery/route.tsx', {
-		id: 'discovery-category',
-	}),
-	route('variable-fonts', './features/discovery/route.tsx', {
-		id: 'discovery-variable',
-	}),
-] satisfies RouteConfig;
+export default flatRoutes() satisfies RouteConfig;

--- a/website/app/routes.ts
+++ b/website/app/routes.ts
@@ -1,4 +1,15 @@
-import type { RouteConfig } from '@react-router/dev/routes';
+import { type RouteConfig, route } from '@react-router/dev/routes';
 import { flatRoutes } from '@react-router/fs-routes';
 
-export default flatRoutes() satisfies RouteConfig;
+export default [
+	...(await flatRoutes()),
+	route('languages/:language', './features/discovery/route.tsx', {
+		id: 'discovery-language',
+	}),
+	route('categories/:category', './features/discovery/route.tsx', {
+		id: 'discovery-category',
+	}),
+	route('variable-fonts', './features/discovery/route.tsx', {
+		id: 'discovery-variable',
+	}),
+] satisfies RouteConfig;

--- a/website/app/routes/[sitemap.xml].tsx
+++ b/website/app/routes/[sitemap.xml].tsx
@@ -2,6 +2,7 @@ import type { LoaderFunction } from 'react-router';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import { listFontValues } from '@/generated/api';
 import { cacheHeaders } from '@/utils/cache';
+import { loadDiscoveryPages } from '@/utils/discovery.server';
 import { source } from '@/utils/docs/source.server';
 
 export const loader: LoaderFunction = async ({ request }) => {
@@ -9,6 +10,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 	// Pipe base urls to stream
 	smStream.write({ url: '/', changefreq: 'daily', priority: 0.9 });
+	smStream.write({ url: '/browse', changefreq: 'weekly', priority: 0.7 });
 	smStream.write({ url: '/tools', changefreq: 'weekly', priority: 0.7 });
 	smStream.write({
 		url: '/tools/converter',
@@ -17,16 +19,24 @@ export const loader: LoaderFunction = async ({ request }) => {
 	});
 
 	// Pipe each font to stream
-	const fontlist = await listFontValues(
-		{ family: '' },
-		{ signal: request.signal },
-	);
+	const [fontlist, discoveryPages] = await Promise.all([
+		listFontValues({ family: '' }, { signal: request.signal }),
+		loadDiscoveryPages(request.signal),
+	]);
 
 	for (const id of Object.keys(fontlist)) {
 		smStream.write({
 			url: `/fonts/${id}`,
 			changefreq: 'weekly',
 			priority: 0.5,
+		});
+	}
+
+	for (const page of discoveryPages) {
+		smStream.write({
+			url: page.path,
+			changefreq: 'weekly',
+			priority: 0.7,
 		});
 	}
 

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -350,7 +350,7 @@ export function CatalogSearchPage() {
 							<Breadcrumbs
 								items={[
 									{ name: 'Browse', url: '/browse' },
-									{ name: discovery.heading },
+									{ name: discovery.label },
 								]}
 							/>
 							<Title order={1} c="purple.0">

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -23,6 +23,7 @@ import {
 	type MetaFunction,
 	useLoaderData,
 	useNavigate,
+	useNavigation,
 } from 'react-router';
 
 import { Breadcrumbs } from '@/components/docs/Breadcrumbs';
@@ -315,7 +316,14 @@ export function CatalogSearchPage() {
 	const collectionsStore = useCollectionsStore();
 	const collectionsReady = useValue(collectionsStore.ready$);
 	const navigate = useNavigate();
+	const navigation = useNavigation();
+	const navigationState = useRef(navigation.state);
 	const searchRef = useRef<HTMLDivElement>(null);
+	navigationState.current = navigation.state;
+	// Ignore delayed search URL writes once React Router is leaving this page.
+	const navigateSearch = (url: string) => {
+		if (navigationState.current === 'idle') void navigate(url);
+	};
 
 	const state$ = useObservable(createPageSearchState(discovery));
 	// Resolve the collection name only after Legend has restored local persistence.
@@ -331,7 +339,7 @@ export function CatalogSearchPage() {
 					state$,
 					collectionsStore,
 					discovery,
-					discovery ? navigate : undefined,
+					discovery ? navigateSearch : undefined,
 				)}
 				future={{ preserveSharedStateOnUnmount: true }}
 			>

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -49,7 +49,7 @@ import { cloudflareContext } from '@/utils/cloudflare-context';
 import type { DiscoveryPage } from '@/utils/discovery';
 import { getPreviewText } from '@/utils/language/language';
 
-interface SearchProps {
+export interface SearchProps {
 	discovery?: DiscoveryPage;
 	hasCollectionFilter: boolean;
 	serverState?: InstantSearchServerState;

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -142,6 +142,15 @@ const routing = (
 
 				return query ? `/?${query}` : '/';
 			},
+			parseURL: ({ qsModule, location }) => {
+				const routeState = qsModule.parse(location.search.slice(1), {
+					arrayLimit: 99,
+				}) as SearchRouteState;
+
+				return discovery
+					? { ...discovery.routeState, ...routeState }
+					: routeState;
+			},
 			...(navigate ? { push: (url: string) => void navigate(url) } : {}),
 			cleanUrlOnDispose: !discovery,
 		} satisfies Partial<BrowserHistoryArgs<SearchRouteState>>),

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -349,7 +349,6 @@ export function CatalogSearchPage() {
 						<Stack gap="xs" maw={760}>
 							<Breadcrumbs
 								items={[
-									{ name: 'Fonts', url: '/' },
 									{ name: 'Browse', url: '/browse' },
 									{ name: discovery.heading },
 								]}

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { createFetchRequester } from '@algolia/requester-fetch';
 import { observable } from '@legendapp/state';
 import { useObservable, useValue } from '@legendapp/state/react';
-import { Box, MantineProvider } from '@mantine/core';
+import { Box, MantineProvider, Stack, Text, Title } from '@mantine/core';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import type { UiState } from 'instantsearch.js';
 import { history } from 'instantsearch.js/es/lib/routers';
@@ -20,9 +20,13 @@ import {
 	data,
 	type LinksFunction,
 	type LoaderFunctionArgs,
+	type MetaFunction,
 	useLoaderData,
+	useNavigate,
 } from 'react-router';
 
+import { Breadcrumbs } from '@/components/docs/Breadcrumbs';
+import { ContentHeader } from '@/components/layout/ContentHeader';
 import { Filters } from '@/components/search/Filters';
 import { InfiniteHits } from '@/components/search/Hits';
 import {
@@ -41,8 +45,11 @@ import { theme } from '@/styles/theme';
 import { buildAlgoliaCacheKey } from '@/utils/algolia';
 import { cacheHeaders, PUBLIC_ORIGIN } from '@/utils/cache';
 import { cloudflareContext } from '@/utils/cloudflare-context';
+import type { DiscoveryPage } from '@/utils/discovery';
+import { getPreviewText } from '@/utils/language/language';
 
-interface SearchProps {
+export interface SearchProps {
+	discovery?: DiscoveryPage;
 	hasCollectionFilter: boolean;
 	serverState?: InstantSearchServerState;
 	serverUrl: string;
@@ -77,6 +84,9 @@ export const links: LinksFunction = () => [
 	},
 ];
 
+export const meta: MetaFunction = ({ location }) =>
+	location.search ? [{ name: 'robots', content: 'noindex, follow' }] : [];
+
 const sortMap: Record<string, string> = {
 	prod_POPULAR: 'popular',
 	prod_NEWEST: 'newest',
@@ -98,10 +108,23 @@ const parseSubsets = (value: unknown): string[] | undefined => {
 	return subsets.length > 0 ? subsets : undefined;
 };
 
+const createPageSearchState = (discovery?: DiscoveryPage) => {
+	const state = createSearchState();
+	const subset = discovery?.routeState.subsets;
+	if (subset) {
+		state.language = subset;
+		state.preview.presetValue = getPreviewText(subset);
+	}
+
+	return state;
+};
+
 const routing = (
 	serverUrl: string,
 	state$: SearchState,
 	collectionsStore?: CollectionsStore,
+	discovery?: DiscoveryPage,
+	navigate?: (url: string) => void,
 ): RouterProps<UiState, SearchRouteState> => {
 	const indexName = 'prod_POPULAR';
 	return {
@@ -111,7 +134,16 @@ const routing = (
 					? (new URL(serverUrl) as unknown as Location)
 					: window.location;
 			},
-			cleanUrlOnDispose: true,
+			createURL: ({ qsModule, routeState }) => {
+				const query = qsModule.stringify(routeState);
+				if (discovery && query === qsModule.stringify(discovery.routeState)) {
+					return discovery.path;
+				}
+
+				return query ? `/?${query}` : '/';
+			},
+			...(navigate ? { push: (url: string) => void navigate(url) } : {}),
+			cleanUrlOnDispose: !discovery,
 		} satisfies Partial<BrowserHistoryArgs<SearchRouteState>>),
 		stateMapping: {
 			stateToRoute(uiState) {
@@ -138,10 +170,13 @@ const routing = (
 				return result;
 			},
 			routeToState(routeState) {
-				const subsets = parseSubsets(routeState.subsets);
+				const resolvedRouteState = discovery
+					? { ...discovery.routeState, ...routeState }
+					: routeState;
+				const subsets = parseSubsets(resolvedRouteState.subsets);
 				// URLs use readable collection names while state keeps the stable local ID.
-				const normalizedCollectionName = routeState.collection
-					? normalizeCollectionName(routeState.collection)
+				const normalizedCollectionName = resolvedRouteState.collection
+					? normalizeCollectionName(resolvedRouteState.collection)
 					: undefined;
 				const collection = collectionsStore?.collections$
 					.peek()
@@ -152,19 +187,21 @@ const routing = (
 				state$.collectionId.set(collection?.id ?? null);
 
 				const state = {
-					query: routeState.query,
+					query: resolvedRouteState.query,
 					// RefinementList facets
 					...(subsets?.length ? { refinementList: { subsets } } : {}),
 					// Menu facets
-					...(routeState.category
-						? { menu: { category: routeState.category } }
+					...(resolvedRouteState.category
+						? { menu: { category: resolvedRouteState.category } }
 						: {}),
 					// Variable toggle
-					...(routeState.variable ? { toggle: { variable: true } } : {}),
+					...(resolvedRouteState.variable
+						? { toggle: { variable: true } }
+						: {}),
 					// Sortby map
-					...(routeState.sort
+					...(resolvedRouteState.sort
 						? {
-								sortBy: sortMap[routeState.sort],
+								sortBy: sortMap[resolvedRouteState.sort],
 							}
 						: {}),
 				};
@@ -177,14 +214,17 @@ const routing = (
 	};
 };
 
-export const loader = async ({ request, context }: LoaderFunctionArgs) => {
+export const loadSearch = async (
+	{ request, context }: LoaderFunctionArgs,
+	discovery?: DiscoveryPage,
+) => {
 	const requestUrl = new URL(request.url);
 	const serverUrl = `${PUBLIC_ORIGIN}${requestUrl.pathname}${requestUrl.search}`;
 	const hasCollectionFilter = requestUrl.searchParams.has('collection');
 	// Collection membership exists only in localStorage and is unavailable to SSR.
 	if (hasCollectionFilter) {
 		return data<SearchProps>(
-			{ hasCollectionFilter, serverUrl },
+			{ discovery, hasCollectionFilter, serverUrl },
 			{ headers: cacheHeaders.short },
 		);
 	}
@@ -194,7 +234,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	const cacheKey = buildAlgoliaCacheKey(serverUrl);
 
 	// Generate default state object for ssr
-	const state$ = observable(createSearchState());
+	const state$ = observable(createPageSearchState(discovery));
 
 	// Check local cache for server state first to avoid unnecessary API calls
 	let serverState = cacheKey
@@ -203,6 +243,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	if (serverState) {
 		return data<SearchProps>(
 			{
+				discovery,
 				hasCollectionFilter,
 				serverState,
 				serverUrl,
@@ -219,7 +260,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 				<InstantSearch
 					searchClient={searchClient}
 					indexName="prod_POPULAR"
-					routing={routing(serverUrl, state$)}
+					routing={routing(serverUrl, state$, undefined, discovery)}
 					future={{ preserveSharedStateOnUnmount: true }}
 				>
 					<CollectionsProvider>
@@ -246,6 +287,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 
 	return data<SearchProps>(
 		{
+			discovery,
 			hasCollectionFilter,
 			serverState,
 			serverUrl,
@@ -256,14 +298,17 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 	);
 };
 
-export default function Index() {
-	const { hasCollectionFilter, serverState, serverUrl } =
-		useLoaderData<typeof loader>();
+export const loader = (args: LoaderFunctionArgs) => loadSearch(args);
+
+export function CatalogSearchPage() {
+	const { discovery, hasCollectionFilter, serverState, serverUrl } =
+		useLoaderData<SearchProps>();
 	const collectionsStore = useCollectionsStore();
 	const collectionsReady = useValue(collectionsStore.ready$);
+	const navigate = useNavigate();
 	const searchRef = useRef<HTMLDivElement>(null);
 
-	const state$ = useObservable(createSearchState());
+	const state$ = useObservable(createPageSearchState(discovery));
 	// Resolve the collection name only after Legend has restored local persistence.
 	if (hasCollectionFilter && !collectionsReady) return null;
 
@@ -272,10 +317,33 @@ export default function Index() {
 			<InstantSearch
 				searchClient={searchClient}
 				indexName="prod_POPULAR"
-				routing={routing(serverUrl, state$, collectionsStore)}
+				routing={routing(
+					serverUrl,
+					state$,
+					collectionsStore,
+					discovery,
+					discovery ? navigate : undefined,
+				)}
 				future={{ preserveSharedStateOnUnmount: true }}
 			>
 				<Configure attributesToRetrieve={attributesToRetrieve} />
+				{discovery && (
+					<ContentHeader>
+						<Stack gap="xs" maw={900}>
+							<Breadcrumbs
+								items={[
+									{ name: 'Fonts', url: '/' },
+									{ name: 'Browse Fonts', url: '/browse' },
+									{ name: discovery.heading },
+								]}
+							/>
+							<Title order={1} c="purple.0">
+								{discovery.heading}
+							</Title>
+							<Text>{discovery.intro}</Text>
+						</Stack>
+					</ContentHeader>
+				)}
 				<Box className={classes.background}>
 					<Box className={classes.container} ref={searchRef}>
 						<Filters state$={state$} />
@@ -288,4 +356,8 @@ export default function Index() {
 			</InstantSearch>
 		</InstantSearchSSRProvider>
 	);
+}
+
+export default function Index() {
+	return <CatalogSearchPage />;
 }

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -350,7 +350,7 @@ export function CatalogSearchPage() {
 							<Breadcrumbs
 								items={[
 									{ name: 'Fonts', url: '/' },
-									{ name: 'Browse Fonts', url: '/browse' },
+									{ name: 'Browse', url: '/browse' },
 									{ name: discovery.heading },
 								]}
 							/>

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -337,8 +337,8 @@ export function CatalogSearchPage() {
 			>
 				<Configure attributesToRetrieve={attributesToRetrieve} />
 				{discovery && (
-					<ContentHeader>
-						<Stack gap="xs" maw={900}>
+					<ContentHeader mih={0} pt={40} pb={24}>
+						<Stack gap="xs" maw={760}>
 							<Breadcrumbs
 								items={[
 									{ name: 'Fonts', url: '/' },
@@ -354,7 +354,11 @@ export function CatalogSearchPage() {
 					</ContentHeader>
 				)}
 				<Box className={classes.background}>
-					<Box className={classes.container} ref={searchRef}>
+					<Box
+						className={classes.container}
+						pt={discovery ? 24 : undefined}
+						ref={searchRef}
+					>
 						<Filters state$={state$} />
 					</Box>
 				</Box>

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -49,7 +49,7 @@ import { cloudflareContext } from '@/utils/cloudflare-context';
 import type { DiscoveryPage } from '@/utils/discovery';
 import { getPreviewText } from '@/utils/language/language';
 
-export interface SearchProps {
+interface SearchProps {
 	discovery?: DiscoveryPage;
 	hasCollectionFilter: boolean;
 	serverState?: InstantSearchServerState;

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -1,4 +1,5 @@
 import {
+	Box,
 	Card,
 	Container,
 	Group,
@@ -31,7 +32,7 @@ export const meta: MetaFunction = () =>
 			'Browse open-source fonts by language, category, and variable-font support, then preview and self-host your selection with Fontsource.',
 	});
 
-const PageGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
+const StyleGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 	<SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
 		{pages.map((page) => (
 			<Card
@@ -47,7 +48,7 @@ const PageGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 					<div>
 						<Title order={3}>{page.heading}</Title>
 						<Text mt="xs" c="dimmed" size="sm">
-							{page.count} families
+							{page.count.toLocaleString('en-US')} families
 						</Text>
 					</div>
 					<IconArrowRight aria-hidden size={20} />
@@ -57,22 +58,30 @@ const PageGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 	</SimpleGrid>
 );
 
-const PageSection = ({
-	title,
-	description,
-	pages,
-}: {
-	title: string;
-	description: string;
-	pages: DiscoveryPage[];
-}) => (
-	<section>
-		<Title order={2}>{title}</Title>
-		<Text c="dimmed" mt="xs" mb="md">
-			{description}
-		</Text>
-		<PageGrid pages={pages} />
-	</section>
+const LanguageDirectory = ({ pages }: { pages: DiscoveryPage[] }) => (
+	<Box component="nav" aria-label="Fonts by language">
+		<Box component="ul" className={classes.languageGrid}>
+			{pages.map((page) => (
+				<li key={page.path}>
+					<Link
+						to={page.path}
+						prefetch="intent"
+						className={classes.languageLink}
+					>
+						<div>
+							<Text component="span" fw={600}>
+								{page.heading}
+							</Text>
+							<Text component="span" display="block" c="dimmed" size="xs">
+								{page.count.toLocaleString('en-US')} families
+							</Text>
+						</div>
+						<IconArrowRight aria-hidden size={18} />
+					</Link>
+				</li>
+			))}
+		</Box>
+	</Box>
 );
 
 export default function Browse() {
@@ -88,23 +97,29 @@ export default function Browse() {
 						Browse Fonts
 					</Title>
 					<Text>
-						Choose a starting point, then refine the results with the same
-						filters and previews available in the full font catalog.
+						Choose a style, language, or variable-font format. Every page
+						includes the full catalog filters and preview controls.
 					</Text>
 				</Stack>
 			</ContentHeader>
 			<Container size="xl" py="xl">
-				<Stack gap="xl">
-					<PageSection
-						title="Browse by style and features"
-						description="Start with a broad font category or explore families with variable axes."
-						pages={stylesAndFeatures}
-					/>
-					<PageSection
-						title="Language support"
-						description="Find font families that publish the character subset your project needs."
-						pages={languages}
-					/>
+				<Stack gap={48}>
+					<section>
+						<Title order={2}>Font styles and features</Title>
+						<Text c="dimmed" mt="xs" mb="md">
+							Start with a broad visual style or explore flexible variable
+							fonts.
+						</Text>
+						<StyleGrid pages={stylesAndFeatures} />
+					</section>
+					<section>
+						<Title order={2}>Fonts by language</Title>
+						<Text c="dimmed" mt="xs" mb="md" maw={720}>
+							Find families for the language your project supports. Each page
+							starts with the matching Fontsource character subset selected.
+						</Text>
+						<LanguageDirectory pages={languages} />
+					</section>
 				</Stack>
 			</Container>
 		</>

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -1,5 +1,4 @@
 import {
-	Box,
 	Card,
 	Container,
 	Group,
@@ -42,7 +41,7 @@ const StyleGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 				prefetch="intent"
 				padding="lg"
 				radius="md"
-				className={classes.card}
+				className={`${classes.link} ${classes.card}`}
 			>
 				<Group justify="space-between" align="center" wrap="nowrap">
 					<div>
@@ -59,14 +58,19 @@ const StyleGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 );
 
 const LanguageDirectory = ({ pages }: { pages: DiscoveryPage[] }) => (
-	<Box component="nav" aria-label="Fonts by language">
-		<Box component="ul" className={classes.languageGrid}>
+	<nav aria-label="Fonts by language">
+		<SimpleGrid
+			component="ul"
+			cols={{ base: 1, sm: 2, md: 3, lg: 4 }}
+			spacing="sm"
+			className={classes.languageGrid}
+		>
 			{pages.map((page) => (
 				<li key={page.path}>
 					<Link
 						to={page.path}
 						prefetch="intent"
-						className={classes.languageLink}
+						className={`${classes.link} ${classes.languageLink}`}
 					>
 						<div>
 							<Text component="span" fw={600}>
@@ -80,8 +84,8 @@ const LanguageDirectory = ({ pages }: { pages: DiscoveryPage[] }) => (
 					</Link>
 				</li>
 			))}
-		</Box>
-	</Box>
+		</SimpleGrid>
+	</nav>
 );
 
 export default function Browse() {

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -1,8 +1,18 @@
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+	Card,
+	Container,
+	Group,
+	SimpleGrid,
+	Stack,
+	Text,
+	Title,
+} from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data, Link, useLoaderData } from 'react-router';
 
 import { ContentHeader } from '@/components/layout/ContentHeader';
+import classes from '@/styles/browse.module.css';
 import { cacheHeaders } from '@/utils/cache';
 import type { DiscoveryPage } from '@/utils/discovery';
 import { loadDiscoveryPages } from '@/utils/discovery.server';
@@ -28,24 +38,47 @@ const PageGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
 				key={page.path}
 				component={Link}
 				to={page.path}
+				prefetch="intent"
 				padding="lg"
-				withBorder
-				style={{ color: 'inherit', textDecoration: 'none' }}
+				radius="md"
+				className={classes.card}
 			>
-				<Title order={3}>{page.heading}</Title>
-				<Text mt="xs" c="dimmed">
-					{page.count} families
-				</Text>
+				<Group justify="space-between" align="center" wrap="nowrap">
+					<div>
+						<Title order={3}>{page.heading}</Title>
+						<Text mt="xs" c="dimmed" size="sm">
+							{page.count} families
+						</Text>
+					</div>
+					<IconArrowRight aria-hidden size={20} />
+				</Group>
 			</Card>
 		))}
 	</SimpleGrid>
 );
 
+const PageSection = ({
+	title,
+	description,
+	pages,
+}: {
+	title: string;
+	description: string;
+	pages: DiscoveryPage[];
+}) => (
+	<section>
+		<Title order={2}>{title}</Title>
+		<Text c="dimmed" mt="xs" mb="md">
+			{description}
+		</Text>
+		<PageGrid pages={pages} />
+	</section>
+);
+
 export default function Browse() {
 	const { pages } = useLoaderData<typeof loader>();
 	const languages = pages.filter((page) => page.kind === 'language');
-	const categories = pages.filter((page) => page.kind === 'category');
-	const features = pages.filter((page) => page.kind === 'variable');
+	const stylesAndFeatures = pages.filter((page) => page.kind !== 'language');
 
 	return (
 		<>
@@ -55,31 +88,23 @@ export default function Browse() {
 						Browse Fonts
 					</Title>
 					<Text>
-						Start with a useful catalog view, then refine it with the same
-						flexible filters and previews available on the main font search.
+						Choose a starting point, then refine the results with the same
+						filters and previews available in the full font catalog.
 					</Text>
 				</Stack>
 			</ContentHeader>
 			<Container size="xl" py="xl">
 				<Stack gap="xl">
-					<section>
-						<Title order={2} mb="md">
-							Languages
-						</Title>
-						<PageGrid pages={languages} />
-					</section>
-					<section>
-						<Title order={2} mb="md">
-							Categories
-						</Title>
-						<PageGrid pages={categories} />
-					</section>
-					<section>
-						<Title order={2} mb="md">
-							Features
-						</Title>
-						<PageGrid pages={features} />
-					</section>
+					<PageSection
+						title="Browse by style and features"
+						description="Start with a broad font category or explore families with variable axes."
+						pages={stylesAndFeatures}
+					/>
+					<PageSection
+						title="Language support"
+						description="Find font families that publish the character subset your project needs."
+						pages={languages}
+					/>
 				</Stack>
 			</Container>
 		</>

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -1,0 +1,87 @@
+import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { data, Link, useLoaderData } from 'react-router';
+
+import { ContentHeader } from '@/components/layout/ContentHeader';
+import { cacheHeaders } from '@/utils/cache';
+import type { DiscoveryPage } from '@/utils/discovery';
+import { loadDiscoveryPages } from '@/utils/discovery.server';
+import { ogMeta } from '@/utils/meta';
+
+export const loader = async ({ request }: LoaderFunctionArgs) =>
+	data(
+		{ pages: await loadDiscoveryPages(request.signal) },
+		{ headers: cacheHeaders.short },
+	);
+
+export const meta: MetaFunction = () =>
+	ogMeta({
+		title: 'Browse Open-Source Fonts | Fontsource',
+		description:
+			'Browse open-source fonts by language, category, and variable-font support, then preview and self-host your selection with Fontsource.',
+	});
+
+const PageGrid = ({ pages }: { pages: DiscoveryPage[] }) => (
+	<SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
+		{pages.map((page) => (
+			<Card
+				key={page.path}
+				component={Link}
+				to={page.path}
+				padding="lg"
+				withBorder
+				style={{ color: 'inherit', textDecoration: 'none' }}
+			>
+				<Title order={3}>{page.heading}</Title>
+				<Text mt="xs" c="dimmed">
+					{page.count} families
+				</Text>
+			</Card>
+		))}
+	</SimpleGrid>
+);
+
+export default function Browse() {
+	const { pages } = useLoaderData<typeof loader>();
+	const languages = pages.filter((page) => page.kind === 'language');
+	const categories = pages.filter((page) => page.kind === 'category');
+	const features = pages.filter((page) => page.kind === 'variable');
+
+	return (
+		<>
+			<ContentHeader>
+				<Stack gap="xs" maw={800}>
+					<Title order={1} c="purple.0">
+						Browse Fonts
+					</Title>
+					<Text>
+						Start with a useful catalog view, then refine it with the same
+						flexible filters and previews available on the main font search.
+					</Text>
+				</Stack>
+			</ContentHeader>
+			<Container size="xl" py="xl">
+				<Stack gap="xl">
+					<section>
+						<Title order={2} mb="md">
+							Languages
+						</Title>
+						<PageGrid pages={languages} />
+					</section>
+					<section>
+						<Title order={2} mb="md">
+							Categories
+						</Title>
+						<PageGrid pages={categories} />
+					</section>
+					<section>
+						<Title order={2} mb="md">
+							Features
+						</Title>
+						<PageGrid pages={features} />
+					</section>
+				</Stack>
+			</Container>
+		</>
+	);
+}

--- a/website/app/routes/categories.$category.tsx
+++ b/website/app/routes/categories.$category.tsx
@@ -1,0 +1,2 @@
+export { loader } from '@/features/discovery/loader.server';
+export { default, links, meta } from '@/features/discovery/route';

--- a/website/app/routes/categories.$category.tsx
+++ b/website/app/routes/categories.$category.tsx
@@ -1,1 +1,0 @@
-export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/routes/categories.$category.tsx
+++ b/website/app/routes/categories.$category.tsx
@@ -1,0 +1,1 @@
+export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/routes/languages.$language.tsx
+++ b/website/app/routes/languages.$language.tsx
@@ -1,0 +1,2 @@
+export { loader } from '@/features/discovery/loader.server';
+export { default, links, meta } from '@/features/discovery/route';

--- a/website/app/routes/languages.$language.tsx
+++ b/website/app/routes/languages.$language.tsx
@@ -1,1 +1,0 @@
-export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/routes/languages.$language.tsx
+++ b/website/app/routes/languages.$language.tsx
@@ -1,0 +1,1 @@
+export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/routes/variable-fonts.tsx
+++ b/website/app/routes/variable-fonts.tsx
@@ -1,0 +1,2 @@
+export { loader } from '@/features/discovery/loader.server';
+export { default, links, meta } from '@/features/discovery/route';

--- a/website/app/routes/variable-fonts.tsx
+++ b/website/app/routes/variable-fonts.tsx
@@ -1,1 +1,0 @@
-export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/routes/variable-fonts.tsx
+++ b/website/app/routes/variable-fonts.tsx
@@ -1,0 +1,1 @@
+export { default, links, loader, meta } from '@/features/discovery/route';

--- a/website/app/styles/browse.module.css
+++ b/website/app/styles/browse.module.css
@@ -1,0 +1,31 @@
+.card {
+	color: inherit;
+	text-decoration: none;
+	border: 1px solid
+		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+	background-color: light-dark(
+		var(--mantine-color-background-1),
+		var(--mantine-color-background-4)
+	);
+	transition:
+		background-color 150ms ease,
+		transform 150ms ease;
+
+	svg {
+		flex: 0 0 auto;
+		color: var(--mantine-color-purple-0);
+	}
+
+	&:hover {
+		background-color: light-dark(
+			var(--mantine-color-background-2),
+			var(--mantine-color-background-5)
+		);
+		transform: translateY(-1px);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--mantine-color-purpleHover-2);
+		outline-offset: 2px;
+	}
+}

--- a/website/app/styles/browse.module.css
+++ b/website/app/styles/browse.module.css
@@ -22,10 +22,110 @@
 			var(--mantine-color-background-5)
 		);
 		transform: translateY(-1px);
+
+		svg {
+			transform: translateX(2px);
+		}
+	}
+
+	&:active {
+		transform: translateY(0);
 	}
 
 	&:focus-visible {
 		outline: 2px solid var(--mantine-color-purpleHover-2);
 		outline-offset: 2px;
+	}
+}
+
+.card svg,
+.languageLink svg {
+	transition: transform 150ms ease;
+}
+
+.languageGrid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: var(--mantine-spacing-sm);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	@media (--lt-lg) {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	@media (--lt-md) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	@media (--lt-sm) {
+		grid-template-columns: 1fr;
+	}
+}
+
+.languageLink {
+	display: flex;
+	min-height: 72px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--mantine-spacing-md);
+	padding: var(--mantine-spacing-md);
+	color: inherit;
+	text-decoration: none;
+	border: 1px solid
+		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+	border-radius: var(--mantine-radius-md);
+	background-color: light-dark(
+		var(--mantine-color-background-1),
+		var(--mantine-color-background-4)
+	);
+	transition: background-color 150ms ease;
+
+	svg {
+		flex: 0 0 auto;
+		color: var(--mantine-color-purple-0);
+	}
+
+	&:hover {
+		background-color: light-dark(
+			var(--mantine-color-background-2),
+			var(--mantine-color-background-5)
+		);
+
+		svg {
+			transform: translateX(2px);
+		}
+	}
+
+	&:active {
+		background-color: light-dark(
+			var(--mantine-color-purpleHover-0),
+			var(--mantine-color-purpleHover-2)
+		);
+
+		svg {
+			transform: translateX(0);
+		}
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--mantine-color-purpleHover-2);
+		outline-offset: 2px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.card,
+	.card svg,
+	.languageLink,
+	.languageLink svg {
+		transition: none;
+	}
+
+	.card:hover,
+	.card:hover svg,
+	.languageLink:hover svg {
+		transform: none;
 	}
 }

--- a/website/app/styles/browse.module.css
+++ b/website/app/styles/browse.module.css
@@ -1,81 +1,8 @@
-.card {
+.link {
 	color: inherit;
 	text-decoration: none;
 	border: 1px solid
 		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
-	background-color: light-dark(
-		var(--mantine-color-background-1),
-		var(--mantine-color-background-4)
-	);
-	transition:
-		background-color 150ms ease,
-		transform 150ms ease;
-
-	svg {
-		flex: 0 0 auto;
-		color: var(--mantine-color-purple-0);
-	}
-
-	&:hover {
-		background-color: light-dark(
-			var(--mantine-color-background-2),
-			var(--mantine-color-background-5)
-		);
-		transform: translateY(-1px);
-
-		svg {
-			transform: translateX(2px);
-		}
-	}
-
-	&:active {
-		transform: translateY(0);
-	}
-
-	&:focus-visible {
-		outline: 2px solid var(--mantine-color-purpleHover-2);
-		outline-offset: 2px;
-	}
-}
-
-.card svg,
-.languageLink svg {
-	transition: transform 150ms ease;
-}
-
-.languageGrid {
-	display: grid;
-	grid-template-columns: repeat(4, minmax(0, 1fr));
-	gap: var(--mantine-spacing-sm);
-	margin: 0;
-	padding: 0;
-	list-style: none;
-
-	@media (--lt-lg) {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-
-	@media (--lt-md) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-
-	@media (--lt-sm) {
-		grid-template-columns: 1fr;
-	}
-}
-
-.languageLink {
-	display: flex;
-	min-height: 72px;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--mantine-spacing-md);
-	padding: var(--mantine-spacing-md);
-	color: inherit;
-	text-decoration: none;
-	border: 1px solid
-		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
-	border-radius: var(--mantine-radius-md);
 	background-color: light-dark(
 		var(--mantine-color-background-1),
 		var(--mantine-color-background-4)
@@ -85,6 +12,7 @@
 	svg {
 		flex: 0 0 auto;
 		color: var(--mantine-color-purple-0);
+		transition: transform 150ms ease;
 	}
 
 	&:hover {
@@ -92,11 +20,45 @@
 			var(--mantine-color-background-2),
 			var(--mantine-color-background-5)
 		);
-
 		svg {
 			transform: translateX(2px);
 		}
 	}
+
+	&:focus-visible {
+		outline: 2px solid var(--mantine-color-purpleHover-2);
+		outline-offset: 2px;
+	}
+}
+
+.card {
+	transition:
+		background-color 150ms ease,
+		transform 150ms ease;
+
+	&:hover {
+		transform: translateY(-1px);
+	}
+
+	&:active {
+		transform: translateY(0);
+	}
+}
+
+.languageGrid {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.languageLink {
+	display: flex;
+	min-height: 72px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--mantine-spacing-md);
+	padding: var(--mantine-spacing-md);
+	border-radius: var(--mantine-radius-md);
 
 	&:active {
 		background-color: light-dark(
@@ -108,24 +70,15 @@
 			transform: translateX(0);
 		}
 	}
-
-	&:focus-visible {
-		outline: 2px solid var(--mantine-color-purpleHover-2);
-		outline-offset: 2px;
-	}
 }
 
 @media (prefers-reduced-motion: reduce) {
+	.link,
+	.link svg,
 	.card,
-	.card svg,
-	.languageLink,
-	.languageLink svg {
-		transition: none;
-	}
-
 	.card:hover,
-	.card:hover svg,
-	.languageLink:hover svg {
+	.link:hover svg {
+		transition: none;
 		transform: none;
 	}
 }

--- a/website/app/utils/algolia.test.ts
+++ b/website/app/utils/algolia.test.ts
@@ -31,6 +31,12 @@ describe('buildAlgoliaCacheKey', () => {
 		);
 	});
 
+	it('isolates clean discovery paths from the homepage cache', () => {
+		expect(
+			buildAlgoliaCacheKey('https://fontsource.org/languages/vietnamese'),
+		).toBe('algolia:ssr:languages:vietnamese');
+	});
+
 	it('skips known params with arbitrary values', () => {
 		expect(
 			buildAlgoliaCacheKey(

--- a/website/app/utils/algolia.ts
+++ b/website/app/utils/algolia.ts
@@ -3,7 +3,8 @@ const ALGOLIA_CACHE_KEY_PREFIX = 'algolia:ssr';
 export const buildAlgoliaCacheKey = (
 	requestUrl: string,
 ): string | undefined => {
-	const source = new URL(requestUrl).searchParams;
+	const url = new URL(requestUrl);
+	const source = url.searchParams;
 
 	if (
 		['query', 'category', 'variable', 'sort'].some((param) =>
@@ -16,5 +17,7 @@ export const buildAlgoliaCacheKey = (
 		return undefined;
 	}
 
-	return `${ALGOLIA_CACHE_KEY_PREFIX}:root`;
+	const pathname = url.pathname.replace(/^\/+|\/+$/g, '');
+	const scope = pathname ? pathname.replaceAll('/', ':') : 'root';
+	return `${ALGOLIA_CACHE_KEY_PREFIX}:${scope}`;
 };

--- a/website/app/utils/discovery-content.ts
+++ b/website/app/utils/discovery-content.ts
@@ -3,13 +3,7 @@ type DiscoveryContent = {
 	intro: string;
 };
 
-type CategoryDiscoveryContent = DiscoveryContent & {
-	label: string;
-};
-
-export const languageDiscoveryContent: Partial<
-	Record<string, DiscoveryContent>
-> = {
+export const languageDiscoveryContent = {
 	arabic: {
 		description:
 			'Browse open-source Arabic fonts with native right-to-left previews. Compare connected letterforms, styles, and families ready to self-host.',
@@ -124,11 +118,9 @@ export const languageDiscoveryContent: Partial<
 		intro:
 			'Compare Vietnamese typefaces through dense diacritics and everyday reading.',
 	},
-};
+} satisfies Record<string, DiscoveryContent>;
 
-export const categoryDiscoveryContent: Partial<
-	Record<string, CategoryDiscoveryContent>
-> = {
+export const categoryDiscoveryContent = {
 	display: {
 		description:
 			'Browse open-source display fonts for headlines, posters, and branding. Preview your text, compare styles, and self-host with Fontsource.',
@@ -171,7 +163,7 @@ export const categoryDiscoveryContent: Partial<
 			'Browse distinctive typefaces for editorial design, branding, and comfortable long-form reading.',
 		label: 'Serif',
 	},
-};
+} satisfies Record<string, DiscoveryContent & { label: string }>;
 
 export const variableDiscoveryContent: DiscoveryContent = {
 	description:

--- a/website/app/utils/discovery-content.ts
+++ b/website/app/utils/discovery-content.ts
@@ -1,0 +1,181 @@
+type DiscoveryContent = {
+	description: string;
+	intro: string;
+};
+
+type CategoryDiscoveryContent = DiscoveryContent & {
+	label: string;
+};
+
+export const languageDiscoveryContent: Partial<
+	Record<string, DiscoveryContent>
+> = {
+	arabic: {
+		description:
+			'Browse open-source Arabic fonts with native right-to-left previews. Compare connected letterforms, styles, and families ready to self-host.',
+		intro:
+			'Find Arabic typefaces for connected, right-to-left text, from long-form reading to display.',
+	},
+	bengali: {
+		description:
+			'Explore open-source Bengali fonts with native previews for conjuncts and vowel marks, then self-host the family that suits your project.',
+		intro:
+			'Compare Bengali typefaces through conjuncts, vowel marks, and flowing native text.',
+	},
+	'chinese-hongkong': {
+		description:
+			'Browse open-source Hong Kong Chinese fonts with native Traditional Chinese previews, compare regional forms, and self-host your choice.',
+		intro:
+			'Explore Hong Kong Chinese typefaces with native text and region-specific character forms.',
+	},
+	'chinese-simplified': {
+		description:
+			'Explore open-source Simplified Chinese fonts in native headlines and body text. Compare families and self-host your selected typeface.',
+		intro:
+			'Compare Simplified Chinese typefaces across interfaces, headlines, and longer passages.',
+	},
+	'chinese-traditional': {
+		description:
+			'Browse open-source Traditional Chinese fonts with native text previews. Inspect character detail, compare styles, and self-host your choice.',
+		intro:
+			'Explore Traditional Chinese typefaces with detailed characters and balanced text texture.',
+	},
+	cyrillic: {
+		description:
+			'Browse open-source Cyrillic fonts across serif, sans serif, display, and handwriting styles, with live previews and easy self-hosting.',
+		intro:
+			'Find Cyrillic typefaces for clear interface text, distinctive headlines, and lettering.',
+	},
+	devanagari: {
+		description:
+			'Explore open-source Devanagari fonts with native previews for conjuncts and vowel marks, then self-host the right family for your project.',
+		intro:
+			'Compare Devanagari typefaces through conjuncts, headline forms, and vowel marks.',
+	},
+	greek: {
+		description:
+			'Browse open-source Greek fonts for body text, interfaces, and display typography. Preview your words and self-host with Fontsource.',
+		intro:
+			'Find Greek typefaces for readable text and expressive display work.',
+	},
+	gujarati: {
+		description:
+			'Explore open-source Gujarati fonts with native previews for vowel marks and conjunct forms, then self-host your selected family.',
+		intro:
+			'Compare Gujarati typefaces through native vowel marks, conjuncts, and overall rhythm.',
+	},
+	gurmukhi: {
+		description:
+			'Browse open-source Gurmukhi fonts, preview native letterforms and vowel signs, and self-host your chosen family with Fontsource.',
+		intro:
+			'Explore Gurmukhi typefaces through native letterforms, vowel signs, and spacing.',
+	},
+	hebrew: {
+		description:
+			'Explore open-source Hebrew fonts with right-to-left previews. Compare readable and expressive styles, then self-host your choice.',
+		intro:
+			'Compare Hebrew typefaces in right-to-left text, from reading faces to display styles.',
+	},
+	japanese: {
+		description:
+			'Browse open-source Japanese fonts with native kana and kanji previews. Compare families for text and display, then self-host your choice.',
+		intro:
+			'Explore Japanese typefaces with kana and kanji together in native text.',
+	},
+	kannada: {
+		description:
+			'Explore open-source Kannada fonts with native previews for rounded forms and conjuncts, then self-host your chosen family.',
+		intro:
+			'Compare Kannada typefaces through rounded forms, conjuncts, and native spacing.',
+	},
+	khmer: {
+		description:
+			'Browse open-source Khmer fonts with native text previews. Inspect stacked forms, compare styles, and self-host your selected family.',
+		intro:
+			'Explore Khmer typefaces through stacked forms, proportions, and native text.',
+	},
+	korean: {
+		description:
+			'Explore open-source Korean fonts with native Hangul previews. Compare text and display styles, then self-host your chosen family.',
+		intro:
+			'Compare Korean typefaces in Hangul, from quiet reading faces to display styles.',
+	},
+	tamil: {
+		description:
+			'Browse open-source Tamil fonts with native text previews. Compare traditional and contemporary styles, then self-host your choice.',
+		intro:
+			'Find Tamil typefaces with the right rhythm for reading, interfaces, and display.',
+	},
+	telugu: {
+		description:
+			'Explore open-source Telugu fonts with native previews. Compare rounded letterforms and styles, then self-host your selected family.',
+		intro:
+			'Compare Telugu typefaces through rounded forms, native spacing, and character.',
+	},
+	thai: {
+		description:
+			'Browse open-source Thai fonts with native previews for marks and diacritics. Compare styles and self-host your chosen family.',
+		intro:
+			'Explore Thai typefaces through tone marks, diacritics, spacing, and native text.',
+	},
+	vietnamese: {
+		description:
+			'Explore open-source Vietnamese fonts with native diacritic previews. Compare readable styles and self-host your chosen family.',
+		intro:
+			'Compare Vietnamese typefaces through dense diacritics and everyday reading.',
+	},
+};
+
+export const categoryDiscoveryContent: Partial<
+	Record<string, CategoryDiscoveryContent>
+> = {
+	display: {
+		description:
+			'Browse open-source display fonts for headlines, posters, and branding. Preview your text, compare styles, and self-host with Fontsource.',
+		intro:
+			'Find expressive typefaces for headlines, posters, branding, and bold visual moments.',
+		label: 'Display',
+	},
+	handwriting: {
+		description:
+			'Explore open-source handwriting fonts in script, brush, and informal styles. Preview your text and self-host your chosen family.',
+		intro:
+			'Explore script, brush, and informal typefaces when your words need a more personal voice.',
+		label: 'Handwriting',
+	},
+	icons: {
+		description:
+			'Browse open-source icon fonts for interface symbols and pictograms, preview each family, and self-host the assets your project needs.',
+		intro:
+			'Browse symbol and pictogram typefaces for interfaces, controls, and reusable visual systems.',
+		label: 'Icon',
+	},
+	monospace: {
+		description:
+			'Explore open-source monospace fonts for code, terminals, data, and technical interfaces. Preview and self-host with Fontsource.',
+		intro:
+			'Compare fixed-width typefaces for code, data, interfaces, and precise editorial details.',
+		label: 'Monospace',
+	},
+	'sans-serif': {
+		description:
+			'Browse open-source sans serif fonts for interfaces, branding, and readable text. Compare families and self-host with Fontsource.',
+		intro:
+			'Explore versatile typefaces for interfaces, branding, and clear everyday reading.',
+		label: 'Sans Serif',
+	},
+	serif: {
+		description:
+			'Explore open-source serif fonts for editorial design, branding, and long-form text. Preview, compare, and self-host with Fontsource.',
+		intro:
+			'Browse distinctive typefaces for editorial design, branding, and comfortable long-form reading.',
+		label: 'Serif',
+	},
+};
+
+export const variableDiscoveryContent: DiscoveryContent = {
+	description:
+		'Browse open-source variable fonts with adjustable weight, width, and other axes. Preview variations and self-host with Fontsource.',
+	intro:
+		'Explore flexible typefaces with adjustable weight, width, and other design axes.',
+};

--- a/website/app/utils/discovery.server.ts
+++ b/website/app/utils/discovery.server.ts
@@ -1,0 +1,36 @@
+import { type ListFontValuesResponse, listFontValues } from '@/generated/api';
+import { getDiscoveryPages } from '@/utils/discovery';
+
+const countProjection = (
+	projection: ListFontValuesResponse,
+): Record<string, number> => {
+	const counts: Record<string, number> = {};
+
+	for (const value of Object.values(projection)) {
+		const values = new Set(
+			(Array.isArray(value) ? value : [value]).map((item) => String(item)),
+		);
+		for (const item of values) {
+			counts[item] = (counts[item] ?? 0) + 1;
+		}
+	}
+
+	return counts;
+};
+
+const loadDiscoveryCounts = async (signal?: AbortSignal) => {
+	const [subsets, categories, variable] = await Promise.all([
+		listFontValues({ subsets: '' }, { signal }),
+		listFontValues({ category: '' }, { signal }),
+		listFontValues({ variable: '' }, { signal }),
+	]);
+
+	return {
+		subsets: countProjection(subsets),
+		categories: countProjection(categories),
+		variable: countProjection(variable).true ?? 0,
+	};
+};
+
+export const loadDiscoveryPages = async (signal?: AbortSignal) =>
+	getDiscoveryPages(await loadDiscoveryCounts(signal));

--- a/website/app/utils/discovery.test.ts
+++ b/website/app/utils/discovery.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDiscoveryPages } from './discovery';
+
+const counts = {
+	subsets: {
+		arabic: 10,
+		latin: 2000,
+		malayalam: 9,
+		math: 77,
+	},
+	categories: {
+		icons: 8,
+		other: 17,
+		serif: 10,
+	},
+	variable: 10,
+};
+
+describe('discovery pages', () => {
+	it('publishes useful catalog views only when they have ten families', () => {
+		expect(getDiscoveryPages(counts).map((page) => page.path)).toEqual([
+			'/languages/arabic',
+			'/categories/serif',
+			'/variable-fonts',
+		]);
+	});
+});

--- a/website/app/utils/discovery.test.ts
+++ b/website/app/utils/discovery.test.ts
@@ -25,4 +25,10 @@ describe('discovery pages', () => {
 			'/variable-fonts',
 		]);
 	});
+
+	it('keeps on-page introductions separate from search descriptions', () => {
+		for (const page of getDiscoveryPages(counts)) {
+			expect(page.description).not.toBe(page.intro);
+		}
+	});
 });

--- a/website/app/utils/discovery.test.ts
+++ b/website/app/utils/discovery.test.ts
@@ -25,10 +25,4 @@ describe('discovery pages', () => {
 			'/variable-fonts',
 		]);
 	});
-
-	it('keeps on-page introductions separate from search descriptions', () => {
-		for (const page of getDiscoveryPages(counts)) {
-			expect(page.description).not.toBe(page.intro);
-		}
-	});
 });

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -1,0 +1,122 @@
+import { subsetToLanguage } from './language/subsets';
+
+const MIN_DISCOVERY_FAMILIES = 10;
+
+const excludedLanguageSubsets = new Set([
+	'emoji',
+	'greek-ext',
+	'latin',
+	'latin-ext',
+	'math',
+	'symbols',
+	'symbols2',
+	'cyrillic-ext',
+]);
+
+const categoryLabels: Record<string, string> = {
+	display: 'Display',
+	handwriting: 'Handwriting',
+	icons: 'Icon',
+	monospace: 'Monospace',
+	'sans-serif': 'Sans Serif',
+	serif: 'Serif',
+};
+
+export interface DiscoveryRouteState {
+	category?: string;
+	subsets?: string;
+	variable?: boolean;
+}
+
+export interface DiscoveryPage {
+	count: number;
+	description: string;
+	heading: string;
+	intro: string;
+	kind: 'category' | 'language' | 'variable';
+	path: string;
+	routeState: DiscoveryRouteState;
+}
+
+export type DiscoveryCounts = {
+	categories: Record<string, number>;
+	subsets: Record<string, number>;
+	variable: number;
+};
+
+type DiscoveryTarget =
+	| { kind: 'category'; value: string }
+	| { kind: 'language'; value: string }
+	| { kind: 'variable' };
+
+const buildDiscoveryPage = (
+	target: DiscoveryTarget,
+	count: number,
+): DiscoveryPage | undefined => {
+	if (count < MIN_DISCOVERY_FAMILIES) return undefined;
+
+	switch (target.kind) {
+		case 'language': {
+			const label = subsetToLanguage(target.value);
+			return {
+				count,
+				description: `Browse open-source font families that publish Fontsource's ${label} subset. Preview and compare fonts, then self-host with npm, a download, or CDN.`,
+				heading: `${label} Fonts`,
+				intro: `Explore ${count} open-source font families that publish Fontsource's ${label} subset. Subset availability describes the packaged character range, so verify the exact characters and shaping your project requires.`,
+				kind: target.kind,
+				path: `/languages/${target.value}`,
+				routeState: { subsets: target.value },
+			};
+		}
+		case 'category': {
+			const label = categoryLabels[target.value];
+			return {
+				count,
+				description: `Browse and preview ${label.toLowerCase()} font families from Fontsource, then self-host your selection with npm, a download, or CDN.`,
+				heading: `${label} Fonts`,
+				intro: `Explore ${count} open-source ${label.toLowerCase()} font families, then use the full catalog controls to refine and compare the results.`,
+				kind: target.kind,
+				path: `/categories/${target.value}`,
+				routeState: { category: target.value },
+			};
+		}
+		case 'variable': {
+			return {
+				count,
+				description:
+					'Browse and preview open-source variable font families from Fontsource, then self-host your selection with npm, a download, or CDN.',
+				heading: 'Variable Fonts',
+				intro: `Explore ${count} open-source variable font families with configurable axes, then refine and compare them with the full catalog controls.`,
+				kind: target.kind,
+				path: '/variable-fonts',
+				routeState: { variable: true },
+			};
+		}
+	}
+};
+
+export const getDiscoveryPages = (counts: DiscoveryCounts): DiscoveryPage[] => {
+	const pages = [
+		...Object.keys(counts.subsets).map((subset) =>
+			excludedLanguageSubsets.has(subset)
+				? undefined
+				: buildDiscoveryPage(
+						{ kind: 'language', value: subset },
+						counts.subsets[subset],
+					),
+		),
+		...Object.keys(counts.categories).map((category) =>
+			categoryLabels[category]
+				? buildDiscoveryPage(
+						{ kind: 'category', value: category },
+						counts.categories[category],
+					)
+				: undefined,
+		),
+		buildDiscoveryPage({ kind: 'variable' }, counts.variable),
+	];
+
+	return pages
+		.filter((page): page is DiscoveryPage => page !== undefined)
+		.sort((a, b) => a.heading.localeCompare(b.heading));
+};

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -60,9 +60,9 @@ const buildDiscoveryPage = (
 			const label = subsetToLanguage(target.value);
 			return {
 				count,
-				description: `Browse open-source font families that publish Fontsource's ${label} subset. Preview and compare fonts, then self-host with npm, a download, or CDN.`,
+				description: `Browse and preview open-source ${label} fonts that include Fontsource's ${label} character subset, then self-host with npm, a download, or CDN.`,
 				heading: `${label} Fonts`,
-				intro: `Explore ${count} open-source font families that publish Fontsource's ${label} subset. Subset availability describes the packaged character range, so verify the exact characters and shaping your project requires.`,
+				intro: `Explore ${count} open-source font families for ${label} typography. Each family includes Fontsource's ${label} character subset, so you can preview native text, compare styles, and verify the exact characters and shaping your project needs.`,
 				kind: target.kind,
 				path: `/languages/${target.value}`,
 				routeState: { subsets: target.value },
@@ -74,7 +74,7 @@ const buildDiscoveryPage = (
 				count,
 				description: `Browse and preview ${label.toLowerCase()} font families from Fontsource, then self-host your selection with npm, a download, or CDN.`,
 				heading: `${label} Fonts`,
-				intro: `Explore ${count} open-source ${label.toLowerCase()} font families, then use the full catalog controls to refine and compare the results.`,
+				intro: `Explore ${count} open-source ${label.toLowerCase()} font families. Preview your own text, compare styles, and refine the results with the full Fontsource catalog controls.`,
 				kind: target.kind,
 				path: `/categories/${target.value}`,
 				routeState: { category: target.value },
@@ -86,7 +86,7 @@ const buildDiscoveryPage = (
 				description:
 					'Browse and preview open-source variable font families from Fontsource, then self-host your selection with npm, a download, or CDN.',
 				heading: 'Variable Fonts',
-				intro: `Explore ${count} open-source variable font families with configurable axes, then refine and compare them with the full catalog controls.`,
+				intro: `Explore ${count} open-source variable font families with configurable weight, width, and other axes. Preview and compare them with the full Fontsource catalog controls.`,
 				kind: target.kind,
 				path: '/variable-fonts',
 				routeState: { variable: true },

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -1,3 +1,8 @@
+import {
+	categoryDiscoveryContent,
+	languageDiscoveryContent,
+	variableDiscoveryContent,
+} from './discovery-content';
 import { subsetToLanguage } from './language/subsets';
 
 const MIN_DISCOVERY_FAMILIES = 10;
@@ -12,85 +17,6 @@ const excludedLanguageSubsets = new Set([
 	'symbols2',
 	'cyrillic-ext',
 ]);
-
-const languageIntros: Record<string, string> = {
-	arabic:
-		'Compare open-source Arabic fonts using native text and right-to-left shaping.',
-	bengali:
-		'Preview open-source Bengali fonts with native text, conjuncts, and vowel marks.',
-	'chinese-hongkong':
-		'Browse open-source Hong Kong Chinese fonts and preview native Traditional Chinese text.',
-	'chinese-simplified':
-		'Compare open-source Simplified Chinese fonts with native text for headlines and body copy.',
-	'chinese-traditional':
-		'Browse open-source Traditional Chinese fonts and inspect detailed characters with native text.',
-	cyrillic:
-		'Explore open-source Cyrillic fonts across serif, sans serif, display, and handwriting styles.',
-	devanagari:
-		'Preview open-source Devanagari fonts with native text, conjuncts, and vowel marks.',
-	greek:
-		'Compare open-source Greek fonts for readable text and distinctive display typography.',
-	gujarati:
-		'Preview open-source Gujarati fonts with native text, vowel marks, and conjunct forms.',
-	gurmukhi:
-		'Browse open-source Gurmukhi fonts and compare native letterforms, vowel signs, and styles.',
-	hebrew:
-		'Compare open-source Hebrew fonts with native right-to-left text across contemporary styles.',
-	japanese:
-		'Explore open-source Japanese fonts with native kana and kanji previews.',
-	kannada:
-		'Preview open-source Kannada fonts with native text, conjuncts, and rounded letterforms.',
-	khmer:
-		'Compare open-source Khmer fonts with native text and complex stacked letterforms.',
-	korean:
-		'Browse open-source Korean fonts and preview Hangul across readable and expressive styles.',
-	tamil:
-		'Preview open-source Tamil fonts with native text across traditional and contemporary styles.',
-	telugu:
-		'Compare open-source Telugu fonts with native text and rounded letterforms.',
-	thai: 'Browse open-source Thai fonts and preview native text with marks and diacritics.',
-	vietnamese:
-		'Compare open-source Vietnamese fonts with native text and Vietnamese diacritics.',
-};
-
-const categories: Record<string, { intro: string; label: string }> = {
-	display: {
-		intro:
-			'Find open-source display fonts for expressive headlines, posters, branding, and bold visual moments.',
-		label: 'Display',
-	},
-	handwriting: {
-		intro:
-			'Explore open-source handwriting fonts with script, brush, and informal styles for personal typography.',
-		label: 'Handwriting',
-	},
-	icons: {
-		intro:
-			'Browse open-source icon fonts for interface symbols, pictograms, and self-hosted visual assets.',
-		label: 'Icon',
-	},
-	monospace: {
-		intro:
-			'Compare open-source monospace fonts for code, data, technical interfaces, and editorial details.',
-		label: 'Monospace',
-	},
-	'sans-serif': {
-		intro:
-			'Explore versatile open-source sans serif fonts for interfaces, branding, and everyday reading.',
-		label: 'Sans Serif',
-	},
-	serif: {
-		intro:
-			'Browse distinctive open-source serif fonts for editorial design, branding, and long-form reading.',
-		label: 'Serif',
-	},
-};
-
-const variableIntro =
-	'Explore open-source variable fonts with flexible weight, width, and other axes within each family.';
-
-const getDescription = (intro: string) =>
-	`${intro} Self-host your chosen family with Fontsource.`;
 
 export interface DiscoveryRouteState {
 	category?: string;
@@ -128,26 +54,28 @@ const buildDiscoveryPage = (
 	switch (target.kind) {
 		case 'language': {
 			const label = subsetToLanguage(target.value);
-			const intro =
-				languageIntros[target.value] ??
-				`Browse open-source ${label} fonts and preview native text before choosing a family.`;
+			const content = languageDiscoveryContent[target.value] ?? {
+				description: `Browse open-source ${label} fonts with native text previews. Compare available families and self-host your choice with Fontsource.`,
+				intro: `Explore ${label} typefaces with native text and find the right family for your project.`,
+			};
 			return {
 				count,
-				description: getDescription(intro),
+				description: content.description,
 				heading: `${label} Fonts`,
-				intro,
+				intro: content.intro,
 				kind: target.kind,
 				path: `/languages/${target.value}`,
 				routeState: { subsets: target.value },
 			};
 		}
 		case 'category': {
-			const { intro, label } = categories[target.value];
+			const content = categoryDiscoveryContent[target.value];
+			if (!content) return undefined;
 			return {
 				count,
-				description: getDescription(intro),
-				heading: `${label} Fonts`,
-				intro,
+				description: content.description,
+				heading: `${content.label} Fonts`,
+				intro: content.intro,
 				kind: target.kind,
 				path: `/categories/${target.value}`,
 				routeState: { category: target.value },
@@ -156,9 +84,9 @@ const buildDiscoveryPage = (
 		case 'variable': {
 			return {
 				count,
-				description: getDescription(variableIntro),
+				description: variableDiscoveryContent.description,
 				heading: 'Variable Fonts',
-				intro: variableIntro,
+				intro: variableDiscoveryContent.intro,
 				kind: target.kind,
 				path: '/variable-fonts',
 				routeState: { variable: true },
@@ -178,12 +106,10 @@ export const getDiscoveryPages = (counts: DiscoveryCounts): DiscoveryPage[] => {
 					),
 		),
 		...Object.keys(counts.categories).map((category) =>
-			categories[category]
-				? buildDiscoveryPage(
-						{ kind: 'category', value: category },
-						counts.categories[category],
-					)
-				: undefined,
+			buildDiscoveryPage(
+				{ kind: 'category', value: category },
+				counts.categories[category],
+			),
 		),
 		buildDiscoveryPage({ kind: 'variable' }, counts.variable),
 	];

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -7,18 +7,7 @@ import { subsetToLanguage } from './language/subsets';
 
 const MIN_DISCOVERY_FAMILIES = 10;
 
-const excludedLanguageSubsets = new Set([
-	'emoji',
-	'greek-ext',
-	'latin',
-	'latin-ext',
-	'math',
-	'symbols',
-	'symbols2',
-	'cyrillic-ext',
-]);
-
-export interface DiscoveryRouteState {
+interface DiscoveryRouteState {
 	category?: string;
 	subsets?: string;
 	variable?: boolean;
@@ -35,90 +24,50 @@ export interface DiscoveryPage {
 	routeState: DiscoveryRouteState;
 }
 
-export type DiscoveryCounts = {
+type DiscoveryCounts = {
 	categories: Record<string, number>;
 	subsets: Record<string, number>;
 	variable: number;
 };
 
-type DiscoveryTarget =
-	| { kind: 'category'; value: string }
-	| { kind: 'language'; value: string }
-	| { kind: 'variable' };
-
-const buildDiscoveryPage = (
-	target: DiscoveryTarget,
-	count: number,
-): DiscoveryPage | undefined => {
-	if (count < MIN_DISCOVERY_FAMILIES) return undefined;
-
-	switch (target.kind) {
-		case 'language': {
-			const label = subsetToLanguage(target.value);
-			const content = languageDiscoveryContent[target.value] ?? {
-				description: `Browse open-source ${label} fonts with native text previews. Compare available families and self-host your choice with Fontsource.`,
-				intro: `Explore ${label} typefaces with native text and find the right family for your project.`,
-			};
+export const getDiscoveryPages = (counts: DiscoveryCounts): DiscoveryPage[] => {
+	const pages: DiscoveryPage[] = [
+		...Object.entries(languageDiscoveryContent).map(([subset, content]) => {
+			const label = subsetToLanguage(subset);
 			return {
-				count,
+				count: counts.subsets[subset] ?? 0,
 				description: content.description,
 				heading: `${label} Fonts`,
 				intro: content.intro,
-				kind: target.kind,
+				kind: 'language' as const,
 				label,
-				path: `/languages/${target.value}`,
-				routeState: { subsets: target.value },
+				path: `/languages/${subset}`,
+				routeState: { subsets: subset },
 			};
-		}
-		case 'category': {
-			const content = categoryDiscoveryContent[target.value];
-			if (!content) return undefined;
-			return {
-				count,
-				description: content.description,
-				heading: `${content.label} Fonts`,
-				intro: content.intro,
-				kind: target.kind,
-				label: content.label,
-				path: `/categories/${target.value}`,
-				routeState: { category: target.value },
-			};
-		}
-		case 'variable': {
-			return {
-				count,
-				description: variableDiscoveryContent.description,
-				heading: 'Variable Fonts',
-				intro: variableDiscoveryContent.intro,
-				kind: target.kind,
-				label: 'Variable',
-				path: '/variable-fonts',
-				routeState: { variable: true },
-			};
-		}
-	}
-};
-
-export const getDiscoveryPages = (counts: DiscoveryCounts): DiscoveryPage[] => {
-	const pages = [
-		...Object.keys(counts.subsets).map((subset) =>
-			excludedLanguageSubsets.has(subset)
-				? undefined
-				: buildDiscoveryPage(
-						{ kind: 'language', value: subset },
-						counts.subsets[subset],
-					),
-		),
-		...Object.keys(counts.categories).map((category) =>
-			buildDiscoveryPage(
-				{ kind: 'category', value: category },
-				counts.categories[category],
-			),
-		),
-		buildDiscoveryPage({ kind: 'variable' }, counts.variable),
+		}),
+		...Object.entries(categoryDiscoveryContent).map(([category, content]) => ({
+			count: counts.categories[category] ?? 0,
+			description: content.description,
+			heading: `${content.label} Fonts`,
+			intro: content.intro,
+			kind: 'category' as const,
+			label: content.label,
+			path: `/categories/${category}`,
+			routeState: { category },
+		})),
+		{
+			count: counts.variable,
+			description: variableDiscoveryContent.description,
+			heading: 'Variable Fonts',
+			intro: variableDiscoveryContent.intro,
+			kind: 'variable' as const,
+			label: 'Variable',
+			path: '/variable-fonts',
+			routeState: { variable: true },
+		},
 	];
 
 	return pages
-		.filter((page): page is DiscoveryPage => page !== undefined)
+		.filter((page) => page.count >= MIN_DISCOVERY_FAMILIES)
 		.sort((a, b) => a.heading.localeCompare(b.heading));
 };

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -30,6 +30,7 @@ export interface DiscoveryPage {
 	heading: string;
 	intro: string;
 	kind: 'category' | 'language' | 'variable';
+	label: string;
 	path: string;
 	routeState: DiscoveryRouteState;
 }
@@ -64,6 +65,7 @@ const buildDiscoveryPage = (
 				heading: `${label} Fonts`,
 				intro: content.intro,
 				kind: target.kind,
+				label,
 				path: `/languages/${target.value}`,
 				routeState: { subsets: target.value },
 			};
@@ -77,6 +79,7 @@ const buildDiscoveryPage = (
 				heading: `${content.label} Fonts`,
 				intro: content.intro,
 				kind: target.kind,
+				label: content.label,
 				path: `/categories/${target.value}`,
 				routeState: { category: target.value },
 			};
@@ -88,6 +91,7 @@ const buildDiscoveryPage = (
 				heading: 'Variable Fonts',
 				intro: variableDiscoveryContent.intro,
 				kind: target.kind,
+				label: 'Variable',
 				path: '/variable-fonts',
 				routeState: { variable: true },
 			};

--- a/website/app/utils/discovery.ts
+++ b/website/app/utils/discovery.ts
@@ -13,14 +13,84 @@ const excludedLanguageSubsets = new Set([
 	'cyrillic-ext',
 ]);
 
-const categoryLabels: Record<string, string> = {
-	display: 'Display',
-	handwriting: 'Handwriting',
-	icons: 'Icon',
-	monospace: 'Monospace',
-	'sans-serif': 'Sans Serif',
-	serif: 'Serif',
+const languageIntros: Record<string, string> = {
+	arabic:
+		'Compare open-source Arabic fonts using native text and right-to-left shaping.',
+	bengali:
+		'Preview open-source Bengali fonts with native text, conjuncts, and vowel marks.',
+	'chinese-hongkong':
+		'Browse open-source Hong Kong Chinese fonts and preview native Traditional Chinese text.',
+	'chinese-simplified':
+		'Compare open-source Simplified Chinese fonts with native text for headlines and body copy.',
+	'chinese-traditional':
+		'Browse open-source Traditional Chinese fonts and inspect detailed characters with native text.',
+	cyrillic:
+		'Explore open-source Cyrillic fonts across serif, sans serif, display, and handwriting styles.',
+	devanagari:
+		'Preview open-source Devanagari fonts with native text, conjuncts, and vowel marks.',
+	greek:
+		'Compare open-source Greek fonts for readable text and distinctive display typography.',
+	gujarati:
+		'Preview open-source Gujarati fonts with native text, vowel marks, and conjunct forms.',
+	gurmukhi:
+		'Browse open-source Gurmukhi fonts and compare native letterforms, vowel signs, and styles.',
+	hebrew:
+		'Compare open-source Hebrew fonts with native right-to-left text across contemporary styles.',
+	japanese:
+		'Explore open-source Japanese fonts with native kana and kanji previews.',
+	kannada:
+		'Preview open-source Kannada fonts with native text, conjuncts, and rounded letterforms.',
+	khmer:
+		'Compare open-source Khmer fonts with native text and complex stacked letterforms.',
+	korean:
+		'Browse open-source Korean fonts and preview Hangul across readable and expressive styles.',
+	tamil:
+		'Preview open-source Tamil fonts with native text across traditional and contemporary styles.',
+	telugu:
+		'Compare open-source Telugu fonts with native text and rounded letterforms.',
+	thai: 'Browse open-source Thai fonts and preview native text with marks and diacritics.',
+	vietnamese:
+		'Compare open-source Vietnamese fonts with native text and Vietnamese diacritics.',
 };
+
+const categories: Record<string, { intro: string; label: string }> = {
+	display: {
+		intro:
+			'Find open-source display fonts for expressive headlines, posters, branding, and bold visual moments.',
+		label: 'Display',
+	},
+	handwriting: {
+		intro:
+			'Explore open-source handwriting fonts with script, brush, and informal styles for personal typography.',
+		label: 'Handwriting',
+	},
+	icons: {
+		intro:
+			'Browse open-source icon fonts for interface symbols, pictograms, and self-hosted visual assets.',
+		label: 'Icon',
+	},
+	monospace: {
+		intro:
+			'Compare open-source monospace fonts for code, data, technical interfaces, and editorial details.',
+		label: 'Monospace',
+	},
+	'sans-serif': {
+		intro:
+			'Explore versatile open-source sans serif fonts for interfaces, branding, and everyday reading.',
+		label: 'Sans Serif',
+	},
+	serif: {
+		intro:
+			'Browse distinctive open-source serif fonts for editorial design, branding, and long-form reading.',
+		label: 'Serif',
+	},
+};
+
+const variableIntro =
+	'Explore open-source variable fonts with flexible weight, width, and other axes within each family.';
+
+const getDescription = (intro: string) =>
+	`${intro} Self-host your chosen family with Fontsource.`;
 
 export interface DiscoveryRouteState {
 	category?: string;
@@ -58,23 +128,26 @@ const buildDiscoveryPage = (
 	switch (target.kind) {
 		case 'language': {
 			const label = subsetToLanguage(target.value);
+			const intro =
+				languageIntros[target.value] ??
+				`Browse open-source ${label} fonts and preview native text before choosing a family.`;
 			return {
 				count,
-				description: `Browse and preview open-source ${label} fonts that include Fontsource's ${label} character subset, then self-host with npm, a download, or CDN.`,
+				description: getDescription(intro),
 				heading: `${label} Fonts`,
-				intro: `Explore ${count} open-source font families for ${label} typography. Each family includes Fontsource's ${label} character subset, so you can preview native text, compare styles, and verify the exact characters and shaping your project needs.`,
+				intro,
 				kind: target.kind,
 				path: `/languages/${target.value}`,
 				routeState: { subsets: target.value },
 			};
 		}
 		case 'category': {
-			const label = categoryLabels[target.value];
+			const { intro, label } = categories[target.value];
 			return {
 				count,
-				description: `Browse and preview ${label.toLowerCase()} font families from Fontsource, then self-host your selection with npm, a download, or CDN.`,
+				description: getDescription(intro),
 				heading: `${label} Fonts`,
-				intro: `Explore ${count} open-source ${label.toLowerCase()} font families. Preview your own text, compare styles, and refine the results with the full Fontsource catalog controls.`,
+				intro,
 				kind: target.kind,
 				path: `/categories/${target.value}`,
 				routeState: { category: target.value },
@@ -83,10 +156,9 @@ const buildDiscoveryPage = (
 		case 'variable': {
 			return {
 				count,
-				description:
-					'Browse and preview open-source variable font families from Fontsource, then self-host your selection with npm, a download, or CDN.',
+				description: getDescription(variableIntro),
 				heading: 'Variable Fonts',
-				intro: `Explore ${count} open-source variable font families with configurable weight, width, and other axes. Preview and compare them with the full Fontsource catalog controls.`,
+				intro: variableIntro,
 				kind: target.kind,
 				path: '/variable-fonts',
 				routeState: { variable: true },
@@ -106,7 +178,7 @@ export const getDiscoveryPages = (counts: DiscoveryCounts): DiscoveryPage[] => {
 					),
 		),
 		...Object.keys(counts.categories).map((category) =>
-			categoryLabels[category]
+			categories[category]
 				? buildDiscoveryPage(
 						{ kind: 'category', value: category },
 						counts.categories[category],


### PR DESCRIPTION
## Overview

Adds indexable discovery pages for font categories, languages, and variable fonts when the live Fontsource catalog has at least 10 matching families.

The routes reuse the existing catalog filters and previews, with server-rendered results, canonical metadata, breadcrumbs, and sitemap coverage. The browse page keeps broad font styles prominent and uses a compact language directory as the entry point.