### PR TITLE
fix(registry): normalize provider metadata

### DIFF
--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -33,6 +33,7 @@ describe('registry source archive', () => {
 		let manifest: unknown;
 		let current: unknown;
 		let family: unknown;
+		let familyWithVariantOverride: unknown;
 		let replacement: unknown;
 		let language: unknown;
 		let sourceContentType: string | undefined;
@@ -53,6 +54,11 @@ describe('registry source archive', () => {
 				}
 				if (object.key.endsWith('/api/families/abel.json')) {
 					family = JSON.parse(
+						Buffer.from(await object.read()).toString('utf8'),
+					);
+				}
+				if (object.key.endsWith('/api/families/alegreya-sans.json')) {
+					familyWithVariantOverride = JSON.parse(
 						Buffer.from(await object.read()).toString('utf8'),
 					);
 				}
@@ -133,6 +139,19 @@ describe('registry source archive', () => {
 			],
 		});
 		expect(RegistryFamilyDetailSchema.parse(family)).toEqual(family);
+		expect(familyWithVariantOverride).toMatchObject({
+			sources: expect.arrayContaining([
+				expect.objectContaining({
+					filename: 'AlegreyaSans-Thin.ttf',
+					type: 'static',
+					weight: 100,
+					style: 'normal',
+				}),
+			]),
+		});
+		expect(RegistryFamilyDetailSchema.parse(familyWithVariantOverride)).toEqual(
+			familyWithVariantOverride,
+		);
 		expect(replacement).toMatchObject({
 			id: 'ek-mukta',
 			status: 'deprecated',

--- a/registry/scripts/archive.ts
+++ b/registry/scripts/archive.ts
@@ -121,6 +121,7 @@ const createArchivePlan = async (root: string, registryRevision: string) => {
 		// Registry validation guarantees matching source and inspection order.
 		const sources = metadata.sourceFiles.map((source, index) => {
 			const inspected = inspection.files[index];
+			const variable = inspected.axes.length > 0;
 			const format = source.path.toLowerCase().endsWith('.otf') ? 'otf' : 'ttf';
 			return {
 				sha256: source.sha256,
@@ -128,10 +129,13 @@ const createArchivePlan = async (root: string, registryRevision: string) => {
 				format,
 				size: source.size,
 				downloadUrl: `/v1/registry/sources/${source.sha256}`,
-				type: inspected.axes.length > 0 ? 'variable' : 'static',
+				type: variable ? 'variable' : 'static',
 				fontVersion: inspected.fontVersion,
-				weight: inspected.weight,
-				style: inspected.style,
+				weight:
+					variable || !source.variant
+						? inspected.weight
+						: source.variant.weight,
+				style: source.variant?.style ?? inspected.style,
 				axes: inspected.axes,
 			};
 		});

--- a/registry/scripts/font-files.ts
+++ b/registry/scripts/font-files.ts
@@ -108,9 +108,21 @@ const writeFamily = async (
 		});
 	}
 	const lastChanged = snapshot.lastChanged(directory);
-	const languages = sourceMetadata.languages ?? matchLanguages(coverage);
+	const languages = new Set(
+		sourceMetadata.languages ?? matchLanguages(coverage),
+	);
+	if (
+		sourceMetadata.languages === undefined &&
+		sourceMetadata.primaryLanguage
+	) {
+		languages.add(sourceMetadata.primaryLanguage);
+	}
+	const { primaryLanguage, ...sourceFields } = sourceMetadata;
 	const metadata = familyMetadataSchema.parse({
-		...sourceMetadata,
+		...sourceFields,
+		...(primaryLanguage && languages.has(primaryLanguage)
+			? { primaryLanguage }
+			: {}),
 		provider: 'fontsource',
 		status: 'active',
 		provenance: {
@@ -124,7 +136,7 @@ const writeFamily = async (
 			new Set(sourceMetadata.classifications),
 		).toSorted(compareStrings),
 		tags: Array.from(new Set(sourceMetadata.tags)).toSorted(compareStrings),
-		languages: Array.from(new Set(languages)).toSorted(compareStrings),
+		languages: [...languages].toSorted(compareStrings),
 		sourceFiles,
 	});
 	const inspection = familyInspectionSchema.parse({ files: inspectionFiles });

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -38,6 +38,12 @@ const TEST_LANGUAGES = languageCatalogSchema.parse({
 		name: 'English',
 		requiredCodepoints: [65, 66, 67],
 	},
+	zz_Latn: {
+		language: 'zz',
+		script: 'Latn',
+		name: 'Test language',
+		requiredCodepoints: [0x10ffff],
+	},
 });
 
 const temporaryDirectory = async (name: string): Promise<string> => {
@@ -325,6 +331,8 @@ const createFontFilesRepository = async (): Promise<{
 			family: 'Example',
 			classifications: ['display', 'sans-serif'],
 			tags: ['theme/stencil'],
+			primaryLanguage: 'zz_Latn',
+			primaryScript: 'Latn',
 			designer: 'Registry Tests',
 			dateAdded: '2026-01-02',
 			license: {
@@ -357,6 +365,8 @@ const createFontFilesRepository = async (): Promise<{
 			family: 'Symbols',
 			classifications: ['symbols'],
 			languages: [],
+			primaryLanguage: 'en_Latn',
+			primaryScript: 'Latn',
 			license: {
 				id: 'OFL-1.1',
 				url: 'https://openfontlicense.org/open-font-license-official-text/',
@@ -493,7 +503,8 @@ describe('registry ingestion', () => {
 			status: 'active',
 			classifications: ['display', 'sans-serif'],
 			tags: ['theme/stencil'],
-			languages: ['en_Latn'],
+			languages: ['en_Latn', 'zz_Latn'],
+			primaryLanguage: 'zz_Latn',
 			provenance: {
 				type: 'github',
 				repository: 'fontsource/font-files',
@@ -522,11 +533,11 @@ describe('registry ingestion', () => {
 				'utf8',
 			),
 		).toBe('# Example\n');
-		expect(
-			await readJson(
-				join(registry, 'families/fontsource/symbols/metadata.json'),
-			),
-		).toMatchObject({ languages: [] });
+		const symbols = await readJson(
+			join(registry, 'families/fontsource/symbols/metadata.json'),
+		);
+		expect(symbols).toMatchObject({ languages: [], primaryScript: 'Latn' });
+		expect(symbols).not.toHaveProperty('primaryLanguage');
 	});
 
 	it('rejects packaged webfonts as sources', () => {


### PR DESCRIPTION
## Overview

Normalizes inferred and explicitly declared languages without provider-specific exceptions, and exposes declared source variant corrections through registry API views while retaining raw inspection internally.