### PR TITLE
feat(registry): model family replacements

### DIFF
--- a/api/shared/registry.ts
+++ b/api/shared/registry.ts
@@ -47,6 +47,7 @@ const FamilySummarySchema = z.strictObject({
 	displayName: z.string().optional(),
 	provider: IdSchema,
 	status: z.enum(['active', 'deprecated']),
+	replacedBy: IdSchema.optional(),
 	classifications: z.array(ClassificationSchema).min(1),
 	tags: z.array(TagIdSchema),
 	languages: z

--- a/registry/README.md
+++ b/registry/README.md
@@ -68,6 +68,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
   globally unique across providers.
 - `data/languages.json` defines semantic languages, public names, and the
   private codepoint requirements used for automatic matching.
+- `data/replacements.json` records reviewed successor relationships between
+  globally unique family IDs.
 - `data/taxonomy.json` defines the reviewed classification and tag labels.
 - `data/subsets/` and `data/axes.json` contain shared Unicode and axis data.
 
@@ -80,6 +82,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 - Each provider owns its directory; Google generation never changes Fontsource
   records.
 - Removed Google families remain buildable but are marked `deprecated`.
+- Replaced families retain their own sources; `replacedBy` recommends an active
+  successor and never aliases its binaries.
 - `github` provenance can recover a missing source from an exact commit;
   `registry` provenance requires the source to be promoted to R2 first.
 - Package policy is reviewed registry state, not derived from legacy catalogs.

--- a/registry/data/families/google/ek-mukta/metadata.json
+++ b/registry/data/families/google/ek-mukta/metadata.json
@@ -489,6 +489,7 @@
 		"type": "github"
 	},
 	"provider": "google",
+	"replacedBy": "mukta",
 	"sourceFiles": [
 		{
 			"path": "ofl/ekmukta/EkMukta-Bold.ttf",
@@ -555,6 +556,6 @@
 		}
 	],
 	"sourceModified": "2026-02-27",
-	"status": "active",
+	"status": "deprecated",
 	"tags": []
 }

--- a/registry/data/replacements.json
+++ b/registry/data/replacements.json
@@ -1,0 +1,3 @@
+{
+	"ek-mukta": "mukta"
+}

--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -33,6 +33,7 @@ describe('registry source archive', () => {
 		let manifest: unknown;
 		let current: unknown;
 		let family: unknown;
+		let replacement: unknown;
 		let language: unknown;
 		let sourceContentType: string | undefined;
 		r2.putObject.mockImplementation(
@@ -52,6 +53,11 @@ describe('registry source archive', () => {
 				}
 				if (object.key.endsWith('/api/families/abel.json')) {
 					family = JSON.parse(
+						Buffer.from(await object.read()).toString('utf8'),
+					);
+				}
+				if (object.key.endsWith('/api/families/ek-mukta.json')) {
+					replacement = JSON.parse(
 						Buffer.from(await object.read()).toString('utf8'),
 					);
 				}
@@ -127,6 +133,12 @@ describe('registry source archive', () => {
 			],
 		});
 		expect(RegistryFamilyDetailSchema.parse(family)).toEqual(family);
+		expect(replacement).toMatchObject({
+			id: 'ek-mukta',
+			status: 'deprecated',
+			replacedBy: 'mukta',
+		});
+		expect(RegistryFamilyDetailSchema.parse(replacement)).toEqual(replacement);
 		expect(language).not.toHaveProperty('requiredCodepoints');
 	}, 15_000);
 });

