### PR TITLE
feat(registry): integrate font-files provider

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -42,12 +42,16 @@ jobs:
           git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
           git -C "$RUNNER_TEMP/google-fonts" sparse-checkout set ofl apache ufl axisregistry tags lang
           git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
+          git clone --filter=blob:none --sparse --single-branch https://github.com/fontsource/font-files.git "$RUNNER_TEMP/font-files"
+          git -C "$RUNNER_TEMP/font-files" sparse-checkout set sources
           # Record immutable upstream commits instead of moving branch names.
           pnpm --filter '@fontsource-utils/registry' generate \
             "$RUNNER_TEMP/google-fonts" \
             "$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" \
             "$RUNNER_TEMP/nam-files" \
-            "$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)"
+            "$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)" \
+            "$RUNNER_TEMP/font-files" \
+            "$(git -C "$RUNNER_TEMP/font-files" rev-parse HEAD)"
 
       - name: Validate
         run: |

--- a/registry/README.md
+++ b/registry/README.md
@@ -8,12 +8,12 @@ It is repository tooling, not a public package.
 Run from the repository root:
 
 ~~~sh
-pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <nam-repo> <nam-commit>
+pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <nam-repo> <nam-commit> <font-files-repo> <font-files-commit>
 pnpm --filter '@fontsource-utils/registry' validate
 pnpm --filter '@fontsource-utils/registry' archive
 ~~~
 
-Both source revisions must be exact 40-character commits. Generation also
+All source revisions must be exact 40-character commits. Generation also
 requires complete Git history so per-path provenance is accurate; shallow
 repositories are rejected.
 Generation validates existing `policy.json` files but never creates or changes
@@ -53,8 +53,7 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 ## Structure
 
 - `scripts/generate.ts` coordinates one complete registry build and validation.
-- `scripts/font-files.ts` implements opt-in Git-backed Fontsource ingestion. It
-  is not part of scheduled generation yet.
+- `scripts/font-files.ts` implements Git-backed Fontsource ingestion.
 - `scripts/google.ts` owns `data/families/google/` and writes family metadata,
   discovery metadata, source inspection, documents, licenses, languages, and
   normalized axis metadata.
@@ -93,7 +92,7 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 
 ## Font-files sources
 
-The opt-in `fontsource/font-files` adapter accepts reviewed source families:
+The `fontsource/font-files` adapter accepts reviewed source families:
 
 ~~~text
 sources/<id>/

--- a/registry/data/index.json
+++ b/registry/data/index.json
@@ -2216,6 +2216,10 @@
 		"znamenny"
 	],
 	"upstreams": {
+		"fontFiles": {
+			"repository": "fontsource/font-files",
+			"revision": "634de953dba143728c21f51b99255c1ff2753b84"
+		},
 		"googleFonts": {
 			"repository": "google/fonts",
 			"revision": "389b770410cc0b7c21c85673bfa2077420fe7f65"

--- a/registry/scripts/font-files.ts
+++ b/registry/scripts/font-files.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual } from 'node:assert/strict';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createFontContext, inspectFont } from '@fontsource-utils/core';
+import { consola } from 'consola';
 import type { GitSnapshot } from './git.ts';
 import { normalizeInspection } from './inspection.ts';
 import { createLanguageMatcher, type FontCoverage } from './languages.ts';
@@ -13,9 +14,16 @@ import {
 	type SourceFamily,
 	sourceFamilySchema,
 } from './schema.ts';
-import { compareStrings, normalizeText, sha256, writeJson } from './shared.ts';
+import {
+	compareStrings,
+	normalizeText,
+	readJson,
+	sha256,
+	writeJson,
+} from './shared.ts';
 
 const FONT_FILES_REPOSITORY = 'fontsource/font-files';
+const logger = consola.withTag('registry');
 
 const DOCUMENTS = ['article.en-US.md', 'description.en-US.md'] as const;
 
