### PR TITLE
perf(website): improve homepage font discovery

### DIFF
--- a/website/app/components/Dropdown.tsx
+++ b/website/app/components/Dropdown.tsx
@@ -87,7 +87,7 @@ const DropdownBase = ({
 					component="button"
 					classNames={{ input: classes.input }}
 					pointer
-					rightSection={<IconCaret />}
+					rightSection={<IconCaret aria-hidden="true" />}
 					onClick={() => {
 						combobox.toggleDropdown();
 					}}

--- a/website/app/components/Dropdown.tsx
+++ b/website/app/components/Dropdown.tsx
@@ -103,6 +103,7 @@ const DropdownBase = ({
 			<Combobox.Dropdown>
 				{search && (
 					<Combobox.Search
+						aria-label="Search languages"
 						value={searchQuery}
 						onChange={(event) => {
 							handleSearchQuery(event.currentTarget.value);

--- a/website/app/components/FontCard.tsx
+++ b/website/app/components/FontCard.tsx
@@ -1,4 +1,5 @@
 import { Box, Group, Text } from '@mantine/core';
+import { useIntersection } from '@mantine/hooks';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 
@@ -16,6 +17,7 @@ interface FontCardProps {
 	preview?: string;
 	previewHeight?: number;
 	size: number;
+	eagerStylesheet?: boolean;
 }
 
 const FontCard = ({
@@ -24,13 +26,25 @@ const FontCard = ({
 	preview,
 	previewHeight,
 	size,
+	eagerStylesheet = false,
 }: FontCardProps) => {
 	const stylesheetHref = `https://cdn.jsdelivr.net/fontsource/css/${font.id}@latest/index.css`;
+	const { ref, entry } = useIntersection<HTMLDivElement>({
+		rootMargin: '150% 0px',
+	});
+	const [shouldLoadStylesheet, setShouldLoadStylesheet] =
+		useState(eagerStylesheet);
 	const [isStylesheetLoaded, setStylesheetLoaded] = useState(false);
 	const isFontReady = useIsFontReady(font.family, isStylesheetLoaded);
 
 	useEffect(() => {
-		if (isStylesheetLoaded) return;
+		if (eagerStylesheet || entry?.isIntersecting) {
+			setShouldLoadStylesheet(true);
+		}
+	}, [eagerStylesheet, entry?.isIntersecting]);
+
+	useEffect(() => {
+		if (!shouldLoadStylesheet || isStylesheetLoaded) return;
 
 		for (const sheet of document.styleSheets) {
 			if (sheet.href === stylesheetHref) {
@@ -38,7 +52,7 @@ const FontCard = ({
 				return;
 			}
 		}
-	}, [isStylesheetLoaded, stylesheetHref]);
+	}, [isStylesheetLoaded, shouldLoadStylesheet, stylesheetHref]);
 
 	const isNotLatin =
 		font.defSubset !== 'latin' ||
@@ -54,13 +68,16 @@ const FontCard = ({
 		<Box
 			className={classes.wrapper}
 			mih={{ base: '150px', sm: layout === 'grid' ? '332px' : '150px' }}
+			ref={ref}
 		>
-			<link
-				rel="stylesheet"
-				href={stylesheetHref}
-				onLoad={() => setStylesheetLoaded(true)}
-				onError={() => setStylesheetLoaded(true)}
-			/>
+			{shouldLoadStylesheet && (
+				<link
+					rel="stylesheet"
+					href={stylesheetHref}
+					onLoad={() => setStylesheetLoaded(true)}
+					onError={() => setStylesheetLoaded(true)}
+				/>
+			)}
 			<Link className={classes.link} prefetch="intent" to={`/fonts/${font.id}`}>
 				<div className={classes.preview}>
 					<Skeleton name="search-hit-preview" loading={!isFontReady}>

--- a/website/app/components/search/Filters.tsx
+++ b/website/app/components/search/Filters.tsx
@@ -1,12 +1,5 @@
 import { useValue } from '@legendapp/state/react';
-import {
-	Box,
-	Button,
-	Checkbox,
-	Group,
-	SimpleGrid,
-	UnstyledButton,
-} from '@mantine/core';
+import { Box, Button, Checkbox, Group, SimpleGrid } from '@mantine/core';
 import { useCallback } from 'react';
 import {
 	Configure,
@@ -101,26 +94,18 @@ const Filters = ({ state$ }: FilterProps) => {
 					<LanguagesDropdown state$={state$} />
 				</Group>
 				<Group justify="center" wrap="nowrap">
-					<UnstyledButton
-						w={200}
-						onClick={() => {
+					<Checkbox
+						checked={variableValue.isRefined}
+						color="purple.0"
+						disabled={!canRefine}
+						label="Show only variable fonts"
+						onChange={() => {
 							variableRefine(variableValue);
 						}}
-						disabled={!canRefine}
-					>
-						<Checkbox
-							color="purple.0"
-							label="Show only variable fonts"
-							checked={variableValue.isRefined}
-							disabled={!canRefine}
-							readOnly
-							style={{
-								pointerEvents: 'none',
-							}}
-						/>
-					</UnstyledButton>
+						w={200}
+					/>
 					<Button
-						leftSection={<IconTrash />}
+						leftSection={<IconTrash aria-hidden="true" />}
 						variant="subtle"
 						className={classes.button}
 						onClick={() => {

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -41,6 +41,7 @@ interface AlgoliaMetadata extends BaseHit {
 interface HitComponentProps {
 	state$: SearchState;
 	hit: AlgoliaMetadata;
+	eagerStylesheet?: boolean;
 }
 
 interface InfiniteHitsProps {
@@ -48,6 +49,7 @@ interface InfiniteHitsProps {
 }
 
 const hitsPerVirtualRow = 12;
+const eagerStylesheetCount = 4;
 const rowGap = 16;
 const loadingPlaceholderKeys = [0, 1, 2, 3];
 type Display = 'grid' | 'list';
@@ -63,48 +65,69 @@ const getRowClassName = (display: Display) =>
 		? `${classes['result-row']} ${classes['list-mode']}`
 		: classes['result-row'];
 
-const HitComponent = observer(({ hit, state$ }: HitComponentProps) => {
-	const display = useValue(state$.display);
-	const size = useValue(state$.size);
+const getNoResultsMessage = (
+	collectionMessage: string | undefined,
+	hasQuery: boolean,
+	hasActiveFilters: boolean,
+) => {
+	if (collectionMessage) return collectionMessage;
+	if (hasQuery && hasActiveFilters) {
+		return 'No font families match your search and filters. Try a different search or remove a filter.';
+	}
+	if (hasQuery) {
+		return 'No font families match your search. Try a different search.';
+	}
+	if (hasActiveFilters) {
+		return 'No font families match these filters. Try removing a filter.';
+	}
+	return 'No font families are available right now.';
+};
 
-	// Change preview text if hit.defSubset is not latin or if it's an ico
-	const isNotLatin =
-		hit.defSubset !== 'latin' ||
-		hit.category === 'icons' ||
-		hit.category === 'other';
+const HitComponent = observer(
+	({ eagerStylesheet, hit, state$ }: HitComponentProps) => {
+		const display = useValue(state$.display);
+		const size = useValue(state$.size);
 
-	// We want a unique preview text for each font if it's not latin
-	const currentPreview = useValue(() => {
-		const customValue = state$.preview.customValue.get();
+		// Change preview text if hit.defSubset is not latin or if it's an ico
+		const isNotLatin =
+			hit.defSubset !== 'latin' ||
+			hit.category === 'icons' ||
+			hit.category === 'other';
 
-		if (customValue !== '') {
-			return customValue;
-		}
+		// We want a unique preview text for each font if it's not latin
+		const currentPreview = useValue(() => {
+			const customValue = state$.preview.customValue.get();
 
-		// Use language-specific preview for non-latin fonts when no custom input
-		if (isNotLatin) {
-			return getPreviewText(hit.defSubset, hit.objectID);
-		}
+			if (customValue !== '') {
+				return customValue;
+			}
 
-		return state$.preview.presetValue.get();
-	});
+			// Use language-specific preview for non-latin fonts when no custom input
+			if (isNotLatin) {
+				return getPreviewText(hit.defSubset, hit.objectID);
+			}
 
-	return (
-		<FontCard
-			font={{
-				id: hit.objectID,
-				family: hit.family,
-				defSubset: hit.defSubset,
-				category: hit.category,
-				variable: hit.variable,
-			}}
-			layout={display}
-			preview={currentPreview}
-			previewHeight={getGridPreviewHeight(size)}
-			size={size}
-		/>
-	);
-});
+			return state$.preview.presetValue.get();
+		});
+
+		return (
+			<FontCard
+				font={{
+					id: hit.objectID,
+					family: hit.family,
+					defSubset: hit.defSubset,
+					category: hit.category,
+					variable: hit.variable,
+				}}
+				layout={display}
+				preview={currentPreview}
+				previewHeight={getGridPreviewHeight(size)}
+				size={size}
+				eagerStylesheet={eagerStylesheet}
+			/>
+		);
+	},
+);
 
 const HitPlaceholder = ({
 	display,
@@ -152,8 +175,8 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 	const collection = collections.find((item) => item.id === collectionId);
 	const collectionMessage = collection
 		? collection.fontIds.length === 0
-			? `${collection.name} does not have any fonts yet.`
-			: `No fonts in ${collection.name} match these filters.`
+			? `${collection.name} is empty. Choose All fonts to find fonts to add.`
+			: `No font families in ${collection.name} match these filters. Try removing a filter.`
 		: undefined;
 	const display = state$.display.get();
 	const loadingStatusId = useId();
@@ -174,7 +197,7 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 						: 1;
 
 	// Infinite Scrolling
-	const { error, indexUiState, refresh, results, status } = useInstantSearch({
+	const { indexUiState, refresh, results, status } = useInstantSearch({
 		catchError: true,
 	});
 	const { items, isLastPage, showMore } = useInfiniteHits<AlgoliaMetadata>();
@@ -191,6 +214,13 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 		sortBy: indexUiState.sortBy ?? '',
 		toggle: indexUiState.toggle ?? {},
 	});
+	const hasQuery = Boolean(indexUiState.query?.trim());
+	const hasActiveFilters =
+		Object.values(indexUiState.menu ?? {}).some(Boolean) ||
+		Object.values(indexUiState.refinementList ?? {}).some(
+			(values) => values.length > 0,
+		) ||
+		Object.values(indexUiState.toggle ?? {}).some(Boolean);
 	const previousSearchKeyRef = useRef(searchKey);
 	// Twelve fills complete rows at every supported grid width: 1, 2, 3, and 4 columns.
 	const rows = useMemo(
@@ -310,14 +340,13 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 		return (
 			<Box px={4} py={24} role="alert">
 				<Stack align="flex-start" gap="xs">
-					<Text fw={600}>Fonts could not load.</Text>
+					<Text fw={600}>Font results could not load.</Text>
 					<Text c="dimmed">
-						{error?.message
-							? 'The font search service did not respond. Try again.'
-							: 'Check your connection, then try again.'}
+						We could not reach the font search service. Check your connection,
+						then try again.
 					</Text>
 					<Button onClick={() => refresh()} size="sm">
-						Try again
+						Reload results
 					</Button>
 				</Stack>
 			</Box>
@@ -329,10 +358,8 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 	if (!results.__isArtificial && results.nbHits === 0) {
 		return (
 			<Box>
-				<Text role="status">
-					{collectionMessage
-						? collectionMessage
-						: `No results found for "${indexUiState.query ?? ''}"`}
+				<Text aria-atomic="true" role="status">
+					{getNoResultsMessage(collectionMessage, hasQuery, hasActiveFilters)}
 				</Text>
 			</Box>
 		);
@@ -370,11 +397,15 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 								>
 									{row ? (
 										<div className={getRowClassName(display)}>
-											{row.map((hit) => (
+											{row.map((hit, hitIndex) => (
 												<HitComponent
 													key={hit.objectID}
 													state$={state$}
 													hit={hit}
+													eagerStylesheet={
+														virtualRow.index === 0 &&
+														hitIndex < eagerStylesheetCount
+													}
 												/>
 											))}
 										</div>
@@ -393,8 +424,13 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 						cols={display === 'grid' ? { base: 1, sm: 2, md: 3, xl: 4 } : 1}
 						spacing={rowGap}
 					>
-						{items.map((hit) => (
-							<HitComponent key={hit.objectID} state$={state$} hit={hit} />
+						{items.map((hit, index) => (
+							<HitComponent
+								key={hit.objectID}
+								state$={state$}
+								hit={hit}
+								eagerStylesheet={index < eagerStylesheetCount}
+							/>
 						))}
 					</SimpleGrid>
 				)}

--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -1,5 +1,13 @@
 import { observer, useValue } from '@legendapp/state/react';
-import { Box, Group, SimpleGrid, Text, VisuallyHidden } from '@mantine/core';
+import {
+	Box,
+	Button,
+	Group,
+	SimpleGrid,
+	Stack,
+	Text,
+	VisuallyHidden,
+} from '@mantine/core';
 import { useMounted, useViewportSize } from '@mantine/hooks';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import type { BaseHit } from 'instantsearch.js';
@@ -166,7 +174,9 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 						: 1;
 
 	// Infinite Scrolling
-	const { results, indexUiState, status } = useInstantSearch();
+	const { error, indexUiState, refresh, results, status } = useInstantSearch({
+		catchError: true,
+	});
 	const { items, isLastPage, showMore } = useInfiniteHits<AlgoliaMetadata>();
 	const isSearchLoading = status === 'loading' || status === 'stalled';
 	const size = state$.size.get();
@@ -295,6 +305,24 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 
 		return unsubscribe;
 	}, [state$.preview, state$.language, items]);
+
+	if (status === 'error') {
+		return (
+			<Box px={4} py={24} role="alert">
+				<Stack align="flex-start" gap="xs">
+					<Text fw={600}>Fonts could not load.</Text>
+					<Text c="dimmed">
+						{error?.message
+							? 'The font search service did not respond. Try again.'
+							: 'Check your connection, then try again.'}
+					</Text>
+					<Button onClick={() => refresh()} size="sm">
+						Try again
+					</Button>
+				</Stack>
+			</Box>
+		);
+	}
 
 	// The `__isArtificial` flag makes sure to not display the No Results message
 	// when no hits have been returned yet.

--- a/website/app/components/search/PreviewTextInput.tsx
+++ b/website/app/components/search/PreviewTextInput.tsx
@@ -69,8 +69,9 @@ const PreviewSelector = observer(({ state$ }: PreviewProps) => {
 			<Menu shadow="md">
 				<Menu.Target>
 					<Button
+						aria-label={`Preview text: ${label}`}
 						className={classes.button}
-						rightSection={<IconCaret />}
+						rightSection={<IconCaret aria-hidden="true" />}
 						styles={{
 							inner: {
 								justifyContent: 'space-between',
@@ -114,11 +115,12 @@ const PreviewSelector = observer(({ state$ }: PreviewProps) => {
 				</Menu.Dropdown>
 			</Menu>
 			<TextInput
+				aria-label="Custom preview text"
 				value={customValue}
 				onChange={(e) => {
 					state$.preview.customValue.set(e.currentTarget.value);
 				}}
-				placeholder="Type something"
+				placeholder="Enter preview text"
 				variant="unstyled"
 				classNames={{ root: classes.inputRoot, input: classes.input }}
 			/>

--- a/website/app/components/search/SearchTextInput.tsx
+++ b/website/app/components/search/SearchTextInput.tsx
@@ -47,7 +47,11 @@ const SearchBar = () => {
 			maxLength={512}
 			ref={ref}
 			leftSection={
-				<IconSearch data-active={focused} className={classes.left} />
+				<IconSearch
+					aria-hidden="true"
+					className={classes.left}
+					data-active={focused}
+				/>
 			}
 			leftSectionWidth={60}
 			rightSection={<SearchByAlgolia height={14} />}

--- a/website/app/components/search/SizeSlider.tsx
+++ b/website/app/components/search/SizeSlider.tsx
@@ -21,7 +21,7 @@ const SizeSlider = observer(({ state$ }: SizeSliderProps) => {
 					classNames={{ root: classes.slider, bar: classes.bar }}
 					color="purple.0"
 					size="sm"
-					thumbLabel="Change font size"
+					thumbLabel="Preview font size"
 					label={null}
 					value={size}
 					onChange={state$.size.set}

--- a/website/app/components/search/Sort.tsx
+++ b/website/app/components/search/Sort.tsx
@@ -26,6 +26,8 @@ const sortMap: Record<string, string> = {
 	prod_RANDOM: 'Random',
 };
 
+const numberFormatter = new Intl.NumberFormat('en');
+
 const getSortItems = () => {
 	return Object.entries(sortMap).map(([key, label]) => ({
 		label,
@@ -53,7 +55,8 @@ const Sort = observer(({ count, state$ }: SortProps) => {
 	return (
 		<Group className={classes.wrapper} justify="space-between" wrap="nowrap">
 			<Text aria-atomic="true" role="status">
-				{count} families loaded
+				{numberFormatter.format(count)}{' '}
+				{count === 1 ? 'font family' : 'font families'}
 			</Text>
 			<Group>
 				<Group visibleFrom="sm">
@@ -66,12 +69,9 @@ const Sort = observer(({ count, state$ }: SortProps) => {
 					<Text span ml="xs" mr={-8} fz={14}>
 						Display
 					</Text>
-					<Tooltip
-						label={display === 'grid' ? 'Grid' : 'List'}
-						openDelay={600}
-						closeDelay={100}
-					>
+					<Tooltip label="Change view" openDelay={600} closeDelay={100}>
 						<SegmentedControl
+							aria-label="Display mode"
 							className={classes.control}
 							value={display}
 							onChange={state$.display.set as (value: string) => void}
@@ -79,8 +79,12 @@ const Sort = observer(({ count, state$ }: SortProps) => {
 								{
 									label: (
 										<>
-											<IconGrid height={20} data-active={display === 'grid'} />
-											<VisuallyHidden>Grid View</VisuallyHidden>
+											<IconGrid
+												aria-hidden="true"
+												height={20}
+												data-active={display === 'grid'}
+											/>
+											<VisuallyHidden>Grid view</VisuallyHidden>
 										</>
 									),
 									value: 'grid',
@@ -88,8 +92,12 @@ const Sort = observer(({ count, state$ }: SortProps) => {
 								{
 									label: (
 										<>
-											<IconList height={20} data-active={display === 'list'} />
-											<VisuallyHidden>List View</VisuallyHidden>
+											<IconList
+												aria-hidden="true"
+												height={20}
+												data-active={display === 'list'}
+											/>
+											<VisuallyHidden>List view</VisuallyHidden>
 										</>
 									),
 									value: 'list',

--- a/website/app/features/collections/CollectionFilter.tsx
+++ b/website/app/features/collections/CollectionFilter.tsx
@@ -77,7 +77,7 @@ const CollectionFilter = ({ onChange, value }: CollectionFilterProps) => {
 			>
 				<Menu.Target>
 					<InputBase
-						aria-label={`Filter by collection, ${selectedCollection?.name ?? 'All fonts'}`}
+						aria-label={`Font collection: ${selectedCollection?.name ?? 'All fonts'}`}
 						classNames={{ input: classes.input }}
 						component="button"
 						disabled={!ready}

--- a/website/app/features/collections/CollectionFilter.tsx
+++ b/website/app/features/collections/CollectionFilter.tsx
@@ -83,7 +83,7 @@ const CollectionFilter = ({ onChange, value }: CollectionFilterProps) => {
 						disabled={!ready}
 						pointer
 						ref={targetRef}
-						rightSection={<IconCaret />}
+						rightSection={<IconCaret aria-hidden="true" />}
 						rightSectionPointerEvents="none"
 						w={250}
 					>


### PR DESCRIPTION
## Overview

Improves homepage font discovery without changing the established desktop or mobile layout. Search controls now recover cleanly from loading and service failures, and the existing mobile filter strip keeps its horizontal scrolling behavior.

Font preview stylesheets load only as cards approach the viewport while the first row remains eager. Result counts, empty states, recovery actions, and accessible control labels are also clearer and more accurate.