--- a/registry/scripts/archive.ts
+++ b/registry/scripts/archive.ts
@@ -146,6 +146,7 @@ const createArchivePlan = async (root: string, registryRevision: string) => {
 			...(metadata.displayName ? { displayName: metadata.displayName } : {}),
 			provider: metadata.provider,
 			status: metadata.status,
+			replacedBy: metadata.replacedBy,
 			classifications: metadata.classifications,
 			tags: metadata.tags,
 			languages: metadata.languages,

--- a/registry/scripts/generate.ts
+++ b/registry/scripts/generate.ts
@@ -3,7 +3,13 @@ import { consola } from 'consola';
 import { openGitSnapshot } from './git.ts';
 import { generateGoogle } from './google.ts';
 import { generateNam } from './nam.ts';
-import { registryIndexSchema, taxonomySchema } from './schema.ts';
+import {
+	familyMetadataSchema,
+	type ReplacementRegistry,
+	registryIndexSchema,
+	replacementRegistrySchema,
+	taxonomySchema,
+} from './schema.ts';
 import {
 	compareStrings,
 	readJson,
@@ -13,6 +19,25 @@ import {
 import { validateRegistry } from './validator.ts';
 
 const logger = consola.withTag('registry');
+
+const applyReplacements = async (
+	root: string,
+	families: readonly string[],
+	replacements: ReplacementRegistry,
+): Promise<void> => {
+	await Promise.all(
+		families.map(async (family) => {
+			const path = join(root, 'families', family, 'metadata.json');
+			const metadata = familyMetadataSchema.parse(await readJson(path));
+			const replacedBy = replacements[metadata.id];
+			await writeJson(path, {
+				...metadata,
+				...(replacedBy ? { status: 'deprecated' } : {}),
+				replacedBy,
+			});
+		}),
+	);
+};
 
 export const generateRegistry = async (
 	googleRepository: string,
@@ -27,6 +52,10 @@ export const generateRegistry = async (
 	const previousIndex =
 		previousValue === null ? null : registryIndexSchema.parse(previousValue);
 	const previousFamilies = previousIndex?.families ?? [];
+	const replacementsValue = await readJsonIfExists(
+		join(root, 'replacements.json'),
+	);
+	const replacements = replacementRegistrySchema.parse(replacementsValue ?? {});
 	const previousGoogleIds = previousFamilies
 		.filter((family) => family.startsWith('google/'))
 		.map((family) => family.slice('google/'.length));
@@ -67,6 +96,8 @@ export const generateRegistry = async (
 		families,
 		subsets,
 	});
+	await writeJson(join(root, 'replacements.json'), replacements);
+	await applyReplacements(root, families, replacements);
 	logger.start('Validating registry');
 	await validateRegistry(root);
 	logger.success('Registry is valid');

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -643,11 +643,14 @@ describe('registry ingestion', () => {
 			registry,
 			'families/google/recursive-sans/metadata.json',
 		);
+		const replacement = familyMetadataSchema.parse(
+			await readJson(replacementPath),
+		);
 		await writeFixture(
 			registry,
 			'families/google/recursive-sans/metadata.json',
 			canonicalJson({
-				...(await readJson(replacementPath)),
+				...replacement,
 				status: 'deprecated',
 			}),
 		);

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -370,6 +370,8 @@ const addRetainedRegistryState = async (root: string): Promise<void> => {
 			id: 'example',
 			family: 'Example',
 			provider: 'fontsource',
+			status: 'active',
+			replacedBy: undefined,
 			provenance: { type: 'registry' },
 		}),
 	);
@@ -511,7 +513,7 @@ describe('registry ingestion', () => {
 		).toBe(false);
 	});
 
-	it('regenerates deterministically, preserves policy, and retains missing families', async () => {
+	it('regenerates deterministically, applies replacements, and retains missing families', async () => {
 		const google = await createGoogleRepository();
 		const nam = await createNamRepository();
 		const registry = await temporaryDirectory('registry');
@@ -524,6 +526,11 @@ describe('registry ingestion', () => {
 			registry,
 		);
 		await addRetainedRegistryState(registry);
+		await writeFixture(
+			registry,
+			'replacements.json',
+			canonicalJson({ abel: 'recursive-sans' }),
+		);
 
 		await writeFixture(
 			google.repository,
@@ -542,6 +549,11 @@ describe('registry ingestion', () => {
 			registry,
 		);
 		const freshRegistry = await temporaryDirectory('fresh-registry');
+		await writeFixture(
+			freshRegistry,
+			'replacements.json',
+			canonicalJson({ abel: 'recursive-sans' }),
+		);
 		await generateRegistry(
 			google.repository,
 			unrelatedRevision,
@@ -564,6 +576,8 @@ describe('registry ingestion', () => {
 				tester: 'All people are born free and equal',
 			},
 			provenance: { revision: google.revision },
+			replacedBy: 'recursive-sans',
+			status: 'deprecated',
 		});
 		expect(await readJson(join(registry, 'languages.json'))).toMatchObject({
 			en_Latn: {
@@ -621,7 +635,24 @@ describe('registry ingestion', () => {
 		);
 		expect(metadata).toMatchObject({
 			status: 'deprecated',
+			replacedBy: 'recursive-sans',
 			provenance: { revision: google.revision },
 		});
+
+		const replacementPath = join(
+			registry,
+			'families/google/recursive-sans/metadata.json',
+		);
+		await writeFixture(
+			registry,
+			'families/google/recursive-sans/metadata.json',
+			canonicalJson({
+				...(await readJson(replacementPath)),
+				status: 'deprecated',
+			}),
+		);
+		await expect(validateRegistry(registry)).rejects.toThrow(
+			'Replacement target recursive-sans must be active',
+		);
 	}, 30_000);
 });

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -98,6 +98,8 @@ export const registryIndexSchema = z.strictObject({
 	subsets: z.array(idSchema),
 });
 
+export const replacementRegistrySchema = z.record(idSchema, idSchema);
+
 const archivedFileSchema = z.strictObject({
 	path: sourcePathSchema,
 	size: z.number().int().nonnegative(),
@@ -131,6 +133,7 @@ export const familyMetadataSchema = z.strictObject({
 	family: z.string().min(1),
 	provider: familyProviderSchema,
 	status: z.enum(['active', 'deprecated']),
+	replacedBy: idSchema.optional(),
 	provenance: z.discriminatedUnion('type', [
 		z.strictObject({
 			type: z.literal('github'),
@@ -169,6 +172,7 @@ export const sourceFamilySchema = familyMetadataSchema
 	.omit({
 		provider: true,
 		status: true,
+		replacedBy: true,
 		provenance: true,
 		sourceModified: true,
 		sourceFiles: true,
@@ -290,6 +294,7 @@ export type FamilyMetadata = z.infer<typeof familyMetadataSchema>;
 export type FamilyInspection = z.infer<typeof familyInspectionSchema>;
 export type FamilyPolicy = z.infer<typeof familyPolicySchema>;
 export type LanguageCatalog = z.infer<typeof languageCatalogSchema>;
+export type ReplacementRegistry = z.infer<typeof replacementRegistrySchema>;
 export type SourceFamily = z.infer<typeof sourceFamilySchema>;
 export type SubsetDefinition = z.infer<typeof subsetDefinitionSchema>;
 export type Taxonomy = z.infer<typeof taxonomySchema>;

--- a/registry/scripts/validator.ts
+++ b/registry/scripts/validator.ts
@@ -14,6 +14,7 @@ import {
 	type LanguageCatalog,
 	languageCatalogSchema,
 	registryIndexSchema,
+	replacementRegistrySchema,
 	subsetDefinitionSchema,
 	type Taxonomy,
 	taxonomySchema,
@@ -193,7 +194,7 @@ const validateFamily = async (
 	subsets: ReadonlySet<string>,
 	taxonomy: Taxonomy,
 	languages: LanguageCatalog,
-): Promise<void> => {
+): Promise<FamilyMetadata> => {
 	const { provider, id } = parseFamilyKey(key);
 	const directory = join(root, 'families', key);
 	const metadata = await validateCanonicalJson(
@@ -279,7 +280,7 @@ const validateFamily = async (
 	}
 
 	const policyPath = join(directory, 'policy.json');
-	if (!(await pathExists(policyPath))) return;
+	if (!(await pathExists(policyPath))) return metadata;
 	const policy = await validateCanonicalJson(policyPath, familyPolicySchema);
 	assert(
 		Boolean(policy.packages.static || policy.packages.variable),
@@ -311,6 +312,7 @@ const validateFamily = async (
 		);
 	}
 	validatePolicyResolution(policy, metadata, inspection, id);
+	return metadata;
 };
 
 const validateSubset = async (root: string, id: string): Promise<void> => {
@@ -378,6 +380,10 @@ export const validateRegistry = async (root: string): Promise<void> => {
 		assert(!familyIds.has(id), `Duplicate registry family ID ${id}`);
 		familyIds.add(id);
 	}
+	const replacements = await validateCanonicalJson(
+		join(root, 'replacements.json'),
+		replacementRegistrySchema,
+	);
 	const taxonomy = await validateCanonicalJson(
 		join(root, 'taxonomy.json'),
 		taxonomySchema,
@@ -422,17 +428,45 @@ export const validateRegistry = async (root: string): Promise<void> => {
 
 	const subsetSet = new Set(index.subsets);
 	let validated = 0;
-	await Promise.all(
+	const families = await Promise.all(
 		index.families.map(async (family) => {
-			await validateFamily(root, family, subsetSet, taxonomy, languages);
+			const metadata = await validateFamily(
+				root,
+				family,
+				subsetSet,
+				taxonomy,
+				languages,
+			);
 			validated += 1;
 			if (validated % 250 === 0 && validated < index.families.length) {
 				logger.info(
 					`Validated ${validated}/${index.families.length} font families`,
 				);
 			}
+			return metadata;
 		}),
 	);
+	const metadataById = new Map(families.map((family) => [family.id, family]));
+	for (const family of families) {
+		strictEqual(
+			family.replacedBy,
+			replacements[family.id],
+			`${family.id} replacement does not match replacements.json`,
+		);
+	}
+	for (const [id, replacedBy] of Object.entries(replacements)) {
+		assert(id !== replacedBy, `${id} cannot replace itself`);
+		const family = metadataById.get(id);
+		assert(family, `Replacement source ${id} does not exist`);
+		const replacement = metadataById.get(replacedBy);
+		assert(replacement, `Replacement target ${replacedBy} does not exist`);
+		strictEqual(family.status, 'deprecated', `${id} must be deprecated`);
+		strictEqual(
+			replacement.status,
+			'active',
+			`Replacement target ${replacedBy} must be active`,
+		);
+	}
 	await Promise.all(index.subsets.map((id) => validateSubset(root, id)));
 	await validateCanonicalJson(join(root, 'axes.json'), axisRegistrySchema);
 
@@ -440,6 +474,7 @@ export const validateRegistry = async (root: string): Promise<void> => {
 		'index.json',
 		'axes.json',
 		'languages.json',
+		'replacements.json',
 		'taxonomy.json',
 		...index.subsets.map((id) => `subsets/${id}.json`),
 	]);

--- a/website/app/generated/api/types.gen.ts
+++ b/website/app/generated/api/types.gen.ts
@@ -741,6 +741,7 @@ export type ListRegistryFamiliesResponses = {
             displayName?: string;
             provider: string;
             status: 'active' | 'deprecated';
+            replacedBy?: string;
             classifications: Array<'serif' | 'sans-serif' | 'slab-serif' | 'display' | 'handwriting' | 'monospace' | 'symbols'>;
             tags: Array<string>;
             /**
@@ -810,6 +811,7 @@ export type GetRegistryFamilyResponses = {
         displayName?: string;
         provider: string;
         status: 'active' | 'deprecated';
+        replacedBy?: string;
         classifications: Array<'serif' | 'sans-serif' | 'slab-serif' | 'display' | 'handwriting' | 'monospace' | 'symbols'>;
         tags: Array<string>;
         /**


### PR DESCRIPTION
## Overview

Adds reviewed family replacement relationships, validates that deprecated families point to active successors, and exposes `replacedBy` through registry API views. Ek Mukta to Mukta is the first recorded replacement.