### PR TITLE
fix(registry): read R2 endpoint from secrets

### DIFF
--- a/.github/workflows/registry-archive.yml
+++ b/.github/workflows/registry-archive.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Archive
         run: pnpm --filter '@fontsource-utils/registry' archive
         env:
-          REGISTRY_R2_ENDPOINT: ${{ vars.REGISTRY_R2_ENDPOINT }}
+          REGISTRY_R2_ENDPOINT: ${{ secrets.REGISTRY_R2_ENDPOINT }}
           REGISTRY_R2_ACCESS_KEY_ID: ${{ secrets.REGISTRY_R2_ACCESS_KEY_ID }}
           REGISTRY_R2_SECRET_ACCESS_KEY: ${{ secrets.REGISTRY_R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Overview

Use repository secrets for every R2 archive environment variable so the workflow receives the configured endpoint.