@@ -165,17 +173,41 @@ const writeFamily = async (
 export const generateFontFiles = async (
 	snapshot: GitSnapshot,
 	root: string,
+	previousFamilyIds: readonly string[],
 	languages: LanguageCatalog,
 ): Promise<string[]> => {
 	const families = readFamilies(snapshot);
+	const familyIds = new Set(previousFamilyIds);
 	const ctx = createFontContext();
 	const matchLanguages = createLanguageMatcher(languages);
 	try {
-		for (const family of families) {
+		for (const [index, family] of families.entries()) {
 			await writeFamily(snapshot, family, root, ctx, matchLanguages);
+			familyIds.add(family.metadata.id);
+			const processed = index + 1;
+			if (processed % 25 === 0 && processed < families.length) {
+				logger.info(
+					`Processed ${processed}/${families.length} Fontsource font families`,
+				);
+			}
 		}
 	} finally {
 		ctx.destroy();
 	}
-	return families.map((family) => family.metadata.id);
+
+	const currentIds = new Set(families.map((family) => family.metadata.id));
+	for (const id of previousFamilyIds) {
+		if (currentIds.has(id)) continue;
+		const metadataPath = join(
+			root,
+			'families',
+			'fontsource',
+			id,
+			'metadata.json',
+		);
+		const metadata = familyMetadataSchema.parse(await readJson(metadataPath));
+		await writeJson(metadataPath, { ...metadata, status: 'deprecated' });
+	}
+
+	return [...familyIds].toSorted(compareStrings);
 };

--- a/registry/scripts/generate.ts
+++ b/registry/scripts/generate.ts
@@ -1,10 +1,12 @@
 import { join } from 'node:path';
 import { consola } from 'consola';
+import { generateFontFiles } from './font-files.ts';
 import { openGitSnapshot } from './git.ts';
 import { generateGoogle } from './google.ts';
 import { generateNam } from './nam.ts';
 import {
 	familyMetadataSchema,
+	languageCatalogSchema,
 	type ReplacementRegistry,
 	registryIndexSchema,
 	replacementRegistrySchema,
@@ -44,10 +46,13 @@ export const generateRegistry = async (
 	googleRevision: string,
 	namRepository: string,
 	namRevision: string,
+	fontFilesRepository: string,
+	fontFilesRevision: string,
 	root: string,
 ): Promise<void> => {
 	const google = openGitSnapshot(googleRepository, googleRevision);
 	const nam = openGitSnapshot(namRepository, namRevision);
+	const fontFiles = openGitSnapshot(fontFilesRepository, fontFilesRevision);
 	const previousValue = await readJsonIfExists(join(root, 'index.json'));
 	const previousIndex =
 		previousValue === null ? null : registryIndexSchema.parse(previousValue);
@@ -59,6 +64,9 @@ export const generateRegistry = async (
 	const previousGoogleIds = previousFamilies
 		.filter((family) => family.startsWith('google/'))
 		.map((family) => family.slice('google/'.length));
+	const previousFontsourceIds = previousFamilies
+		.filter((family) => family.startsWith('fontsource/'))
+		.map((family) => family.slice('fontsource/'.length));
 	const taxonomy = taxonomySchema.parse(
 		await readJson(join(import.meta.dirname, '..', 'data', 'taxonomy.json')),
 	);
@@ -72,9 +80,25 @@ export const generateRegistry = async (
 		taxonomy,
 	);
 	logger.success(`Generated ${googleFamilies.length} Google font families`);
+	const languages = languageCatalogSchema.parse(
+		await readJson(join(root, 'languages.json')),
+	);
+	logger.start(
+		`Generating families from fontsource/font-files@${fontFiles.revision}`,
+	);
+	const fontsourceFamilies = await generateFontFiles(
+		fontFiles,
+		root,
+		previousFontsourceIds,
+		languages,
+	);
+	logger.success(
+		`Generated ${fontsourceFamilies.length} Fontsource font families`,
+	);
+
 	const families = [
-		...previousFamilies.filter((family) => !family.startsWith('google/')),
 		...googleFamilies.map((family) => `google/${family}`),
+		...fontsourceFamilies.map((family) => `fontsource/${family}`),
 	].toSorted(compareStrings);
 
 	logger.start(`Generating subsets from googlefonts/nam-files@${nam.revision}`);
@@ -92,6 +116,10 @@ export const generateRegistry = async (
 				repository: 'googlefonts/nam-files',
 				revision: nam.revision,
 			},
+			fontFiles: {
+				repository: 'fontsource/font-files',
+				revision: fontFiles.revision,
+			},
 		},
 		families,
 		subsets,
@@ -104,17 +132,25 @@ export const generateRegistry = async (
 };
 
 if (import.meta.main) {
-	const [googleRepository, googleRevision, namRepository, namRevision] =
-		process.argv.slice(2);
+	const [
+		googleRepository,
+		googleRevision,
+		namRepository,
+		namRevision,
+		fontFilesRepository,
+		fontFilesRevision,
+	] = process.argv.slice(2);
 	if (
 		!googleRepository ||
 		!googleRevision ||
 		!namRepository ||
 		!namRevision ||
-		process.argv.length !== 6
+		!fontFilesRepository ||
+		!fontFilesRevision ||
+		process.argv.length !== 8
 	) {
 		throw new Error(
-			'Usage: generate.ts <google-fonts-repo> <google-commit> <nam-files-repo> <nam-commit>',
+			'Usage: generate.ts <google-fonts-repo> <google-commit> <nam-files-repo> <nam-commit> <font-files-repo> <font-files-commit>',
 		);
 	}
 	await generateRegistry(
@@ -122,6 +158,8 @@ if (import.meta.main) {
 		googleRevision,
 		namRepository,
 		namRevision,
+		fontFilesRepository,
+		fontFilesRevision,
 		join(import.meta.dirname, '..', 'data'),
 	);
 }

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -17,7 +17,6 @@ import { assertGitPathClean, openGitSnapshot } from './git.ts';
 import {
 	familyMetadataSchema,
 	languageCatalogSchema,
-	registryIndexSchema,
 	sourceFamilySchema,
 } from './schema.ts';
 import { canonicalJson, compareStrings, readJson, sha256 } from './shared.ts';
@@ -385,46 +384,11 @@ const createFontFilesRepository = async (): Promise<{
 	};
 };
 
-const addRetainedRegistryState = async (root: string): Promise<void> => {
+const addPackagePolicy = async (root: string): Promise<void> => {
 	await writeFixture(
 		root,
 		'families/google/abel/policy.json',
 		canonicalJson(ABEL_POLICY),
-	);
-	const googleDirectory = join(root, 'families/google/abel');
-	const fontsourceDirectory = join(root, 'families/fontsource/example');
-	const metadata = familyMetadataSchema.parse(
-		await readJson(join(googleDirectory, 'metadata.json')),
-	);
-	await writeFixture(
-		root,
-		'families/fontsource/example/metadata.json',
-		canonicalJson({
-			...metadata,
-			id: 'example',
-			family: 'Example',
-			provider: 'fontsource',
-			status: 'active',
-			replacedBy: undefined,
-			provenance: { type: 'registry' },
-		}),
-	);
-	await cp(
-		join(googleDirectory, 'inspection.json'),
-		join(fontsourceDirectory, 'inspection.json'),
-	);
-	const index = registryIndexSchema.parse(
-		await readJson(join(root, 'index.json')),
-	);
-	await writeFixture(
-		root,
-		'index.json',
-		canonicalJson({
-			...index,
-			families: [...index.families, 'fontsource/example'].toSorted(
-				compareStrings,
-			),
-		}),
 	);
 };
 
@@ -475,6 +439,10 @@ describe('registry ingestion', () => {
 						repository: 'googlefonts/nam-files',
 						revision: '2'.repeat(40),
 					},
+					fontFiles: {
+						repository: 'fontsource/font-files',
+						revision: '3'.repeat(40),
+					},
 				},
 				families: ['fontsource/abel', 'google/abel'],
 				subsets: [],
@@ -492,7 +460,7 @@ describe('registry ingestion', () => {
 		const snapshot = openGitSnapshot(source.repository, source.revision);
 
 		await expect(
-			generateFontFiles(snapshot, registry, TEST_LANGUAGES),
+			generateFontFiles(snapshot, registry, [], TEST_LANGUAGES),
 		).resolves.toEqual(['example', 'symbols']);
 		expect(
 			await readJson(
@@ -555,6 +523,7 @@ describe('registry ingestion', () => {
 	it('regenerates deterministically, applies replacements, and retains missing families', async () => {
 		const google = await createGoogleRepository();
 		const nam = await createNamRepository();
+		const fontFiles = await createFontFilesRepository();
 		const registry = await temporaryDirectory('registry');
 
 		await generateRegistry(
@@ -562,9 +531,11 @@ describe('registry ingestion', () => {
 			google.revision,
 			nam.repository,
 			nam.revision,
+			fontFiles.repository,
+			fontFiles.revision,
 			registry,
 		);
-		await addRetainedRegistryState(registry);
+		await addPackagePolicy(registry);
 		await writeFixture(
 			registry,
 			'replacements.json',
@@ -585,6 +556,8 @@ describe('registry ingestion', () => {
 			unrelatedRevision,
 			nam.repository,
 			nam.revision,
+			fontFiles.repository,
+			fontFiles.revision,
 			registry,
 		);
 		const freshRegistry = await temporaryDirectory('fresh-registry');
@@ -598,9 +571,11 @@ describe('registry ingestion', () => {
 			unrelatedRevision,
 			nam.repository,
 			nam.revision,
+			fontFiles.repository,
+			fontFiles.revision,
 			freshRegistry,
 		);
-		await addRetainedRegistryState(freshRegistry);
+		await addPackagePolicy(freshRegistry);
 		expect(await treeHashes(registry)).toEqual(await treeHashes(freshRegistry));
 		expect(
 			await readJson(join(registry, 'families/google/abel/metadata.json')),
@@ -662,11 +637,20 @@ describe('registry ingestion', () => {
 
 		await rm(join(google.repository, 'ofl/abel'), { recursive: true });
 		const removedRevision = commitAll(google.repository, 'remove Abel');
+		await rm(join(fontFiles.repository, 'sources/symbols'), {
+			recursive: true,
+		});
+		const removedFontFilesRevision = commitAll(
+			fontFiles.repository,
+			'remove Symbols',
+		);
 		await generateRegistry(
 			google.repository,
 			removedRevision,
 			nam.repository,
 			nam.revision,
+			fontFiles.repository,
+			removedFontFilesRevision,
 			registry,
 		);
 		const metadata = await readJson(
@@ -676,6 +660,14 @@ describe('registry ingestion', () => {
 			status: 'deprecated',
 			replacedBy: 'recursive-sans',
 			provenance: { revision: google.revision },
+		});
+		expect(
+			await readJson(
+				join(registry, 'families/fontsource/symbols/metadata.json'),
+			),
+		).toMatchObject({
+			status: 'deprecated',
+			provenance: { revision: fontFiles.revision },
 		});
 
 		const replacementPath = join(

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -93,6 +93,10 @@ export const registryIndexSchema = z.strictObject({
 			repository: z.literal('googlefonts/nam-files'),
 			revision: revisionSchema,
 		}),
+		fontFiles: z.strictObject({
+			repository: z.literal('fontsource/font-files'),
+			revision: revisionSchema,
+		}),
 	}),
 	families: z.array(familyKeySchema),
 	subsets: z.array(idSchema),


### PR DESCRIPTION
Depends on #1215

## Overview

Adds `fontsource/font-files` to scheduled registry generation, retains removed families as deprecated records, and checks out only its `sources/` tree.