### PR TITLE
feat(website): add privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Generic badge](https://img.shields.io/badge/fontsource-passing-brightgreen)](https://github.com/fontsource/fontsource) [![Monthly NPM Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.fontsource.org%2Fv1%2Fstats%2Fbadge%2Fnpm-monthly)](https://fontsource.org/docs/api/stats) [![Total NPM Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.fontsource.org%2Fv1%2Fstats%2Fbadge%2Fnpm-total)](https://fontsource.org/docs/api/stats) [![Monthly jsDelivr Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.fontsource.org%2Fv1%2Fstats%2Fbadge%2Fjsdelivr-monthly)](https://fontsource.org/docs/api/stats) [![Total jsDelivr Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.fontsource.org%2Fv1%2Fstats%2Fbadge%2Fjsdelivr-total)](https://fontsource.org/docs/api/stats) [![License](https://badgen.net/badge/license/MIT/green)](https://github.com/fontsource/fontsource/blob/main/LICENSE)
 
-> **Looking for privacy-focused website analytics?** Check out [Medama](https://github.com/medama-io/medama), an open-source, lightweight and self-hostable analytics solution designed to respect user privacy. 
-
 An updating monorepo full of self-hostable Open Source fonts bundled into individual NPM packages!
 
 Our full documentation and search directory can be found [here](https://fontsource.org/).

--- a/website/app/components/docs/Breadcrumbs.module.css
+++ b/website/app/components/docs/Breadcrumbs.module.css
@@ -6,6 +6,8 @@
 	margin-bottom: 22px;
 	color: light-dark(#667086, #a9b3ca);
 	font-size: 14px;
+	letter-spacing: normal;
+	text-transform: none;
 }
 
 .breadcrumbs span {

--- a/website/app/components/layout/ContentHeader.module.css
+++ b/website/app/components/layout/ContentHeader.module.css
@@ -1,30 +1,112 @@
-/* ContentHeader */
 .header {
-	background: light-dark(var(--mantine-color-background-1), var(--mantine-color-background-5));
+	border-bottom: 1px solid
+		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+	background: light-dark(
+		var(--mantine-color-background-1),
+		var(--mantine-color-background-5)
+	);
 }
 
 .inner {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: end;
+	gap: clamp(2rem, 4vw, 4rem);
 	max-width: 1440px;
 	margin-left: auto;
 	margin-right: auto;
-	min-height: 144px;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 64px 64px 40px;
+	min-height: 240px;
+	padding: 56px 64px 44px;
 
 	@media (--lt-md) {
-		padding: 56px 32px 36px;
+		padding: 48px 32px 40px;
 	}
 
 	@media (--lt-sm) {
-		min-height: 168px;
-		flex-direction: column;
-		align-items: flex-start;
-		justify-content: center;
-		gap: 22px;
-		padding: 40px 24px 28px;
+		grid-template-columns: minmax(0, 1fr);
+		align-items: start;
+		gap: 1.5rem;
+		min-height: 200px;
+		padding: 40px 24px 32px;
 	}
 }
 
-/* Footer */
+.content {
+	display: grid;
+	gap: 0.75rem;
+	min-width: 0;
+	max-width: 62rem;
+}
+
+.eyebrow {
+	color: var(--mantine-color-purple-0);
+	font-size: 0.8125rem;
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.eyebrow > * {
+	margin: 0;
+}
+
+.heading {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.875rem 1.25rem;
+	min-width: 0;
+}
+
+.title {
+	max-width: 22ch;
+	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
+	font-size: clamp(2.5rem, 4vw, 3.5rem);
+	font-weight: 650;
+	letter-spacing: -0.045em;
+	line-height: 1;
+	overflow-wrap: anywhere;
+	text-wrap: balance;
+}
+
+.actions {
+	display: flex;
+	flex: 0 1 auto;
+	align-items: center;
+	min-width: 0;
+}
+
+.description {
+	max-width: 50rem;
+	color: light-dark(#4a566d, #bdc6d9);
+	font-size: clamp(1rem, 1.7vw, 1.125rem);
+	line-height: 1.55;
+	text-wrap: pretty;
+}
+
+.description a {
+	color: light-dark(#473ef6, #9b97ff);
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+	text-decoration: none;
+}
+
+.description a:hover {
+	text-decoration: underline;
+	text-underline-offset: 0.25rem;
+}
+
+.description a:focus-visible {
+	border-radius: 0.125rem;
+	outline: 2px solid var(--mantine-color-purple-0);
+	outline-offset: 0.1875rem;
+}
+
+.controls {
+	align-self: end;
+	max-width: 100%;
+
+	@media (--lt-sm) {
+		width: 100%;
+	}
+}

--- a/website/app/components/layout/ContentHeader.tsx
+++ b/website/app/components/layout/ContentHeader.tsx
@@ -1,12 +1,42 @@
 import type { ContainerProps } from '@mantine/core';
-import { Box, Container } from '@mantine/core';
+import { Box, Container, Text, Title } from '@mantine/core';
+import type { ReactNode } from 'react';
 
 import classes from './ContentHeader.module.css';
 
-export const ContentHeader = ({ ...other }: ContainerProps) => {
+type ContentHeaderProps = Omit<ContainerProps, 'children' | 'title'> & {
+	actions?: ReactNode;
+	children?: ReactNode;
+	description?: ReactNode;
+	eyebrow?: ReactNode;
+	title: ReactNode;
+};
+
+export const ContentHeader = ({
+	actions,
+	children,
+	description,
+	eyebrow,
+	title,
+	...other
+}: ContentHeaderProps) => {
 	return (
 		<Box component="header" className={classes.header}>
-			<Container className={classes.inner} {...other} />
+			<Container className={classes.inner} {...other}>
+				<Box className={classes.content}>
+					{eyebrow && <Box className={classes.eyebrow}>{eyebrow}</Box>}
+					<Box className={classes.heading}>
+						<Title order={1} className={classes.title}>
+							{title}
+						</Title>
+						{actions && <Box className={classes.actions}>{actions}</Box>}
+					</Box>
+					{description && (
+						<Text className={classes.description}>{description}</Text>
+					)}
+				</Box>
+				{children && <Box className={classes.controls}>{children}</Box>}
+			</Container>
 		</Box>
 	);
 };

--- a/website/app/components/layout/Footer.tsx
+++ b/website/app/components/layout/Footer.tsx
@@ -70,6 +70,7 @@ export const Footer = ({ ...other }: ContainerProps) => {
 							<FooterNavLink label="Fonts" to="/" />
 							<FooterNavLink label="Browse" to="/browse" />
 							<FooterNavLink label="Documentation" to="/docs" />
+							<FooterNavLink label="Privacy" to="/privacy" />
 							<ThemeButton stroke="white" />
 							<Icon
 								label="GitHub"

--- a/website/app/components/layout/Footer.tsx
+++ b/website/app/components/layout/Footer.tsx
@@ -70,7 +70,7 @@ export const Footer = ({ ...other }: ContainerProps) => {
 							<FooterNavLink label="Fonts" to="/" />
 							<FooterNavLink label="Browse" to="/browse" />
 							<FooterNavLink label="Documentation" to="/docs" />
-							<FooterNavLink label="Privacy" to="/privacy" />
+							<FooterNavLink label="Privacy Policy" to="/privacy" />
 							<ThemeButton stroke="white" />
 							<Icon
 								label="GitHub"

--- a/website/app/components/layout/Header.tsx
+++ b/website/app/components/layout/Header.tsx
@@ -101,6 +101,7 @@ const MobileHeader = ({ toggle }: MobileHeaderProps) => {
 					<HeaderNavLink label="Fonts" to="/" toggle={toggle} />
 					<HeaderNavLink label="Documentation" to="/docs" toggle={toggle} />
 					<HeaderNavLink label="Tools" to="/tools" toggle={toggle} />
+					<HeaderNavLink label="Privacy" to="/privacy" toggle={toggle} />
 					<Divider />
 					<ThemeButtonMobile />
 					<MobileExternalIcon

--- a/website/app/components/layout/Header.tsx
+++ b/website/app/components/layout/Header.tsx
@@ -101,7 +101,7 @@ const MobileHeader = ({ toggle }: MobileHeaderProps) => {
 					<HeaderNavLink label="Fonts" to="/" toggle={toggle} />
 					<HeaderNavLink label="Documentation" to="/docs" toggle={toggle} />
 					<HeaderNavLink label="Tools" to="/tools" toggle={toggle} />
-					<HeaderNavLink label="Privacy" to="/privacy" toggle={toggle} />
+					<HeaderNavLink label="Privacy Policy" to="/privacy" toggle={toggle} />
 					<Divider />
 					<ThemeButtonMobile />
 					<MobileExternalIcon

--- a/website/app/components/preview/Tabs.module.css
+++ b/website/app/components/preview/Tabs.module.css
@@ -1,13 +1,3 @@
-/* Tabs */
-.heading {
-	min-width: 0;
-}
-
-.title {
-	line-height: 1.05;
-	overflow-wrap: anywhere;
-}
-
 .badge {
 	padding: 4px 8px;
 

--- a/website/app/components/preview/Tabs.tsx
+++ b/website/app/components/preview/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { BoxProps } from '@mantine/core';
-import { Badge, Group, Tabs, Title, VisuallyHidden } from '@mantine/core';
+import { Badge, Group, Tabs, VisuallyHidden } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { Link } from 'react-router';
 
@@ -43,25 +43,23 @@ export const TabsWrapper = ({
 				list: classes.list,
 			}}
 		>
-			<ContentHeader>
-				<Group
-					align="center"
-					gap="sm"
-					className={classes.heading}
-					data-m:load={`view-tab=${tabsValue}`}
-				>
-					<Title order={1} c="purple.0" className={classes.title}>
-						{metadata.family}
-					</Title>
-					<Badge color="gray" variant="light" className={classes.badge}>
-						{metadata.category}
-					</Badge>
-					<Badge color="gray" variant="light" className={classes.badge}>
-						{metadata.type}
-					</Badge>
-					<FavoriteButton font={fontSummary} />
-					<AddToCollectionMenu font={fontSummary} />
-				</Group>
+			<ContentHeader
+				eyebrow="Font family"
+				title={metadata.family}
+				data-m:load={`view-tab=${tabsValue}`}
+				actions={
+					<Group align="center" gap="sm">
+						<Badge color="gray" variant="light" className={classes.badge}>
+							{metadata.category}
+						</Badge>
+						<Badge color="gray" variant="light" className={classes.badge}>
+							{metadata.type}
+						</Badge>
+						<FavoriteButton font={fontSummary} />
+						<AddToCollectionMenu font={fontSummary} />
+					</Group>
+				}
+			>
 				<Tabs.List>
 					<Link
 						to={`/fonts/${metadata.id}`}

--- a/website/app/root.tsx
+++ b/website/app/root.tsx
@@ -175,7 +175,6 @@ export const Document = ({ children }: DocumentProps) => {
 					defaultColorScheme="light"
 					suppressHydrationWarning
 				/>
-				<script defer src="https://demo.medama.io/script.js" />
 			</head>
 			<body>
 				<MantineProvider theme={theme}>

--- a/website/app/routes/[sitemap.xml].tsx
+++ b/website/app/routes/[sitemap.xml].tsx
@@ -12,6 +12,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 	smStream.write({ url: '/', changefreq: 'daily', priority: 0.9 });
 	smStream.write({ url: '/browse', changefreq: 'weekly', priority: 0.7 });
 	smStream.write({ url: '/tools', changefreq: 'weekly', priority: 0.7 });
+	smStream.write({ url: '/privacy', changefreq: 'yearly', priority: 0.3 });
 	smStream.write({
 		url: '/tools/converter',
 		changefreq: 'weekly',

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { createFetchRequester } from '@algolia/requester-fetch';
 import { observable } from '@legendapp/state';
 import { useObservable, useValue } from '@legendapp/state/react';
-import { Box, MantineProvider, Stack, Text, Title } from '@mantine/core';
+import { Box, MantineProvider } from '@mantine/core';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import type { UiState } from 'instantsearch.js';
 import { history } from 'instantsearch.js/es/lib/routers';
@@ -345,20 +345,18 @@ export function CatalogSearchPage() {
 			>
 				<Configure attributesToRetrieve={attributesToRetrieve} />
 				{discovery && (
-					<ContentHeader mih={0} pt={40} pb={24}>
-						<Stack gap="xs" maw={760}>
+					<ContentHeader
+						eyebrow={
 							<Breadcrumbs
 								items={[
 									{ name: 'Browse', url: '/browse' },
 									{ name: discovery.label },
 								]}
 							/>
-							<Title order={1} c="purple.0">
-								{discovery.heading}
-							</Title>
-							<Text>{discovery.intro}</Text>
-						</Stack>
-					</ContentHeader>
+						}
+						title={discovery.heading}
+						description={discovery.intro}
+					/>
 				)}
 				<Box className={classes.background}>
 					<Box

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -95,17 +95,11 @@ export default function Browse() {
 
 	return (
 		<>
-			<ContentHeader>
-				<Stack gap="xs" maw={800}>
-					<Title order={1} c="purple.0">
-						Browse Fonts
-					</Title>
-					<Text>
-						Choose a style, language, or variable-font format. Every page
-						includes the full catalog filters and preview controls.
-					</Text>
-				</Stack>
-			</ContentHeader>
+			<ContentHeader
+				eyebrow="Font discovery"
+				title="Browse Fonts"
+				description="Choose a style, language, or variable-font format. Every page includes the full catalog filters and preview controls."
+			/>
 			<Container size="xl" py="xl">
 				<Stack gap={48}>
 					<section>

--- a/website/app/routes/privacy.tsx
+++ b/website/app/routes/privacy.tsx
@@ -1,16 +1,16 @@
-import { Anchor, Box, Container, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Box, Container, Text, Title } from '@mantine/core';
+import type { ReactNode } from 'react';
 import type { MetaFunction } from 'react-router';
 import { ContentHeader } from '@/components/layout/ContentHeader';
 import classes from '@/styles/privacy.module.css';
 import { ogMeta } from '@/utils/meta';
 
-export const meta: MetaFunction = () => {
-	const title = 'Privacy Policy | Fontsource';
-	const description =
-		'How Fontsource approaches privacy across its website and services.';
-
-	return ogMeta({ title, description });
-};
+export const meta: MetaFunction = () =>
+	ogMeta({
+		title: 'Privacy Policy | Fontsource',
+		description:
+			'How Fontsource approaches privacy across its website and services.',
+	});
 
 const sections = [
 	{ href: '#requests', label: 'Website, API, and CDN' },
@@ -21,20 +21,48 @@ const sections = [
 	{ href: '#changes', label: 'Changes' },
 ];
 
+interface PolicySectionProps {
+	children: ReactNode;
+	id: string;
+	number: string;
+	title: string;
+}
+
+const PolicySection = ({ children, id, number, title }: PolicySectionProps) => (
+	<Box component="section" id={id} className={classes.section}>
+		<Text component="span" className={classes.sectionNumber}>
+			{number}
+		</Text>
+		<Box>
+			<Title order={2} className={classes.sectionTitle}>
+				{title}
+			</Title>
+			<Box className={classes.copy}>{children}</Box>
+		</Box>
+	</Box>
+);
+
 export default function PrivacyPage() {
 	return (
 		<>
-			<ContentHeader>
-				<Stack gap="sm" maw={760}>
-					<Text className={classes.eyebrow}>Fontsource</Text>
-					<Title order={1} className={classes.title}>
-						Privacy Policy
-					</Title>
-					<Text className={classes.lede}>
-						Fontsource is an open-source project for self-hostable fonts.
-					</Text>
-				</Stack>
-			</ContentHeader>
+			<ContentHeader
+				eyebrow="Fontsource / Privacy Policy"
+				title="Privacy Policy"
+				description={
+					<>
+						Fontsource is an{' '}
+						<Anchor
+							href="https://github.com/fontsource/fontsource"
+							target="_blank"
+							rel="noreferrer"
+							inherit
+						>
+							open-source
+						</Anchor>{' '}
+						project for self-hostable fonts.
+					</>
+				}
+			/>
 			<Container className={classes.container}>
 				<Box className={classes.layout}>
 					<Box component="aside" className={classes.sidebar}>
@@ -70,166 +98,107 @@ export default function PrivacyPage() {
 					</Box>
 
 					<Box component="article" className={classes.article}>
-						<Box component="section" id="requests" className={classes.section}>
-							<Text component="span" className={classes.sectionNumber}>
-								01
-							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Website, API, and CDN requests
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										Fontsource uses Cloudflare to deliver and protect its
-										website and API, and partners with jsDelivr to provide its
-										public CDN. These providers may process technical
-										information needed to provide those services. You can read
-										the{' '}
-										<Anchor
-											href="https://www.cloudflare.com/privacypolicy/"
-											target="_blank"
-											rel="noreferrer"
-										>
-											Cloudflare Privacy Policy
-										</Anchor>{' '}
-										and the{' '}
-										<Anchor
-											href="https://www.jsdelivr.com/terms/privacy-policy"
-											target="_blank"
-											rel="noreferrer"
-										>
-											jsDelivr Privacy Policy
-										</Anchor>
-										.
-									</Text>
-									<Text>
-										Using the Fontsource public CDN causes browsers to connect
-										to jsDelivr and the services it uses to deliver files.
-										Installing and self-hosting Fontsource packages avoids those
-										CDN requests.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
-
-						<Box component="section" id="search" className={classes.section}>
-							<Text component="span" className={classes.sectionNumber}>
-								02
-							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Search
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										Fontsource uses Algolia to provide catalogue search. Algolia
-										may process information needed to return search results. You
-										can read the{' '}
-										<Anchor
-											href="https://www.algolia.com/policies/privacy"
-											target="_blank"
-											rel="noreferrer"
-										>
-											Algolia Privacy Policy
-										</Anchor>
-										.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
-
-						<Box
-							component="section"
-							id="advertising"
-							className={classes.section}
+						<PolicySection
+							id="requests"
+							number="01"
+							title="Website, API, and CDN requests"
 						>
-							<Text component="span" className={classes.sectionNumber}>
-								03
+							<Text>
+								Fontsource uses Cloudflare to deliver and protect its website
+								and API, and partners with jsDelivr to provide its public CDN.
+								These providers may process technical information needed to
+								provide those services. You can read the{' '}
+								<Anchor
+									href="https://www.cloudflare.com/privacypolicy/"
+									target="_blank"
+									rel="noreferrer"
+								>
+									Cloudflare Privacy Policy
+								</Anchor>{' '}
+								and the{' '}
+								<Anchor
+									href="https://www.jsdelivr.com/terms/privacy-policy"
+									target="_blank"
+									rel="noreferrer"
+								>
+									jsDelivr Privacy Policy
+								</Anchor>
+								.
 							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Advertising
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										Some pages may display ads provided by Carbon Ads. Carbon
-										may process information needed to deliver and measure those
-										ads and may use browser storage. You can read the{' '}
-										<Anchor
-											href="https://www.carbonads.net/privacy"
-											target="_blank"
-											rel="noreferrer"
-										>
-											Carbon Ads Privacy Policy
-										</Anchor>
-										.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
+							<Text>
+								Using the Fontsource public CDN causes browsers to connect to
+								jsDelivr and the services it uses to deliver files. Installing
+								and self-hosting Fontsource packages avoids those CDN requests.
+							</Text>
+						</PolicySection>
 
-						<Box
-							component="section"
+						<PolicySection id="search" number="02" title="Search">
+							<Text>
+								Fontsource uses Algolia to provide catalogue search. Algolia may
+								process information needed to return search results. You can
+								read the{' '}
+								<Anchor
+									href="https://www.algolia.com/policies/privacy"
+									target="_blank"
+									rel="noreferrer"
+								>
+									Algolia Privacy Policy
+								</Anchor>
+								.
+							</Text>
+						</PolicySection>
+
+						<PolicySection id="advertising" number="03" title="Advertising">
+							<Text>
+								Some pages may display ads provided by Carbon Ads. Carbon may
+								process information needed to deliver and measure those ads and
+								may use browser storage. You can read the{' '}
+								<Anchor
+									href="https://www.carbonads.net/privacy"
+									target="_blank"
+									rel="noreferrer"
+								>
+									Carbon Ads Privacy Policy
+								</Anchor>
+								.
+							</Text>
+						</PolicySection>
+
+						<PolicySection
 							id="browser-storage"
-							className={classes.section}
+							number="04"
+							title="Information stored in your browser"
 						>
-							<Text component="span" className={classes.sectionNumber}>
-								04
+							<Text>
+								Fontsource may store information in your browser to support site
+								features. You can remove it by clearing the site's data in your
+								browser.
 							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Information stored in your browser
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										Fontsource may store information in your browser to support
-										site features. You can remove it by clearing the site's data
-										in your browser.
-									</Text>
-									<Text>
-										Some tools may also process information locally in your
-										browser.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
+							<Text>
+								Some tools may also process information locally in your browser.
+							</Text>
+						</PolicySection>
 
-						<Box component="section" id="contact" className={classes.section}>
-							<Text component="span" className={classes.sectionNumber}>
-								05
+						<PolicySection id="contact" number="05" title="Contact">
+							<Text>
+								For privacy questions, email{' '}
+								<Anchor href="mailto:hello@ayuhito.com">
+									hello@ayuhito.com
+								</Anchor>
+								.
 							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Contact
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										For privacy questions, email{' '}
-										<Anchor href="mailto:hello@ayuhito.com">
-											hello@ayuhito.com
-										</Anchor>
-										.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
+						</PolicySection>
 
-						<Box component="section" id="changes" className={classes.section}>
-							<Text component="span" className={classes.sectionNumber}>
-								06
+						<PolicySection
+							id="changes"
+							number="06"
+							title="Changes to this policy"
+						>
+							<Text>
+								We may update this policy as Fontsource's services change. The
+								date at the top shows when it was last updated.
 							</Text>
-							<Box>
-								<Title order={2} className={classes.sectionTitle}>
-									Changes to this policy
-								</Title>
-								<Box className={classes.copy}>
-									<Text>
-										We may update this policy as Fontsource's services change.
-										The date at the top shows when it was last updated.
-									</Text>
-								</Box>
-							</Box>
-						</Box>
+						</PolicySection>
 					</Box>
 				</Box>
 			</Container>

--- a/website/app/routes/privacy.tsx
+++ b/website/app/routes/privacy.tsx
@@ -1,0 +1,247 @@
+import { Anchor, Box, Container, Stack, Text, Title } from '@mantine/core';
+import type { MetaFunction } from 'react-router';
+import { ContentHeader } from '@/components/layout/ContentHeader';
+import classes from '@/styles/privacy.module.css';
+import { ogMeta } from '@/utils/meta';
+
+export const meta: MetaFunction = () => {
+	const title = 'Privacy | Fontsource';
+	const description =
+		'How Fontsource approaches privacy across its website and services.';
+
+	return ogMeta({ title, description });
+};
+
+const sections = [
+	{ href: '#requests', label: 'Website, API, and CDN' },
+	{ href: '#search', label: 'Search' },
+	{ href: '#advertising', label: 'Advertising' },
+	{ href: '#browser-storage', label: 'Browser storage' },
+	{ href: '#contact', label: 'Contact' },
+	{ href: '#changes', label: 'Changes' },
+];
+
+export default function PrivacyPage() {
+	return (
+		<>
+			<ContentHeader>
+				<Stack gap="sm" maw={760}>
+					<Text className={classes.eyebrow}>Fontsource privacy notice</Text>
+					<Title order={1} className={classes.title}>
+						Privacy
+					</Title>
+					<Text className={classes.lede}>
+						Fontsource is an{' '}
+						<Anchor
+							href="https://github.com/fontsource/fontsource"
+							target="_blank"
+							rel="noreferrer"
+							className={classes.ledeLink}
+						>
+							open-source project
+						</Anchor>{' '}
+						for self-hostable fonts.
+					</Text>
+				</Stack>
+			</ContentHeader>
+			<Container className={classes.container}>
+				<Box className={classes.layout}>
+					<Box component="aside" className={classes.sidebar}>
+						<Box className={classes.updated}>
+							<Text className={classes.label}>Last updated</Text>
+							<Text className={classes.date}>July 25, 2026</Text>
+						</Box>
+
+						<Box component="nav" aria-label="Privacy notice sections">
+							<Text className={classes.label}>On this page</Text>
+							<Box className={classes.navigation}>
+								{sections.map((section) => (
+									<Anchor
+										key={section.href}
+										href={section.href}
+										className={classes.navigationLink}
+									>
+										{section.label}
+									</Anchor>
+								))}
+							</Box>
+						</Box>
+
+						<Box className={classes.sidebarContact}>
+							<Text className={classes.label}>Privacy questions</Text>
+							<Anchor
+								href="mailto:hello@ayuhito.com"
+								className={classes.contactLink}
+							>
+								hello@ayuhito.com
+							</Anchor>
+						</Box>
+					</Box>
+
+					<Box component="article" className={classes.article}>
+						<Box component="section" id="requests" className={classes.section}>
+							<Text component="span" className={classes.sectionNumber}>
+								01
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Website, API, and CDN requests
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										Fontsource uses Cloudflare to deliver and protect its
+										website and API, and partners with jsDelivr to provide its
+										public CDN. These providers may process technical
+										information needed to provide those services. You can read
+										the{' '}
+										<Anchor
+											href="https://www.cloudflare.com/privacypolicy/"
+											target="_blank"
+											rel="noreferrer"
+										>
+											Cloudflare Privacy Policy
+										</Anchor>{' '}
+										and the{' '}
+										<Anchor
+											href="https://www.jsdelivr.com/terms/privacy-policy"
+											target="_blank"
+											rel="noreferrer"
+										>
+											jsDelivr Privacy Policy
+										</Anchor>
+										.
+									</Text>
+									<Text>
+										Using the Fontsource public CDN causes browsers to connect
+										to jsDelivr and the services it uses to deliver files.
+										Installing and self-hosting Fontsource packages avoids those
+										CDN requests.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+
+						<Box component="section" id="search" className={classes.section}>
+							<Text component="span" className={classes.sectionNumber}>
+								02
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Search
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										Fontsource uses Algolia to provide catalogue search. Algolia
+										may process information needed to return search results. You
+										can read the{' '}
+										<Anchor
+											href="https://www.algolia.com/policies/privacy"
+											target="_blank"
+											rel="noreferrer"
+										>
+											Algolia Privacy Policy
+										</Anchor>
+										.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+
+						<Box
+							component="section"
+							id="advertising"
+							className={classes.section}
+						>
+							<Text component="span" className={classes.sectionNumber}>
+								03
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Advertising
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										Some pages may display ads provided by Carbon Ads. Carbon
+										may process information needed to deliver and measure those
+										ads and may use browser storage. You can read the{' '}
+										<Anchor
+											href="https://www.carbonads.net/privacy"
+											target="_blank"
+											rel="noreferrer"
+										>
+											Carbon Ads Privacy Policy
+										</Anchor>
+										.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+
+						<Box
+							component="section"
+							id="browser-storage"
+							className={classes.section}
+						>
+							<Text component="span" className={classes.sectionNumber}>
+								04
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Information stored in your browser
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										Fontsource may store information in your browser to support
+										site features. You can remove it by clearing the site's data
+										in your browser.
+									</Text>
+									<Text>
+										Some tools may also process information locally in your
+										browser.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+
+						<Box component="section" id="contact" className={classes.section}>
+							<Text component="span" className={classes.sectionNumber}>
+								05
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Contact
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										For privacy questions, email{' '}
+										<Anchor href="mailto:hello@ayuhito.com">
+											hello@ayuhito.com
+										</Anchor>
+										.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+
+						<Box component="section" id="changes" className={classes.section}>
+							<Text component="span" className={classes.sectionNumber}>
+								06
+							</Text>
+							<Box>
+								<Title order={2} className={classes.sectionTitle}>
+									Changes to this notice
+								</Title>
+								<Box className={classes.copy}>
+									<Text>
+										We may update this notice as Fontsource's services change.
+										The date at the top shows when it was last updated.
+									</Text>
+								</Box>
+							</Box>
+						</Box>
+					</Box>
+				</Box>
+			</Container>
+		</>
+	);
+}

--- a/website/app/routes/privacy.tsx
+++ b/website/app/routes/privacy.tsx
@@ -5,7 +5,7 @@ import classes from '@/styles/privacy.module.css';
 import { ogMeta } from '@/utils/meta';
 
 export const meta: MetaFunction = () => {
-	const title = 'Privacy | Fontsource';
+	const title = 'Privacy Policy | Fontsource';
 	const description =
 		'How Fontsource approaches privacy across its website and services.';
 
@@ -26,21 +26,12 @@ export default function PrivacyPage() {
 		<>
 			<ContentHeader>
 				<Stack gap="sm" maw={760}>
-					<Text className={classes.eyebrow}>Fontsource privacy notice</Text>
+					<Text className={classes.eyebrow}>Fontsource</Text>
 					<Title order={1} className={classes.title}>
-						Privacy
+						Privacy Policy
 					</Title>
 					<Text className={classes.lede}>
-						Fontsource is an{' '}
-						<Anchor
-							href="https://github.com/fontsource/fontsource"
-							target="_blank"
-							rel="noreferrer"
-							className={classes.ledeLink}
-						>
-							open-source project
-						</Anchor>{' '}
-						for self-hostable fonts.
+						Fontsource is an open-source project for self-hostable fonts.
 					</Text>
 				</Stack>
 			</ContentHeader>
@@ -52,7 +43,7 @@ export default function PrivacyPage() {
 							<Text className={classes.date}>July 25, 2026</Text>
 						</Box>
 
-						<Box component="nav" aria-label="Privacy notice sections">
+						<Box component="nav" aria-label="Privacy policy sections">
 							<Text className={classes.label}>On this page</Text>
 							<Box className={classes.navigation}>
 								{sections.map((section) => (
@@ -229,11 +220,11 @@ export default function PrivacyPage() {
 							</Text>
 							<Box>
 								<Title order={2} className={classes.sectionTitle}>
-									Changes to this notice
+									Changes to this policy
 								</Title>
 								<Box className={classes.copy}>
 									<Text>
-										We may update this notice as Fontsource's services change.
+										We may update this policy as Fontsource's services change.
 										The date at the top shows when it was last updated.
 									</Text>
 								</Box>

--- a/website/app/routes/tools.tsx
+++ b/website/app/routes/tools.tsx
@@ -1,4 +1,4 @@
-import { Container, Title } from '@mantine/core';
+import { Container } from '@mantine/core';
 import { Outlet } from 'react-router';
 
 import { ContentHeader } from '@/components/layout/ContentHeader';
@@ -8,11 +8,11 @@ import classes from '../styles/global.module.css';
 export default function ToolsLayout() {
 	return (
 		<>
-			<ContentHeader>
-				<Title order={1} c="purple.0">
-					Developer Tools
-				</Title>
-			</ContentHeader>
+			<ContentHeader
+				eyebrow="Browser utilities"
+				title="Developer Tools"
+				description="Utilities for working with font files directly in your browser."
+			/>
 			<Container className={classes.container}>
 				<Outlet />
 			</Container>

--- a/website/app/styles/privacy.module.css
+++ b/website/app/styles/privacy.module.css
@@ -9,7 +9,7 @@
 	grid-template-columns: minmax(11.5rem, 14rem) minmax(0, 46rem);
 	gap: clamp(3.5rem, 8vw, 8rem);
 	max-width: 68rem;
-	margin-inline: auto;
+	margin-inline: 0;
 	align-items: start;
 }
 
@@ -160,7 +160,7 @@
 
 @media (--lt-md) {
 	.container {
-		padding-inline: 2.5rem;
+		padding-inline: 2rem;
 	}
 
 	.layout {

--- a/website/app/styles/privacy.module.css
+++ b/website/app/styles/privacy.module.css
@@ -1,0 +1,266 @@
+.eyebrow {
+	color: var(--mantine-color-purple-0);
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.11em;
+	text-transform: uppercase;
+}
+
+.title {
+	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
+	font-size: clamp(2.5rem, 5vw, 4rem);
+	font-weight: 650;
+	letter-spacing: -0.045em;
+	line-height: 1;
+}
+
+.lede {
+	max-width: 46rem;
+	color: light-dark(#4a566d, #bdc6d9);
+	font-size: clamp(1rem, 1.7vw, 1.125rem);
+	line-height: 1.65;
+	text-wrap: pretty;
+}
+
+.ledeLink {
+	color: inherit;
+	font-weight: 550;
+	text-decoration-color: light-dark(#8992a3, #7f89a0);
+	text-underline-offset: 0.25rem;
+}
+
+.ledeLink:hover {
+	color: var(--mantine-color-purple-0);
+}
+
+.ledeLink:focus-visible {
+	border-radius: 0.125rem;
+	outline: 2px solid var(--mantine-color-purple-0);
+	outline-offset: 0.1875rem;
+}
+
+.container {
+	max-width: 90rem;
+	margin-inline: auto;
+	padding: clamp(3.5rem, 7vw, 6rem) 4rem clamp(5rem, 8vw, 7rem);
+}
+
+.layout {
+	display: grid;
+	grid-template-columns: minmax(11.5rem, 14rem) minmax(0, 46rem);
+	gap: clamp(3.5rem, 8vw, 8rem);
+	max-width: 68rem;
+	margin-inline: auto;
+	align-items: start;
+}
+
+.sidebar {
+	position: sticky;
+	top: 6rem;
+	display: grid;
+	gap: 2.25rem;
+}
+
+.updated {
+	padding-left: 1rem;
+	border-left: 2px solid var(--mantine-color-purple-0);
+}
+
+.label {
+	margin-bottom: 0.5rem;
+	color: light-dark(#778197, #8f9ab1);
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+}
+
+.date {
+	color: light-dark(#18243b, #eef2ff);
+	font-size: 0.9375rem;
+	font-weight: 550;
+	font-variant-numeric: tabular-nums;
+}
+
+.navigation {
+	display: grid;
+	gap: 0.125rem;
+}
+
+.navigationLink {
+	width: fit-content;
+	padding-block: 0.375rem;
+	color: light-dark(#59657c, #a9b3ca);
+	font-size: 0.875rem;
+	line-height: 1.35;
+	text-decoration: none;
+	transition:
+		color 150ms ease,
+		transform 150ms ease;
+}
+
+.navigationLink:hover {
+	color: var(--mantine-color-purple-0);
+	transform: translateX(0.1875rem);
+}
+
+.navigationLink:focus-visible {
+	border-radius: 0.125rem;
+	outline: 2px solid var(--mantine-color-purple-0);
+	outline-offset: 0.1875rem;
+}
+
+.sidebarContact {
+	padding-top: 1.5rem;
+	border-top: 1px solid
+		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+}
+
+.contactLink {
+	color: light-dark(#27344c, #d4dcf0);
+	font-size: 0.875rem;
+	font-weight: 550;
+	text-underline-offset: 0.25rem;
+}
+
+.article {
+	min-width: 0;
+}
+
+.section {
+	display: grid;
+	grid-template-columns: 2.25rem minmax(0, 1fr);
+	gap: 1.5rem;
+	padding-bottom: 3.5rem;
+	margin-bottom: 3.5rem;
+	border-bottom: 1px solid
+		light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+	scroll-margin-top: 6rem;
+}
+
+.section:last-child {
+	padding-bottom: 0;
+	margin-bottom: 0;
+	border-bottom: 0;
+}
+
+.sectionNumber {
+	padding-top: 0.35rem;
+	color: var(--mantine-color-purple-0);
+	font-family: var(--mantine-font-family-monospace);
+	font-size: 0.75rem;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 0.08em;
+}
+
+.sectionTitle {
+	margin-bottom: 1.125rem;
+	color: light-dark(#101a2f, #f2f5ff);
+	font-size: clamp(1.4rem, 2.3vw, 1.75rem);
+	font-weight: 650;
+	letter-spacing: -0.025em;
+	line-height: 1.2;
+	text-wrap: balance;
+}
+
+.copy {
+	display: grid;
+	gap: 1rem;
+}
+
+.copy p {
+	max-width: 65ch;
+	color: light-dark(#354159, #d3dbec);
+	font-size: 1rem;
+	line-height: 1.75;
+	text-wrap: pretty;
+}
+
+.copy a {
+	color: light-dark(#473ef6, #9b97ff);
+	font-weight: 550;
+	text-decoration-color: light-dark(
+		rgba(98, 91, 248, 0.42),
+		rgba(155, 151, 255, 0.48)
+	);
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.25rem;
+}
+
+.copy a:hover {
+	text-decoration-color: currentColor;
+}
+
+.copy a:focus-visible,
+.contactLink:focus-visible {
+	border-radius: 0.125rem;
+	outline: 2px solid var(--mantine-color-purple-0);
+	outline-offset: 0.1875rem;
+}
+
+@media (--lt-md) {
+	.container {
+		padding-inline: 2.5rem;
+	}
+
+	.layout {
+		grid-template-columns: minmax(10.5rem, 12rem) minmax(0, 1fr);
+		gap: 3.5rem;
+	}
+}
+
+@media (--lt-sm) {
+	.container {
+		padding: 3rem 1.5rem 5rem;
+	}
+
+	.layout {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 3.5rem;
+	}
+
+	.sidebar {
+		position: static;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 1.75rem 2rem;
+		padding-bottom: 2.25rem;
+		border-bottom: 1px solid
+			light-dark(var(--mantine-color-border-0), var(--mantine-color-border-1));
+	}
+
+	.updated {
+		grid-column: 1 / -1;
+	}
+
+	.sidebarContact {
+		padding-top: 0;
+		border-top: 0;
+	}
+}
+
+@media (--lt-xs) {
+	.sidebar {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.updated {
+		grid-column: auto;
+	}
+
+	.navigation {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		column-gap: 1rem;
+	}
+
+	.section {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 0.75rem;
+		padding-bottom: 2.75rem;
+		margin-bottom: 2.75rem;
+	}
+
+	.sectionNumber {
+		padding-top: 0;
+	}
+}

--- a/website/app/styles/privacy.module.css
+++ b/website/app/styles/privacy.module.css
@@ -22,23 +22,6 @@
 	text-wrap: pretty;
 }
 
-.ledeLink {
-	color: inherit;
-	font-weight: 550;
-	text-decoration-color: light-dark(#8992a3, #7f89a0);
-	text-underline-offset: 0.25rem;
-}
-
-.ledeLink:hover {
-	color: var(--mantine-color-purple-0);
-}
-
-.ledeLink:focus-visible {
-	border-radius: 0.125rem;
-	outline: 2px solid var(--mantine-color-purple-0);
-	outline-offset: 0.1875rem;
-}
-
 .container {
 	max-width: 90rem;
 	margin-inline: auto;

--- a/website/app/styles/privacy.module.css
+++ b/website/app/styles/privacy.module.css
@@ -1,27 +1,3 @@
-.eyebrow {
-	color: var(--mantine-color-purple-0);
-	font-size: 0.75rem;
-	font-weight: 600;
-	letter-spacing: 0.11em;
-	text-transform: uppercase;
-}
-
-.title {
-	color: light-dark(var(--mantine-color-text-1), var(--mantine-color-text-0));
-	font-size: clamp(2.5rem, 5vw, 4rem);
-	font-weight: 650;
-	letter-spacing: -0.045em;
-	line-height: 1;
-}
-
-.lede {
-	max-width: 46rem;
-	color: light-dark(#4a566d, #bdc6d9);
-	font-size: clamp(1rem, 1.7vw, 1.125rem);
-	line-height: 1.65;
-	text-wrap: pretty;
-}
-
 .container {
 	max-width: 90rem;
 	margin-inline: auto;


### PR DESCRIPTION
Adds a concise `/privacy` policy covering Fontsource's current website, API, CDN, search, advertising, and browser-local storage behavior, with navigation and sitemap links. Removes the Medama script and README promotion so the website no longer loads an analytics service omitted from the policy. Validated with the website TypeScript check, production build, and Biome checks for the touched files.
