### PR TITLE
feat(registry): add font-files source adapter

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -52,6 +52,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 ## Structure
 
 - `scripts/generate.ts` coordinates one complete registry build and validation.
+- `scripts/font-files.ts` implements opt-in Git-backed Fontsource ingestion. It
+  is not part of scheduled generation yet.
 - `scripts/google.ts` owns `data/families/google/` and writes family metadata,
   source inspection, documents, licenses, and normalized axis metadata.
 - `scripts/nam.ts` writes Unicode subset and slicing definitions.
@@ -76,7 +78,48 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
   `registry` provenance requires the source to be promoted to R2 first.
 - Package policy is reviewed registry state, not derived from legacy catalogs.
 - Package variants are explicit relations, not weight/style cross-products.
-- Core owns generic font processing; these scripts own Google and NAM ingestion.
+- Core owns generic font processing; these scripts own provider ingestion and
+  NAM data.
+
+## Font-files sources
+
+The opt-in `fontsource/font-files` adapter accepts reviewed source families:
+
+~~~text
+sources/<id>/
+  metadata.json
+  license.txt
+  files/*.ttf
+  files/*.otf
+  description.en-US.md
+  article.en-US.md
+~~~
+
+The two Markdown files are optional. `metadata.json` contains the portable
+family fields and declares every source file:
+
+~~~json
+{
+	"id": "example",
+	"family": "Example",
+	"category": "sans-serif",
+	"license": {
+		"id": "OFL-1.1",
+		"url": "https://openfontlicense.org/open-font-license-official-text/"
+	},
+	"declaredSubsets": ["latin"],
+	"sourceFiles": [
+		{
+			"path": "files/Example-Regular.ttf",
+			"variant": { "weight": 400, "style": "normal" }
+		}
+	]
+}
+~~~
+
+The adapter derives hashes, sizes, inspection, modification dates, and Git
+provenance. The source repository stores the raw binaries; this repository
+commits only generated text records.
 
 ## Development
 

--- a/registry/scripts/font-files.ts
+++ b/registry/scripts/font-files.ts
@@ -1,0 +1,159 @@
+import { deepStrictEqual } from 'node:assert/strict';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createFontContext, inspectFont } from '@fontsource-utils/core';
+import type { GitSnapshot } from './git.ts';
+import { normalizeInspection } from './inspection.ts';
+import {
+	type FamilyMetadata,
+	familyInspectionSchema,
+	familyMetadataSchema,
+	type SourceFamily,
+	sourceFamilySchema,
+} from './schema.ts';
+import { compareStrings, normalizeText, sha256, writeJson } from './shared.ts';
+
+const FONT_FILES_REPOSITORY = 'fontsource/font-files';
+
+const DOCUMENTS = ['article.en-US.md', 'description.en-US.md'] as const;
+
+type FontFilesFamily = {
+	directory: string;
+	files: ReadonlySet<string>;
+	metadata: SourceFamily;
+};
+
+const readFamilies = (snapshot: GitSnapshot): FontFilesFamily[] => {
+	const filesByDirectory = new Map<string, Set<string>>();
+	for (const path of snapshot.paths) {
+		const match = path.match(/^sources\/([^/]+)\//);
+		if (!match?.[1]) continue;
+		const directory = `sources/${match[1]}`;
+		const files = filesByDirectory.get(directory) ?? new Set<string>();
+		files.add(path);
+		filesByDirectory.set(directory, files);
+	}
+
+	const families: FontFilesFamily[] = [];
+	for (const [directory, files] of filesByDirectory) {
+		const metadataPath = `${directory}/metadata.json`;
+		if (!files.has(metadataPath)) {
+			throw new Error(`${directory} is missing metadata.json`);
+		}
+		const metadata = sourceFamilySchema.parse(
+			JSON.parse(snapshot.read(metadataPath).toString('utf8')),
+		);
+		const id = directory.slice('sources/'.length);
+		if (metadata.id !== id) {
+			throw new Error(`${directory} metadata ID must be ${id}`);
+		}
+		families.push({ directory, files, metadata });
+	}
+	return families.toSorted((left, right) =>
+		compareStrings(left.metadata.id, right.metadata.id),
+	);
+};
+
+const writeFamily = async (
+	snapshot: GitSnapshot,
+	source: FontFilesFamily,
+	root: string,
+	ctx: ReturnType<typeof createFontContext>,
+): Promise<void> => {
+	const { directory, files, metadata: sourceMetadata } = source;
+	const licensePath = `${directory}/license.txt`;
+	if (!files.has(licensePath)) {
+		throw new Error(`${directory} is missing license.txt`);
+	}
+	const declaredFiles = sourceMetadata.sourceFiles.map((file) => ({
+		...file,
+		path: `${directory}/${file.path}`,
+	}));
+	const actualPaths = Array.from(files)
+		.filter((path) => path.startsWith(`${directory}/files/`))
+		.toSorted(compareStrings);
+	for (const path of actualPaths) {
+		if (!/\.(?:otf|ttf)$/i.test(path)) {
+			throw new Error(`${path} must be a TTF or OTF source`);
+		}
+	}
+	deepStrictEqual(
+		declaredFiles.map((file) => file.path).toSorted(compareStrings),
+		actualPaths,
+		`${sourceMetadata.id} metadata must declare every source file`,
+	);
+
+	const sourceFiles: FamilyMetadata['sourceFiles'] = [];
+	const inspectionFiles: Array<ReturnType<typeof normalizeInspection>> = [];
+	for (const sourceFile of declaredFiles.toSorted((left, right) =>
+		compareStrings(left.path, right.path),
+	)) {
+		const contents = snapshot.read(sourceFile.path);
+		sourceFiles.push({
+			path: sourceFile.path,
+			sha256: sha256(contents),
+			size: contents.byteLength,
+			...(sourceFile.variant ? { variant: sourceFile.variant } : {}),
+		});
+		inspectionFiles.push(
+			normalizeInspection(
+				sourceFile.path,
+				await inspectFont(ctx, new Uint8Array(contents)),
+			),
+		);
+	}
+	const lastChanged = snapshot.lastChanged(directory);
+	const metadata = familyMetadataSchema.parse({
+		...sourceMetadata,
+		provider: 'fontsource',
+		status: 'active',
+		provenance: {
+			type: 'github',
+			repository: FONT_FILES_REPOSITORY,
+			revision: lastChanged.revision,
+			directory,
+		},
+		sourceModified: lastChanged.date,
+		declaredSubsets: Array.from(
+			new Set(sourceMetadata.declaredSubsets),
+		).toSorted(compareStrings),
+		sourceFiles,
+	});
+	const inspection = familyInspectionSchema.parse({ files: inspectionFiles });
+	const output = join(root, 'families', 'fontsource', metadata.id);
+	await mkdir(output, { recursive: true });
+	await writeJson(join(output, 'metadata.json'), metadata);
+	await writeJson(join(output, 'inspection.json'), inspection);
+
+	await writeFile(
+		join(output, 'license.txt'),
+		normalizeText(snapshot.read(licensePath).toString('utf8')),
+	);
+	for (const document of DOCUMENTS) {
+		const path = `${directory}/${document}`;
+		if (files.has(path)) {
+			await writeFile(
+				join(output, document),
+				normalizeText(snapshot.read(path).toString('utf8')),
+			);
+		} else {
+			await rm(join(output, document), { force: true });
+		}
+	}
+};
+
+export const generateFontFiles = async (
+	snapshot: GitSnapshot,
+	root: string,
+): Promise<string[]> => {
+	const families = readFamilies(snapshot);
+	const ctx = createFontContext();
+	try {
+		for (const family of families) {
+			await writeFamily(snapshot, family, root, ctx);
+		}
+	} finally {
+		ctx.destroy();
+	}
+	return families.map((family) => family.metadata.id);
+};

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -11,9 +11,14 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { describe, expect, it, onTestFinished } from 'vitest';
+import { generateFontFiles } from './font-files.ts';
 import { generateRegistry } from './generate.ts';
 import { assertGitPathClean, openGitSnapshot } from './git.ts';
-import { familyMetadataSchema, registryIndexSchema } from './schema.ts';
+import {
+	familyMetadataSchema,
+	registryIndexSchema,
+	sourceFamilySchema,
+} from './schema.ts';
 import { canonicalJson, compareStrings, readJson, sha256 } from './shared.ts';
 import { validateRegistry } from './validator.ts';
 
@@ -227,6 +232,54 @@ const createNamRepository = async (): Promise<{
 	};
 };
 
+const createFontFilesRepository = async (): Promise<{
+	repository: string;
+	revision: string;
+}> => {
+	const repository = await createGitRepository('font-files');
+	await copyFont(
+		repository,
+		'abel-latin-400-normal.ttf',
+		'sources/example/files/Example-Regular.ttf',
+	);
+	await writeFixture(
+		repository,
+		'sources/example/metadata.json',
+		canonicalJson({
+			id: 'example',
+			family: 'Example',
+			category: 'sans-serif',
+			designer: 'Registry Tests',
+			dateAdded: '2026-01-02',
+			license: {
+				id: 'OFL-1.1',
+				url: 'https://openfontlicense.org/open-font-license-official-text/',
+			},
+			declaredSubsets: ['latin'],
+			sourceFiles: [
+				{
+					path: 'files/Example-Regular.ttf',
+					variant: { weight: 400, style: 'normal' },
+				},
+			],
+		}),
+	);
+	await writeFixture(
+		repository,
+		'sources/example/license.txt',
+		'Example license\n',
+	);
+	await writeFixture(
+		repository,
+		'sources/example/description.en-US.md',
+		'# Example\n',
+	);
+	return {
+		repository,
+		revision: commitAll(repository, 'initial Fontsource snapshot'),
+	};
+};
+
 const addRetainedRegistryState = async (root: string): Promise<void> => {
 	await writeFixture(
 		root,
@@ -324,6 +377,64 @@ describe('registry ingestion', () => {
 		await expect(validateRegistry(registry)).rejects.toThrow(
 			'Duplicate registry family ID abel',
 		);
+	});
+
+	it('ingests a Fontsource source family', async () => {
+		const source = await createFontFilesRepository();
+		const registry = await temporaryDirectory('font-files-registry');
+		const snapshot = openGitSnapshot(source.repository, source.revision);
+
+		await expect(generateFontFiles(snapshot, registry)).resolves.toEqual([
+			'example',
+		]);
+		expect(
+			await readJson(
+				join(registry, 'families/fontsource/example/metadata.json'),
+			),
+		).toMatchObject({
+			provider: 'fontsource',
+			status: 'active',
+			provenance: {
+				type: 'github',
+				repository: 'fontsource/font-files',
+				revision: source.revision,
+				directory: 'sources/example',
+			},
+			sourceFiles: [
+				{
+					path: 'sources/example/files/Example-Regular.ttf',
+					variant: { weight: 400, style: 'normal' },
+				},
+			],
+		});
+		expect(
+			await readJson(
+				join(registry, 'families/fontsource/example/inspection.json'),
+			),
+		).toMatchObject({
+			files: [
+				{ path: 'sources/example/files/Example-Regular.ttf', weight: 400 },
+			],
+		});
+		expect(
+			await readFile(
+				join(registry, 'families/fontsource/example/description.en-US.md'),
+				'utf8',
+			),
+		).toBe('# Example\n');
+	});
+
+	it('rejects packaged webfonts as sources', () => {
+		expect(
+			sourceFamilySchema.safeParse({
+				id: 'example',
+				family: 'Example',
+				category: 'sans-serif',
+				license: { id: 'OFL-1.1', url: 'https://example.com/license' },
+				declaredSubsets: ['latin'],
+				sourceFiles: [{ path: 'files/Example.woff2' }],
+			}).success,
+		).toBe(false);
 	});
 
 	it('regenerates deterministically, preserves policy, and retains missing families', async () => {

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -109,6 +109,28 @@ export const familyMetadataSchema = z.strictObject({
 	sourceFiles: z.array(sourceFileSchema).min(1),
 });
 
+export const sourceFamilySchema = familyMetadataSchema
+	.omit({
+		provider: true,
+		status: true,
+		provenance: true,
+		sourceModified: true,
+		sourceFiles: true,
+	})
+	.extend({
+		sourceFiles: z
+			.array(
+				z.strictObject({
+					path: sourcePathSchema.refine(
+						(path) => /^files\/.+\.(?:otf|ttf)$/i.test(path),
+						{ message: 'must be a TTF or OTF under files/' },
+					),
+					variant: staticVariantSchema.optional(),
+				}),
+			)
+			.min(1),
+	});
+
 const axisSchema = z.strictObject({
 	tag: z.string().length(4),
 	min: finiteNumberSchema,
@@ -202,4 +224,5 @@ export const axisRegistrySchema = z.record(
 export type FamilyMetadata = z.infer<typeof familyMetadataSchema>;
 export type FamilyInspection = z.infer<typeof familyInspectionSchema>;
 export type FamilyPolicy = z.infer<typeof familyPolicySchema>;
+export type SourceFamily = z.infer<typeof sourceFamilySchema>;
 export type SubsetDefinition = z.infer<typeof subsetDefinitionSchema>;


### PR DESCRIPTION
Follows #1202

## Overview

Adds an opt-in source-family contract and a `fontsource/font-files` adapter that validates raw TTF/OTF declarations, inspects them, and writes Git-pinned Fontsource registry records. It remains outside scheduled generation until the first source backfill is ready, so this adds no clone, index, or generated corpus churn.