### PR TITLE
fix(website): preserve scroll position when filtering

### DIFF
--- a/website/app/components/search/Hits.tsx
+++ b/website/app/components/search/Hits.tsx
@@ -313,13 +313,6 @@ const InfiniteHits = observer(({ state$ }: InfiniteHitsProps) => {
 
 		previousSearchKeyRef.current = searchKey;
 		setIsLoadingMore(false);
-		const resultsTop = resultsRootRef.current
-			? resultsRootRef.current.getBoundingClientRect().top + window.scrollY
-			: 0;
-		window.scrollTo({
-			top: Math.max(resultsTop - 16, 0),
-			behavior: 'auto',
-		});
 	}, [searchKey]);
 
 	useEffect(() => {

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -47,6 +47,7 @@ import { cacheHeaders, PUBLIC_ORIGIN } from '@/utils/cache';
 import { cloudflareContext } from '@/utils/cloudflare-context';
 import type { DiscoveryPage } from '@/utils/discovery';
 import { getPreviewText } from '@/utils/language/language';
+import { ogMeta } from '@/utils/meta';
 
 export interface SearchProps {
 	discovery?: DiscoveryPage;
@@ -84,8 +85,10 @@ export const links: LinksFunction = () => [
 	},
 ];
 
-export const meta: MetaFunction = ({ location }) =>
-	location.search ? [{ name: 'robots', content: 'noindex, follow' }] : [];
+export const meta: MetaFunction = ({ location }) => [
+	...ogMeta({}),
+	...(location.search ? [{ name: 'robots', content: 'noindex, follow' }] : []),
+];
 
 const sortMap: Record<string, string> = {
 	prod_POPULAR: 'popular',


### PR DESCRIPTION
## Overview

Changing any homepage search refinement called `window.scrollTo` as part of the shared search-state effect, moving the viewport to the first result after every category, language, or variable-font update.

This removes the forced scroll while retaining the infinite-loading reset, so refinements update results in place and preserve the user's viewport. It also restores the homepage's shared default metadata so the document title is present while filtered URLs remain noindexed.
