### PR TITLE
fix(processor): pin unused axes in static font builds

### DIFF
--- a/packages/core/src/processor.ts
+++ b/packages/core/src/processor.ts
@@ -24,6 +24,7 @@ import {
 	extractStyleValue,
 	formatAxisValue,
 	formatSlantValue,
+	formatStyle,
 	generateStaticFilename,
 	generateVariableFilename,
 	normalizeKebabCase,
@@ -47,6 +48,24 @@ const STYLE_VALUE_AXIS_MAP: Record<keyof StyleValues, string> = {
 	width: 'wdth',
 	italic: 'ital',
 	slant: 'slnt',
+};
+
+const pinUnusedStyleAxes = (
+	styleValues: Partial<StyleValues>,
+): Partial<Record<keyof StyleValues, SubsetAxisSetting>> => {
+	const settings = { ...styleValues };
+
+	for (const styleKey of ['width', 'slant'] as const) {
+		const styleValue = styleValues[styleKey];
+		if (styleValue?.type === 'variable') {
+			settings[styleKey] = {
+				type: 'single',
+				value: styleValue.value.defaultValue,
+			};
+		}
+	}
+
+	return settings;
 };
 
 const getSourceVariableConfig = (fonts: FontRef[]): VariableAxisConfig => {
@@ -198,7 +217,14 @@ export const buildFont = async (
 				};
 			}
 
-			const styleValues: Partial<Record<string, SubsetAxisSetting>> = {};
+			let fonts = isVariableFont
+				? family.fonts
+				: family.fonts.map(({ font, styleValues }) => ({
+						font,
+						styleValues: pinUnusedStyleAxes(styleValues),
+					}));
+			const styleValues: Partial<Record<string, SubsetAxisSetting>> =
+				isVariableFont ? {} : pinUnusedStyleAxes(family.styleValues);
 			const axes: Partial<Record<string, SubsetAxisSetting>> = {};
 
 			if (isVariableFont && variableConfig) {
@@ -219,6 +245,15 @@ export const buildFont = async (
 					}
 				}
 			} else {
+				// Glypht preserves unspecified axes, so a static build must pin
+				// every custom axis it does not instance.
+				for (const axis of family.axes) {
+					axes[axis.tag] = {
+						type: 'single',
+						value: axis.defaultValue,
+					};
+				}
+
 				// If weights aren't explicitly configured, extract them from the font metadata.
 				let weights = config.weights;
 				if (!weights || weights.length === 0) {
@@ -254,22 +289,44 @@ export const buildFont = async (
 					(s) => s === 'italic' || s.startsWith('oblique'),
 				);
 				const hasNormal = styles.includes('normal');
+				const italicAxis = family.styleValues.italic;
+				const slantAxis = family.styleValues.slant;
 
-				// If both italic and normal styles are present, we can use a single 'italic' axis with values 0 and 1.
-				if (hasItalic && hasNormal) {
-					styleValues.italic = {
-						type: 'multiple',
-						value: { ranges: [0, 1] },
-					};
-				} else if (hasItalic) {
-					styleValues.italic = { type: 'single', value: 1 };
+				// Use the source endpoints instead of assuming every style axis is
+				// encoded as ital 0–1 or a particular slant angle.
+				if (slantAxis?.type === 'variable' && italicAxis?.type !== 'variable') {
+					const { min, defaultValue, max } = slantAxis.value;
+					const upright = min <= 0 && max >= 0 ? 0 : defaultValue;
+					const italic =
+						Math.abs(min - upright) > Math.abs(max - upright) ? min : max;
+					styleValues.slant =
+						hasItalic && hasNormal
+							? {
+									type: 'multiple',
+									value: { ranges: [upright, italic] },
+								}
+							: { type: 'single', value: hasItalic ? italic : upright };
+				} else if (italicAxis?.type === 'variable') {
+					const italic = italicAxis.value.max;
+					styleValues.italic =
+						hasItalic && hasNormal
+							? {
+									type: 'multiple',
+									value: { ranges: [0, italic] },
+								}
+							: { type: 'single', value: hasItalic ? italic : 0 };
 				} else {
-					styleValues.italic = { type: 'single', value: 0 };
+					const requestedStyles = new Set(styles.map(formatStyle));
+					fonts = fonts.filter(({ font }) =>
+						requestedStyles.has(
+							formatStyle(extractFontStyle(font.styleValues).style),
+						),
+					);
 				}
 			}
 
 			return {
-				fonts: family.fonts,
+				fonts,
 				enableSubsetting: true,
 				styleValues,
 				axes,

--- a/packages/core/src/processor.ts
+++ b/packages/core/src/processor.ts
@@ -247,11 +247,8 @@ export const buildFont = async (
 			} else {
 				// Glypht preserves unspecified axes, so a static build must pin
 				// every custom axis it does not instance.
-				for (const axis of family.axes) {
-					axes[axis.tag] = {
-						type: 'single',
-						value: axis.defaultValue,
-					};
+				for (const { tag, defaultValue } of family.axes) {
+					axes[tag] = { type: 'single', value: defaultValue };
 				}
 
 				// If weights aren't explicitly configured, extract them from the font metadata.
@@ -285,12 +282,21 @@ export const buildFont = async (
 					value: { ranges: weights },
 				};
 
-				const hasItalic = styles.some(
-					(s) => s === 'italic' || s.startsWith('oblique'),
-				);
-				const hasNormal = styles.includes('normal');
+				const requestedStyles = new Set(styles.map(formatStyle));
+				const hasItalic = requestedStyles.has('italic');
+				const hasNormal = requestedStyles.has('normal');
 				const italicAxis = family.styleValues.italic;
 				const slantAxis = family.styleValues.slant;
+				const styleSetting = (
+					upright: number,
+					italic: number,
+				): SubsetAxisSetting =>
+					hasItalic && hasNormal
+						? {
+								type: 'multiple',
+								value: { ranges: [upright, italic] },
+							}
+						: { type: 'single', value: hasItalic ? italic : upright };
 
 				// Use the source endpoints instead of assuming every style axis is
 				// encoded as ital 0–1 or a particular slant angle.
@@ -299,24 +305,10 @@ export const buildFont = async (
 					const upright = min <= 0 && max >= 0 ? 0 : defaultValue;
 					const italic =
 						Math.abs(min - upright) > Math.abs(max - upright) ? min : max;
-					styleValues.slant =
-						hasItalic && hasNormal
-							? {
-									type: 'multiple',
-									value: { ranges: [upright, italic] },
-								}
-							: { type: 'single', value: hasItalic ? italic : upright };
+					styleValues.slant = styleSetting(upright, italic);
 				} else if (italicAxis?.type === 'variable') {
-					const italic = italicAxis.value.max;
-					styleValues.italic =
-						hasItalic && hasNormal
-							? {
-									type: 'multiple',
-									value: { ranges: [0, italic] },
-								}
-							: { type: 'single', value: hasItalic ? italic : 0 };
+					styleValues.italic = styleSetting(0, italicAxis.value.max);
 				} else {
-					const requestedStyles = new Set(styles.map(formatStyle));
 					fonts = fonts.filter(({ font }) =>
 						requestedStyles.has(
 							formatStyle(extractFontStyle(font.styleValues).style),

--- a/packages/core/tests/processor.test.ts
+++ b/packages/core/tests/processor.test.ts
@@ -129,49 +129,13 @@ describe('buildFont integration with real fixtures', () => {
 		expect(result.faces[0]?.weight).toBe('300 1000');
 	});
 
-	it('pins unused variable axes when building static faces', async () => {
+	it('builds static weights and styles without retaining variable axes', async () => {
 		const result = await buildWithFixture(loadVariableFontFixture(), {
 			type: 'static',
 			id: 'recursive',
 			family: 'Recursive',
 			subsets: ['latin'],
 			weights: [400, 700],
-			styles: ['normal'],
-			formats: ['woff2'],
-			featureSettings: {},
-			subsetSources: {
-				latin: latinRangeSubset,
-			},
-		});
-		const ctx = createFontContext();
-
-		try {
-			const inspections = await Promise.all(
-				result.fonts.map((font) => inspectFont(ctx, font.content)),
-			);
-
-			expect(
-				inspections.map(({ weight, style, axes }) => ({
-					weight,
-					style,
-					axes,
-				})),
-			).toEqual([
-				{ weight: 400, style: 'normal', axes: [] },
-				{ weight: 700, style: 'normal', axes: [] },
-			]);
-		} finally {
-			ctx.destroy();
-		}
-	});
-
-	it('instances a slant axis for requested static styles', async () => {
-		const result = await buildWithFixture(loadVariableFontFixture(), {
-			type: 'static',
-			id: 'recursive',
-			family: 'Recursive',
-			subsets: ['latin'],
-			weights: [400],
 			styles: ['normal', 'italic'],
 			formats: ['woff2'],
 			featureSettings: {},
@@ -188,11 +152,21 @@ describe('buildFont integration with real fixtures', () => {
 
 			expect(result.fonts.map((font) => font.filename)).toEqual([
 				'files/recursive-latin-400-normal.woff2',
+				'files/recursive-latin-700-normal.woff2',
 				'files/recursive-latin-400-italic.woff2',
+				'files/recursive-latin-700-italic.woff2',
 			]);
-			expect(inspections.map(({ style, axes }) => ({ style, axes }))).toEqual([
-				{ style: 'normal', axes: [] },
-				{ style: 'oblique', axes: [] },
+			expect(
+				inspections.map(({ weight, style, axes }) => ({
+					weight,
+					style,
+					axes,
+				})),
+			).toEqual([
+				{ weight: 400, style: 'normal', axes: [] },
+				{ weight: 700, style: 'normal', axes: [] },
+				{ weight: 400, style: 'oblique', axes: [] },
+				{ weight: 700, style: 'oblique', axes: [] },
 			]);
 		} finally {
 			ctx.destroy();

--- a/packages/core/tests/processor.test.ts
+++ b/packages/core/tests/processor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createFontContext } from '../src/context';
+import { inspectFont } from '../src/inspection';
 import { buildFont } from '../src/processor';
 import type { FontBuildConfig, FontBuildResult } from '../src/types';
 import {
@@ -126,6 +127,95 @@ describe('buildFont integration with real fixtures', () => {
 		]);
 		expect(result.faces.map((face) => face.axisKey)).toEqual(['full']);
 		expect(result.faces[0]?.weight).toBe('300 1000');
+	});
+
+	it('pins unused variable axes when building static faces', async () => {
+		const result = await buildWithFixture(loadVariableFontFixture(), {
+			type: 'static',
+			id: 'recursive',
+			family: 'Recursive',
+			subsets: ['latin'],
+			weights: [400, 700],
+			styles: ['normal'],
+			formats: ['woff2'],
+			featureSettings: {},
+			subsetSources: {
+				latin: latinRangeSubset,
+			},
+		});
+		const ctx = createFontContext();
+
+		try {
+			const inspections = await Promise.all(
+				result.fonts.map((font) => inspectFont(ctx, font.content)),
+			);
+
+			expect(
+				inspections.map(({ weight, style, axes }) => ({
+					weight,
+					style,
+					axes,
+				})),
+			).toEqual([
+				{ weight: 400, style: 'normal', axes: [] },
+				{ weight: 700, style: 'normal', axes: [] },
+			]);
+		} finally {
+			ctx.destroy();
+		}
+	});
+
+	it('instances a slant axis for requested static styles', async () => {
+		const result = await buildWithFixture(loadVariableFontFixture(), {
+			type: 'static',
+			id: 'recursive',
+			family: 'Recursive',
+			subsets: ['latin'],
+			weights: [400],
+			styles: ['normal', 'italic'],
+			formats: ['woff2'],
+			featureSettings: {},
+			subsetSources: {
+				latin: latinRangeSubset,
+			},
+		});
+		const ctx = createFontContext();
+
+		try {
+			const inspections = await Promise.all(
+				result.fonts.map((font) => inspectFont(ctx, font.content)),
+			);
+
+			expect(result.fonts.map((font) => font.filename)).toEqual([
+				'files/recursive-latin-400-normal.woff2',
+				'files/recursive-latin-400-italic.woff2',
+			]);
+			expect(inspections.map(({ style, axes }) => ({ style, axes }))).toEqual([
+				{ style: 'normal', axes: [] },
+				{ style: 'oblique', axes: [] },
+			]);
+		} finally {
+			ctx.destroy();
+		}
+	});
+
+	it('does not synthesize styles missing from the source faces', async () => {
+		const result = await buildWithFixture(loadStaticFontFixture(), {
+			type: 'static',
+			family: 'Abel',
+			subsets: ['latin'],
+			weights: [400],
+			styles: ['normal', 'italic'],
+			formats: ['woff2'],
+			featureSettings: {},
+			subsetSources: {
+				latin: latinRangeSubset,
+			},
+		});
+
+		expect(result.fonts.map((font) => font.filename)).toEqual([
+			'files/abel-latin-400-normal.woff2',
+		]);
 	});
 
 	it('deduplicates colliding outputs from equivalent source faces', async () => {


### PR DESCRIPTION
Related to fontsource/font-files#143

## Overview

Static builds from variable sources currently preserve unconfigured axes and assume italic styles always use an `ital` value of 1. This pins unused standard and custom axes to their source defaults, instances the source's actual `ital` or `slnt` endpoint, and avoids synthesizing styles that the input faces cannot provide.