### PR TITLE
refactor(website): remove redundant header breadcrumbs

### DIFF
--- a/website/app/components/layout/ContentHeader.module.css
+++ b/website/app/components/layout/ContentHeader.module.css
@@ -38,17 +38,6 @@
 	max-width: 62rem;
 }
 
-.eyebrow {
-	color: var(--mantine-color-purple-0);
-	font-size: 0.8125rem;
-	font-weight: 600;
-	line-height: 1.4;
-}
-
-.eyebrow > * {
-	margin: 0;
-}
-
 .heading {
 	display: flex;
 	flex-wrap: wrap;

--- a/website/app/components/layout/ContentHeader.tsx
+++ b/website/app/components/layout/ContentHeader.tsx
@@ -8,7 +8,6 @@ type ContentHeaderProps = Omit<ContainerProps, 'children' | 'title'> & {
 	actions?: ReactNode;
 	children?: ReactNode;
 	description?: ReactNode;
-	eyebrow?: ReactNode;
 	title: ReactNode;
 };
 
@@ -16,7 +15,6 @@ export const ContentHeader = ({
 	actions,
 	children,
 	description,
-	eyebrow,
 	title,
 	...other
 }: ContentHeaderProps) => {
@@ -24,7 +22,6 @@ export const ContentHeader = ({
 		<Box component="header" className={classes.header}>
 			<Container className={classes.inner} {...other}>
 				<Box className={classes.content}>
-					{eyebrow && <Box className={classes.eyebrow}>{eyebrow}</Box>}
 					<Box className={classes.heading}>
 						<Title order={1} className={classes.title}>
 							{title}

--- a/website/app/components/preview/Tabs.tsx
+++ b/website/app/components/preview/Tabs.tsx
@@ -44,7 +44,7 @@ export const TabsWrapper = ({
 			}}
 		>
 			<ContentHeader
-				eyebrow="Font family"
+				eyebrow="Fontsource / Font Family"
 				title={metadata.family}
 				data-m:load={`view-tab=${tabsValue}`}
 				actions={

--- a/website/app/components/preview/Tabs.tsx
+++ b/website/app/components/preview/Tabs.tsx
@@ -44,7 +44,6 @@ export const TabsWrapper = ({
 			}}
 		>
 			<ContentHeader
-				eyebrow="Fontsource / Font Family"
 				title={metadata.family}
 				data-m:load={`view-tab=${tabsValue}`}
 				actions={

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -26,7 +26,6 @@ import {
 	useNavigation,
 } from 'react-router';
 
-import { Breadcrumbs } from '@/components/docs/Breadcrumbs';
 import { ContentHeader } from '@/components/layout/ContentHeader';
 import { Filters } from '@/components/search/Filters';
 import { InfiniteHits } from '@/components/search/Hits';
@@ -346,15 +345,6 @@ export function CatalogSearchPage() {
 				<Configure attributesToRetrieve={attributesToRetrieve} />
 				{discovery && (
 					<ContentHeader
-						eyebrow={
-							<Breadcrumbs
-								items={[
-									{ name: 'Fontsource', url: '/' },
-									{ name: 'Browse Fonts', url: '/browse' },
-									{ name: discovery.label },
-								]}
-							/>
-						}
 						title={discovery.heading}
 						description={discovery.intro}
 					/>

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -349,7 +349,8 @@ export function CatalogSearchPage() {
 						eyebrow={
 							<Breadcrumbs
 								items={[
-									{ name: 'Browse', url: '/browse' },
+									{ name: 'Fontsource', url: '/' },
+									{ name: 'Browse Fonts', url: '/browse' },
 									{ name: discovery.label },
 								]}
 							/>

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -96,7 +96,6 @@ export default function Browse() {
 	return (
 		<>
 			<ContentHeader
-				eyebrow="Fontsource / Browse Fonts"
 				title="Browse Fonts"
 				description="Choose a style, language, or variable-font format. Every page includes the full catalog filters and preview controls."
 			/>

--- a/website/app/routes/browse.tsx
+++ b/website/app/routes/browse.tsx
@@ -96,7 +96,7 @@ export default function Browse() {
 	return (
 		<>
 			<ContentHeader
-				eyebrow="Font discovery"
+				eyebrow="Fontsource / Browse Fonts"
 				title="Browse Fonts"
 				description="Choose a style, language, or variable-font format. Every page includes the full catalog filters and preview controls."
 			/>

--- a/website/app/routes/privacy.tsx
+++ b/website/app/routes/privacy.tsx
@@ -46,7 +46,6 @@ export default function PrivacyPage() {
 	return (
 		<>
 			<ContentHeader
-				eyebrow="Fontsource / Privacy Policy"
 				title="Privacy Policy"
 				description={
 					<>

--- a/website/app/routes/tools.tsx
+++ b/website/app/routes/tools.tsx
@@ -9,7 +9,6 @@ export default function ToolsLayout() {
 	return (
 		<>
 			<ContentHeader
-				eyebrow="Fontsource / Developer Tools"
 				title="Developer Tools"
 				description="Utilities for working with font files directly in your browser."
 			/>

--- a/website/app/routes/tools.tsx
+++ b/website/app/routes/tools.tsx
@@ -9,7 +9,7 @@ export default function ToolsLayout() {
 	return (
 		<>
 			<ContentHeader
-				eyebrow="Browser utilities"
+				eyebrow="Fontsource / Developer Tools"
 				title="Developer Tools"
 				description="Utilities for working with font files directly in your browser."
 			/>


### PR DESCRIPTION
## Summary

- Remove redundant page-header breadcrumbs that repeat Fontsource and the title directly below.
- Delete the unused `ContentHeader` eyebrow API and styling while preserving documentation navigation breadcrumbs.

## Testing

- Targeted Biome checks
- Responsive browser checks at desktop and mobile widths
- GitHub Actions CI
