### PR TITLE
feat(registry): archive source snapshots

### DIFF
--- a/.github/workflows/registry-archive.yml
+++ b/.github/workflows/registry-archive.yml
@@ -1,0 +1,35 @@
+name: Registry Archive
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'registry/data/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency: registry-archive
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Archive
+        run: pnpm --filter '@fontsource-utils/registry' archive
+        env:
+          REGISTRY_R2_ENDPOINT: ${{ vars.REGISTRY_R2_ENDPOINT }}
+          REGISTRY_R2_ACCESS_KEY_ID: ${{ secrets.REGISTRY_R2_ACCESS_KEY_ID }}
+          REGISTRY_R2_SECRET_ACCESS_KEY: ${{ secrets.REGISTRY_R2_SECRET_ACCESS_KEY }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,9 +333,15 @@ importers:
 
   registry:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1090.0
+        version: 3.1090.0
       '@fontsource-utils/core':
         specifier: workspace:*
         version: link:../packages/core
+      fastq:
+        specifier: ^1.20.1
+        version: 1.20.1
       protobufjs:
         specifier: 8.7.1
         version: 8.7.1
@@ -575,6 +581,78 @@ packages:
     resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
       zod: ^4.0.0
+
+  '@aws-sdk/checksums@3.1000.18':
+    resolution: {integrity: sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1090.0':
+    resolution: {integrity: sha512-R6GX9cd1jljwzZ8xFmgAI/hHCuX1MobIKBdsymv7WL9SENvO9Vgz9KOR6avTnu0Ao+w1LmxnTe+jqmZXEn7Q/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.70':
+    resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
+    resolution: {integrity: sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1950,6 +2028,30 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.29.5':
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.10':
+    resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.7':
+    resolution: {integrity: sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.7':
+    resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.6':
+    resolution: {integrity: sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@smol-range/decompress@0.1.0':
     resolution: {integrity: sha512-I+BaXBb2BeR5Dj+ntqy9+DOXex5FrvzPLQBxx7SDstJAcxFN2AIL2V5HCf9UqW7urJkeEOhy7agN4FWfzFJ7fA==}
 
@@ -2520,6 +2622,9 @@ packages:
     resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
     engines: {node: '>=20.19.0'}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
@@ -2873,6 +2978,9 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3921,6 +4029,10 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown-plugin-dts@0.27.11:
     resolution: {integrity: sha512-DnBl4USSTV/h/sgy//QjCLHVo2JypE/52P5QugGeYaEqZmjBz/FYESOld0MhyIhul2U3Vsh41K63UWGHhJU/qQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -4583,6 +4695,171 @@ snapshots:
     dependencies:
       openapi3-ts: 4.6.0
       zod: 4.4.3
+
+  '@aws-sdk/checksums@3.1000.18':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1090.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.18
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/middleware-sdk-s3': 3.972.64
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.5
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.70':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.33':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5821,6 +6098,39 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.6':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@smol-range/decompress@0.1.0': {}
 
   '@speed-highlight/core@1.2.17': {}
@@ -6277,6 +6587,8 @@ snapshots:
 
   boolbase@2.0.0: {}
 
+  bowser@2.14.1: {}
+
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
@@ -6626,6 +6938,10 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -7963,6 +8279,8 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  reusify@1.1.0: {}
 
   rolldown-plugin-dts@0.27.11(rolldown@1.2.0)(typescript@6.0.3):
     dependencies:

--- a/registry/README.md
+++ b/registry/README.md
@@ -11,6 +11,7 @@ Run from the repository root:
 ~~~sh
 pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <nam-repo> <nam-commit>
 pnpm --filter '@fontsource-utils/registry' validate
+pnpm --filter '@fontsource-utils/registry' archive
 ~~~
 
 Both source revisions must be exact 40-character commits. Generation also
@@ -20,6 +21,29 @@ Generation validates existing `policy.json` files but never creates or changes
 package policy. Registry data is written to `data/` and refreshed weekly or on
 demand by the [registry sync workflow](../.github/workflows/registry-sync.yml),
 which validates changes before committing them to `main`.
+
+The [registry archive workflow](../.github/workflows/registry-archive.yml)
+runs after registry data changes. It copies the exact registry files and every
+verified source TTF into the private `fontsource-registry` R2 bucket:
+
+~~~text
+registry/sha256/<sha256>
+sources/sha256/<sha256>
+snapshots/<fontsource-commit>/manifest.json
+~~~
+
+Each manifest maps registry paths and sources to their SHA-256 objects and is
+written last. Later runs add only changed objects and one manifest.
+
+Provision the bucket once:
+
+~~~sh
+wrangler r2 bucket create fontsource-registry
+~~~
+
+The workflow needs `REGISTRY_R2_ENDPOINT` and bucket-scoped Object Read & Write
+credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
+`REGISTRY_R2_SECRET_ACCESS_KEY`.
 
 ## Structure
 

--- a/registry/package.json
+++ b/registry/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"archive": "node scripts/archive.ts",
 		"generate": "pnpm --filter '@fontsource-utils/core' build && node scripts/generate.ts",
 		"test": "pnpm --filter '@fontsource-utils/core' build && vitest run",
 		"typecheck": "pnpm --filter '@fontsource-utils/core' build && tsc --noEmit",
@@ -10,6 +11,8 @@
 	},
 	"dependencies": {
 		"@fontsource-utils/core": "workspace:*",
+		"@aws-sdk/client-s3": "^3.1090.0",
+		"fastq": "^1.20.1",
 		"protobufjs": "8.7.1",
 		"turndown": "7.2.4",
 		"zod": "4.4.3"

--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -1,0 +1,62 @@
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const r2 = vi.hoisted(() => ({
+	objectMatches: vi.fn(),
+	putObject: vi.fn(),
+}));
+
+vi.mock('./r2.ts', () => r2);
+
+import { publishArchive } from './archive.ts';
+import { archiveManifestSchema } from './schema.ts';
+
+const REGISTRY_ROOT = resolve(import.meta.dirname, '../data');
+const REVISION = 'a'.repeat(40);
+
+describe('registry source archive', () => {
+	it('rejects non-commit snapshot revisions', () => {
+		expect(() =>
+			archiveManifestSchema.parse({
+				schemaVersion: 1,
+				registryRevision: 'latest',
+				registry: [],
+				sources: [],
+			}),
+		).toThrow();
+	});
+
+	it('publishes content-addressed objects before the snapshot manifest', async () => {
+		const keys: string[] = [];
+		let manifest: unknown;
+		r2.objectMatches.mockResolvedValue(false);
+		r2.putObject.mockImplementation(
+			async (object: { key: string; read: () => Promise<Uint8Array> }) => {
+				keys.push(object.key);
+				if (object.key.startsWith('snapshots/')) {
+					manifest = JSON.parse(
+						Buffer.from(await object.read()).toString('utf8'),
+					);
+				}
+			},
+		);
+
+		await publishArchive(REGISTRY_ROOT, REVISION);
+
+		expect(keys.at(-1)).toBe(`snapshots/${REVISION}/manifest.json`);
+		expect(keys.some((key) => key.startsWith('registry/sha256/'))).toBe(true);
+		expect(keys.some((key) => key.startsWith('sources/sha256/'))).toBe(true);
+		expect(manifest).toMatchObject({
+			schemaVersion: 1,
+			registryRevision: REVISION,
+			registry: expect.arrayContaining([
+				expect.objectContaining({ path: 'index.json' }),
+			]),
+			sources: expect.arrayContaining([
+				expect.objectContaining({
+					sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+				}),
+			]),
+		});
+	}, 15_000);
+});

--- a/registry/scripts/archive.ts
+++ b/registry/scripts/archive.ts
@@ -1,0 +1,149 @@
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import fastq from 'fastq';
+import { assertGitPathClean, getGitRevision } from './git.ts';
+import { objectMatches, putObject } from './r2.ts';
+import {
+	archiveManifestSchema,
+	familyMetadataSchema,
+	registryIndexSchema,
+} from './schema.ts';
+import { canonicalJson, compareStrings, readJson, sha256 } from './shared.ts';
+import { listFiles, validateRegistry } from './validator.ts';
+
+const CONCURRENCY = 16;
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '../..');
+const REGISTRY_ROOT = join(REPOSITORY_ROOT, 'registry', 'data');
+
+interface RegistryFile {
+	path: string;
+	bytes: Uint8Array;
+	size: number;
+	sha256: string;
+}
+
+interface SourceFile {
+	path: string;
+	repository: string;
+	revision: string;
+	size: number;
+	sha256: string;
+}
+
+const createArchivePlan = async (root: string, registryRevision: string) => {
+	await validateRegistry(root);
+
+	const registry = await Promise.all(
+		(await listFiles(root)).map(async (path): Promise<RegistryFile> => {
+			const bytes = await readFile(join(root, path));
+			return { path, bytes, size: bytes.byteLength, sha256: sha256(bytes) };
+		}),
+	);
+	const index = registryIndexSchema.parse(
+		await readJson(join(root, 'index.json')),
+	);
+	const sourceMap = new Map<string, SourceFile>();
+	for (const family of index.families) {
+		const metadata = familyMetadataSchema.parse(
+			await readJson(join(root, 'families', family, 'metadata.json')),
+		);
+		for (const source of metadata.sourceFiles) {
+			sourceMap.set(source.sha256, {
+				path: source.path,
+				repository: index.upstreams.googleFonts.repository,
+				revision: metadata.origin.revision,
+				size: source.size,
+				sha256: source.sha256,
+			});
+		}
+	}
+	const sources = [...sourceMap.values()].toSorted((left, right) =>
+		compareStrings(left.sha256, right.sha256),
+	);
+
+	return {
+		registry,
+		sources,
+		manifest: archiveManifestSchema.parse({
+			schemaVersion: 1,
+			registryRevision,
+			registry: registry.map(({ path, size, sha256: hash }) => ({
+				path,
+				size,
+				sha256: hash,
+			})),
+			sources: sources.map((source) => ({
+				size: source.size,
+				sha256: source.sha256,
+			})),
+		}),
+	};
+};
+
+const readSource = async (source: SourceFile): Promise<Uint8Array> => {
+	// Some source TTFs exceed jsDelivr's per-file limit, so read the pinned
+	// GitHub object directly and let the registry hash verify the response.
+	const path = source.path.split('/').map(encodeURIComponent).join('/');
+	const response = await fetch(
+		`https://raw.githubusercontent.com/${source.repository}/${source.revision}/${path}`,
+	);
+	if (!response.ok) {
+		throw new Error(
+			`Unable to fetch ${source.path}: ${response.status} ${response.statusText}`,
+		);
+	}
+	return response.bytes();
+};
+
+export const publishArchive = async (
+	root: string,
+	registryRevision: string,
+): Promise<void> => {
+	const plan = await createArchivePlan(root, registryRevision);
+	const manifestBytes = Buffer.from(canonicalJson(plan.manifest));
+	const manifestKey = `snapshots/${registryRevision}/manifest.json`;
+	const manifestHash = sha256(manifestBytes);
+	if (
+		await objectMatches(manifestKey, manifestBytes.byteLength, manifestHash)
+	) {
+		console.log(`[registry] Snapshot ${registryRevision} already archived`);
+		return;
+	}
+
+	const registryObjects = [
+		...new Map(plan.registry.map((file) => [file.sha256, file])).values(),
+	];
+	const uploads = fastq.promise(putObject, CONCURRENCY);
+	await Promise.all(
+		[
+			...registryObjects.map((file) => ({
+				key: `registry/sha256/${file.sha256}`,
+				size: file.size,
+				sha256: file.sha256,
+				read: async () => file.bytes,
+			})),
+			...plan.sources.map((source) => ({
+				key: `sources/sha256/${source.sha256}`,
+				size: source.size,
+				sha256: source.sha256,
+				read: () => readSource(source),
+			})),
+		].map((object) => uploads.push(object)),
+	);
+	await putObject({
+		key: manifestKey,
+		size: manifestBytes.byteLength,
+		sha256: manifestHash,
+		read: async () => manifestBytes,
+	});
+
+	console.log(
+		`[registry] Archived ${plan.registry.length} registry files and ${plan.sources.length} sources`,
+	);
+};
+
+if (import.meta.main) {
+	assertGitPathClean(REPOSITORY_ROOT, 'registry/data');
+	const revision = getGitRevision(REPOSITORY_ROOT);
+	await publishArchive(REGISTRY_ROOT, revision);
+}

--- a/registry/scripts/git.ts
+++ b/registry/scripts/git.ts
@@ -12,6 +12,23 @@ const runGitBuffer = (repository: string, args: string[]): Buffer =>
 const runGitText = (repository: string, args: string[]): string =>
 	runGitBuffer(repository, args).toString('utf8').trim();
 
+export const getGitRevision = (repository: string): string =>
+	runGitText(repository, ['rev-parse', 'HEAD']);
+
+export const assertGitPathClean = (repository: string, path: string): void => {
+	if (
+		runGitText(repository, [
+			'status',
+			'--porcelain=v1',
+			'--untracked-files=all',
+			'--',
+			path,
+		])
+	) {
+		throw new Error(`${path} must match HEAD before it can be archived`);
+	}
+};
+
 export type GitSnapshot = {
 	revision: string;
 	paths: readonly string[];

--- a/registry/scripts/r2.test.ts
+++ b/registry/scripts/r2.test.ts
@@ -1,0 +1,74 @@
+import { PutObjectCommand, S3ServiceException } from '@aws-sdk/client-s3';
+import { describe, expect, it, vi } from 'vitest';
+import { sha256 } from './shared.ts';
+
+const s3 = vi.hoisted(() => {
+	process.env.REGISTRY_R2_ENDPOINT = 'https://example.r2.cloudflarestorage.com';
+	process.env.REGISTRY_R2_ACCESS_KEY_ID = 'access-key';
+	process.env.REGISTRY_R2_SECRET_ACCESS_KEY = 'secret-key';
+	return { send: vi.fn() };
+});
+
+vi.mock('@aws-sdk/client-s3', async (importOriginal) => {
+	const original = await importOriginal<typeof import('@aws-sdk/client-s3')>();
+	return {
+		...original,
+		S3Client: class {
+			send = s3.send;
+		},
+	};
+});
+
+import { putObject } from './r2.ts';
+
+describe('R2 source archive', () => {
+	it('verifies bodies and conditionally uploads only missing objects', async () => {
+		const body = new TextEncoder().encode('font');
+		const hash = sha256(body);
+		const missing = new S3ServiceException({
+			name: 'NotFound',
+			$fault: 'client',
+			$metadata: { httpStatusCode: 404 },
+		});
+
+		s3.send.mockRejectedValueOnce(missing);
+		await expect(
+			putObject({
+				key: 'sources/font',
+				size: body.byteLength,
+				sha256: hash,
+				read: async () => new Uint8Array([0]),
+			}),
+		).rejects.toThrow('Object body does not match sources/font');
+
+		s3.send.mockRejectedValueOnce(missing).mockResolvedValueOnce({});
+		await putObject({
+			key: 'sources/font',
+			size: body.byteLength,
+			sha256: hash,
+			read: async () => body,
+		});
+
+		const command = s3.send.mock.calls[2]?.[0];
+		expect(command).toBeInstanceOf(PutObjectCommand);
+		expect(command?.input).toMatchObject({
+			Bucket: 'fontsource-registry',
+			Key: 'sources/font',
+			IfNoneMatch: '*',
+			Metadata: { sha256: hash },
+		});
+
+		s3.send.mockResolvedValueOnce({
+			ContentLength: body.byteLength,
+			Metadata: { sha256: hash },
+		});
+		const read = vi.fn(async () => body);
+		await putObject({
+			key: 'sources/font',
+			size: body.byteLength,
+			sha256: hash,
+			read,
+		});
+		expect(read).not.toHaveBeenCalled();
+	});
+});

--- a/registry/scripts/r2.ts
+++ b/registry/scripts/r2.ts
@@ -1,0 +1,86 @@
+import type { HeadObjectCommandOutput } from '@aws-sdk/client-s3';
+import {
+	HeadObjectCommand,
+	PutObjectCommand,
+	S3Client,
+	S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { sha256 } from './shared.ts';
+
+const BUCKET = 'fontsource-registry';
+
+const requireEnv = (name: string): string => {
+	const value = process.env[name];
+	if (!value) throw new Error(`Missing environment variable ${name}`);
+	return value;
+};
+
+const client = new S3Client({
+	endpoint: requireEnv('REGISTRY_R2_ENDPOINT'),
+	credentials: {
+		accessKeyId: requireEnv('REGISTRY_R2_ACCESS_KEY_ID'),
+		secretAccessKey: requireEnv('REGISTRY_R2_SECRET_ACCESS_KEY'),
+	},
+	region: 'auto',
+	// R2 does not support the SDK's default full-object CRC32 uploads; the
+	// archive verifies each object against its registry SHA-256 instead.
+	requestChecksumCalculation: 'WHEN_REQUIRED',
+});
+
+export const objectMatches = async (
+	key: string,
+	size: number,
+	expectedSha256: string,
+): Promise<boolean> => {
+	let object: HeadObjectCommandOutput;
+	try {
+		object = await client.send(
+			new HeadObjectCommand({ Bucket: BUCKET, Key: key }),
+		);
+	} catch (error) {
+		if (
+			error instanceof S3ServiceException &&
+			error.$metadata.httpStatusCode === 404
+		) {
+			return false;
+		}
+		throw new Error(`Unable to inspect ${key}`, { cause: error });
+	}
+	if (
+		object.ContentLength !== size ||
+		object.Metadata?.sha256 !== expectedSha256
+	) {
+		throw new Error(`Existing R2 object does not match ${key}`);
+	}
+	return true;
+};
+
+interface ImmutableObject {
+	key: string;
+	size: number;
+	sha256: string;
+	read: () => Promise<Uint8Array>;
+}
+
+export const putObject = async (object: ImmutableObject): Promise<void> => {
+	if (await objectMatches(object.key, object.size, object.sha256)) return;
+
+	const body = await object.read();
+	if (body.byteLength !== object.size || sha256(body) !== object.sha256) {
+		throw new Error(`Object body does not match ${object.key}`);
+	}
+
+	try {
+		await client.send(
+			new PutObjectCommand({
+				Bucket: BUCKET,
+				Key: object.key,
+				Body: body,
+				IfNoneMatch: '*',
+				Metadata: { sha256: object.sha256 },
+			}),
+		);
+	} catch (error) {
+		throw new Error(`Unable to upload ${object.key}`, { cause: error });
+	}
+};

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { describe, expect, it, onTestFinished } from 'vitest';
 import { generateRegistry } from './generate.ts';
-import { openGitSnapshot } from './git.ts';
+import { assertGitPathClean, openGitSnapshot } from './git.ts';
 import { canonicalJson, compareStrings, readJson, sha256 } from './shared.ts';
 
 const temporaryDirectory = async (name: string): Promise<string> => {
@@ -218,6 +218,18 @@ const createNamRepository = async (): Promise<{
 };
 
 describe('registry ingestion', () => {
+	it('archives only committed registry data', async () => {
+		const repository = await createGitRepository('committed-registry');
+		await writeFixture(repository, 'registry/data/index.json', '{}\n');
+		commitAll(repository, 'registry snapshot');
+		expect(() => assertGitPathClean(repository, 'registry/data')).not.toThrow();
+
+		await writeFixture(repository, 'registry/data/untracked.json', '{}\n');
+		expect(() => assertGitPathClean(repository, 'registry/data')).toThrow(
+			'must match HEAD',
+		);
+	});
+
 	it('rejects shallow repositories that cannot prove source history', async () => {
 		const source = await createGitRepository('source-history');
 		await writeFixture(source, 'family/METADATA.pb', 'name: "Example"\n');

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -38,6 +38,24 @@ export const registryIndexSchema = z.strictObject({
 	subsets: z.array(idSchema),
 });
 
+export const archiveManifestSchema = z.strictObject({
+	schemaVersion: z.literal(1),
+	registryRevision: revisionSchema,
+	registry: z.array(
+		z.strictObject({
+			path: sourcePathSchema,
+			size: z.number().int().nonnegative(),
+			sha256: sha256Schema,
+		}),
+	),
+	sources: z.array(
+		z.strictObject({
+			size: z.number().int().nonnegative(),
+			sha256: sha256Schema,
+		}),
+	),
+});
+
 const sourceFileSchema = z.strictObject({
 	path: sourcePathSchema,
 	sha256: sha256Schema,

--- a/registry/scripts/validator.ts
+++ b/registry/scripts/validator.ts
@@ -294,7 +294,7 @@ const validateSubset = async (root: string, id: string): Promise<void> => {
 	deepStrictEqual(union, expected, `${id} slice union differs from its ranges`);
 };
 
-const listFiles = async (root: string): Promise<string[]> =>
+export const listFiles = async (root: string): Promise<string[]> =>
 	(await readdir(root, { recursive: true, withFileTypes: true }))
 		.filter((entry) => !entry.isDirectory())
 		.map((entry) =>


### PR DESCRIPTION
## Overview

This preserves the exact registry inputs needed for future Fontsource package builds even when an upstream source changes or disappears, while deduplicating unchanged metadata and font binaries.

- archive committed registry metadata and verified source TTFs in R2
- store immutable objects by SHA-256 and publish a commit-addressed snapshot manifest last
- validate the persisted manifest with a Zod schema and automate archival after registry updates
