### PR TITLE
ci(registry): check font-files sources

### DIFF
--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -1,0 +1,35 @@
+name: Registry
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Fontsource
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: fontsource/fontsource
+          ref: main
+
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: font-files
+          sparse-checkout: sources
+
+      - name: Setup
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Check
+        run: pnpm --filter '@fontsource-utils/registry' check:font-files "$GITHUB_WORKSPACE/font-files"

--- a/registry/README.md
+++ b/registry/README.md
@@ -10,6 +10,7 @@ Run from the repository root:
 ~~~sh
 pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <nam-repo> <nam-commit> <font-files-repo> <font-files-commit>
 pnpm --filter '@fontsource-utils/registry' validate
+pnpm --filter '@fontsource-utils/registry' check:font-files <font-files-repo>
 pnpm --filter '@fontsource-utils/registry' archive
 ~~~
 

--- a/registry/package.json
+++ b/registry/package.json
@@ -7,7 +7,8 @@
 		"generate": "pnpm --filter '@fontsource-utils/core' build && node scripts/generate.ts",
 		"test": "pnpm --filter '@fontsource-utils/core' build && vitest run",
 		"typecheck": "pnpm --filter '@fontsource-utils/core' build && tsc --noEmit",
-		"validate": "node scripts/validator.ts"
+		"validate": "node scripts/validator.ts",
+		"check:font-files": "pnpm --filter '@fontsource-utils/core' build && node scripts/check-font-files.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1090.0",

--- a/registry/scripts/check-font-files.ts
+++ b/registry/scripts/check-font-files.ts
@@ -1,0 +1,75 @@
+import { cp, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { consola } from 'consola';
+import { generateFontFiles } from './font-files.ts';
+import { applyReplacements } from './generate.ts';
+import { assertGitPathClean, getGitRevision, openGitSnapshot } from './git.ts';
+import {
+	languageCatalogSchema,
+	registryIndexSchema,
+	replacementRegistrySchema,
+} from './schema.ts';
+import { compareStrings, readJson, writeJson } from './shared.ts';
+import { validateRegistry } from './validator.ts';
+
+const logger = consola.withTag('registry');
+
+const [repository] = process.argv.slice(2);
+if (!repository || process.argv.length !== 3) {
+	throw new Error('Usage: check-font-files.ts <font-files-repo>');
+}
+
+assertGitPathClean(repository, 'sources');
+const revision = getGitRevision(repository);
+const snapshot = openGitSnapshot(repository, revision);
+const temporary = await mkdtemp(join(tmpdir(), 'fontsource-registry-'));
+const root = join(temporary, 'data');
+
+try {
+	await cp(join(import.meta.dirname, '..', 'data'), root, { recursive: true });
+	const index = registryIndexSchema.parse(
+		await readJson(join(root, 'index.json')),
+	);
+	const languages = languageCatalogSchema.parse(
+		await readJson(join(root, 'languages.json')),
+	);
+	const replacements = replacementRegistrySchema.parse(
+		await readJson(join(root, 'replacements.json')),
+	);
+	const previousFamilyIds = index.families
+		.filter((family) => family.startsWith('fontsource/'))
+		.map((family) => family.slice('fontsource/'.length));
+
+	logger.start(`Checking fontsource/font-files@${revision}`);
+	const familyIds = await generateFontFiles(
+		snapshot,
+		root,
+		previousFamilyIds,
+		languages,
+	);
+	const families = [
+		...index.families.filter((family) => !family.startsWith('fontsource/')),
+		...familyIds.map((family) => `fontsource/${family}`),
+	].toSorted(compareStrings);
+	await writeJson(join(root, 'index.json'), {
+		...index,
+		upstreams: {
+			...index.upstreams,
+			fontFiles: {
+				repository: 'fontsource/font-files',
+				revision,
+			},
+		},
+		families,
+	});
+	await applyReplacements(
+		root,
+		familyIds.map((family) => `fontsource/${family}`),
+		replacements,
+	);
+	await validateRegistry(root);
+	logger.success(`Checked ${familyIds.length} Fontsource font families`);
+} finally {
+	await rm(temporary, { recursive: true, force: true });
+}

--- a/registry/scripts/generate.ts
+++ b/registry/scripts/generate.ts
@@ -22,7 +22,7 @@ import { validateRegistry } from './validator.ts';
 
 const logger = consola.withTag('registry');
 
-const applyReplacements = async (
+export const applyReplacements = async (
 	root: string,
 	families: readonly string[],
 	replacements: ReplacementRegistry,


### PR DESCRIPTION
Depends on #1216

## Overview

Adds a reusable check that ingests the complete font-files corpus into an isolated registry copy. CI sparsely checks out only `sources/` while retaining the Git history required for provenance.