### PR TITLE
feat(registry): add google icon provider

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -41,6 +41,9 @@ jobs:
           # Keep complete history for provenance while hydrating only adapter inputs.
           git clone --filter=blob:none --sparse --single-branch https://github.com/google/fonts.git "$RUNNER_TEMP/google-fonts"
           git -C "$RUNNER_TEMP/google-fonts" sparse-checkout set ofl apache ufl axisregistry tags lang
+          # This repository has millions of paths; the adapter reads its small
+          # font trees directly from Git without populating a working tree.
+          git clone --filter=blob:none --no-checkout --single-branch https://github.com/google/material-design-icons.git "$RUNNER_TEMP/google-icons"
           git clone --no-checkout --single-branch https://github.com/googlefonts/nam-files.git "$RUNNER_TEMP/nam-files"
           git clone --filter=blob:none --sparse --single-branch https://github.com/fontsource/font-files.git "$RUNNER_TEMP/font-files"
           git -C "$RUNNER_TEMP/font-files" sparse-checkout set sources
@@ -48,6 +51,8 @@ jobs:
           pnpm --filter '@fontsource-utils/registry' generate \
             "$RUNNER_TEMP/google-fonts" \
             "$(git -C "$RUNNER_TEMP/google-fonts" rev-parse HEAD)" \
+            "$RUNNER_TEMP/google-icons" \
+            "$(git -C "$RUNNER_TEMP/google-icons" rev-parse HEAD)" \
             "$RUNNER_TEMP/nam-files" \
             "$(git -C "$RUNNER_TEMP/nam-files" rev-parse HEAD)" \
             "$RUNNER_TEMP/font-files" \

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,14 +1,14 @@
 # Registry
 
-This private workspace package maintains Fontsource's text-only font registry.
-It is repository tooling, not a public package.
+This private workspace package maintains Fontsource's font registry as
+text-only metadata. It is repository tooling, not a public package.
 
 ## Commands
 
 Run from the repository root:
 
 ~~~sh
-pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <nam-repo> <nam-commit> <font-files-repo> <font-files-commit>
+pnpm --filter '@fontsource-utils/registry' generate <google-repo> <google-commit> <google-icons-repo> <google-icons-commit> <nam-repo> <nam-commit> <font-files-repo> <font-files-commit>
 pnpm --filter '@fontsource-utils/registry' validate
 pnpm --filter '@fontsource-utils/registry' check:font-files <font-files-repo>
 pnpm --filter '@fontsource-utils/registry' archive
@@ -44,7 +44,7 @@ those responses. The manifest maps every registry file, API view, and source to
 a SHA-256 object and is written before `current.json` selects the complete
 snapshot.
 
-Google sources can be recovered from their pinned GitHub commit.
+Google font and icon sources can be recovered from their pinned GitHub commit.
 Registry-managed sources must already exist at their content-addressed R2 key.
 
 The workflow needs `REGISTRY_R2_ENDPOINT` and bucket-scoped Object Read & Write
@@ -55,6 +55,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 
 - `scripts/generate.ts` coordinates one complete registry build and validation.
 - `scripts/font-files.ts` implements Git-backed Fontsource ingestion.
+- `scripts/google-icons.ts` ingests Material Icons, Material Symbols, and their
+  public name-to-codepoint mappings.
 - `scripts/google.ts` owns `data/families/google/` and writes family metadata,
   discovery metadata, source inspection, documents, licenses, languages, and
   normalized axis metadata.
@@ -65,7 +67,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 - `scripts/schema.ts` defines the Zod contracts; `scripts/validator.ts` checks
   files and cross-file references.
 - `data/families/<provider>/<id>/` contains family records. Family IDs are
-  globally unique across providers.
+  globally unique across providers. Icon families also include `icons.json`
+  with their public names and Unicode codepoints.
 - `data/languages.json` defines semantic languages, public names, and the
   private codepoint requirements used for automatic matching.
 - `data/replacements.json` records reviewed successor relationships between
@@ -79,8 +82,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
 - Output is canonical, deterministic, text-only, and schema-validated.
 - Public API views explicitly map registry records rather than exposing them.
 - Provenance comes from Git history, not prior generated metadata.
-- Each provider owns its directory; Google generation never changes Fontsource
-  records.
+- Each provider owns its directory; one adapter never changes another
+  provider's records.
 - Removed Google families remain buildable but are marked `deprecated`.
 - Replaced families retain their own sources; `replacedBy` recommends an active
   successor and never aliases its binaries.

--- a/registry/data/families/google-icons/material-icons-outlined/description.en-US.md
+++ b/registry/data/families/google-icons/material-icons-outlined/description.en-US.md
@@ -1,0 +1,1 @@
+Material Icons Outlined is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.

--- a/registry/data/families/google-icons/material-icons-outlined/icons.json
+++ b/registry/data/families/google-icons/material-icons-outlined/icons.json
@@ -1,0 +1,8790 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 57744,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 57745,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 57746,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59475,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 61241,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 57747,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 59771,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 57671,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 57672,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 59772,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 57854,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 60054,
+			"name": "adobe"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_off"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_on"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59482,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 61402,
+			"name": "aod"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 61247,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 61249,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 60132,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 60032,
+			"name": "apple"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61250,
+			"name": "article"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 59484,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 58272,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 58273,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 60377,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 60384,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 60381,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 60386,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 60372,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 60370,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 57764,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61252,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 57675,
+			"name": "block"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 57770,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 59493,
+			"name": "book"
+		},
+		{
+			"codepoint": 61975,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 59494,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_outline"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 58278,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 58279,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 59497,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 57519,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 57520,
+			"name": "call"
+		},
+		{
+			"codepoint": 57521,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58288,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 58289,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 58290,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 58825,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 58632,
+			"name": "catching_pokemon"
+		},
+		{
+			"codepoint": 58740,
+			"name": "category"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 61853,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 57527,
+			"name": "chat"
+		},
+		{
+			"codepoint": 57546,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 58826,
+			"name": "check"
+		},
+		{
+			"codepoint": 59444,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 59500,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 59693,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 60226,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 57676,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 57372,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 58045,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 58050,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 58294,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58295,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 57529,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58122,
+			"name": "computer"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_num"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 57551,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 61578,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 61579,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 61592,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 58298,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 61578,
+			"name": "copy"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 57680,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59504,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 58305,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58308,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 57775,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59506,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60018,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 57776,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 58169,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 57777,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 58672,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 58673,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_ferry"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 58675,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61433,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_train"
+		},
+		{
+			"codepoint": 58677,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 60012,
+			"name": "discord"
+		},
+		{
+			"codepoint": 60361,
+			"name": "discount"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 58897,
+			"name": "dnd_forwardslash"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 58898,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 58897,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 58947,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 58948,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 58126,
+			"name": "dock"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 58899,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 58997,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59245,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 61445,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 61446,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 58313,
+			"name": "edit"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57534,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 59930,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 59644,
+			"name": "enhance_photo_translate"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 57344,
+			"name": "error"
+		},
+		{
+			"codepoint": 57345,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 58314,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_minus_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_minus_2"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 58317,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 59516,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62004,
+			"name": "facebook"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 59517,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_outline"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 58052,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 59818,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 58054,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 63729,
+			"name": "fire_hydrant_alt"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 59435,
+			"name": "fitbit"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 57683,
+			"name": "flag"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 61453,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 61453,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61455,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underline"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 57535,
+			"name": "forum"
+		},
+		{
+			"codepoint": 57684,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 57377,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 59524,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 57779,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57780,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57781,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 59525,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 59375,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 58128,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 59527,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_remove"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59529,
+			"name": "history"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59530,
+			"name": "home"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 59913,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58682,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59533,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 58357,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 57539,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 57931,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 57962,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 57933,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 57934,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 57935,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 57937,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 60274,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors_on"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 60139,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60129,
+			"name": "keyboard_control"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 59538,
+			"name": "label"
+		},
+		{
+			"codepoint": 59703,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58359,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59540,
+			"name": "language"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59541,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 62011,
+			"name": "leave_bags_at_home"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 57390,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 57584,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57687,
+			"name": "link"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 57582,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58937,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_attraction"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 58689,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 58695,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 58701,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 58702,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 58705,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_print_shop"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_restaurant"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 58714,
+			"name": "location_history"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 57544,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 59543,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 57384,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 57688,
+			"name": "mail"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 57569,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57546,
+			"name": "messenger"
+		},
+		{
+			"codepoint": 57547,
+			"name": "messenger_outline"
+		},
+		{
+			"codepoint": 57385,
+			"name": "mic"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 57386,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61708,
+			"name": "miscellaneous_services"
+		},
+		{
+			"codepoint": 57459,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 57856,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 57575,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 57940,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61493,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 57948,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 59378,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 60129,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 59842,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 57388,
+			"name": "movie"
+		},
+		{
+			"codepoint": 58372,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 57784,
+			"name": "multitrack_audio"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 57390,
+			"name": "my_library_add"
+		},
+		{
+			"codepoint": 57391,
+			"name": "my_library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "my_library_music"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58376,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58377,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 57393,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61278,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 59974,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 61860,
+			"name": "no_cell"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 58945,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57548,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 57395,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 57455,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59380,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_on"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 59231,
+			"name": "now_wallpaper"
+		},
+		{
+			"codepoint": 59230,
+			"name": "now_widgets"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 59845,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 61992,
+			"name": "outbond"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 57710,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 58379,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fisheye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 61280,
+			"name": "panorama_horizontal_select"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 59850,
+			"name": "panorama_photosphere_select"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 61281,
+			"name": "panorama_vertical_select"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 61282,
+			"name": "panorama_wide_angle_select"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 61592,
+			"name": "paste"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57397,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57398,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60045,
+			"name": "paypal"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59387,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59388,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_cal"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_info"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 59558,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 59389,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59390,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 61285,
+			"name": "person_add_alt_1"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 59391,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61287,
+			"name": "person_remove_alt_1"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 57549,
+			"name": "phone"
+		},
+		{
+			"codepoint": 58148,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 58149,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 57563,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 57564,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 58151,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 57565,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 57566,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 58384,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 58418,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 59076,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61508,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 60067,
+			"name": "pix"
+		},
+		{
+			"codepoint": 58719,
+			"name": "place"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_fill"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_filled"
+		},
+		{
+			"codepoint": 57401,
+			"name": "play_circle_outline"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 59393,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 57550,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 58390,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 59564,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 59678,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 59566,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 57551,
+			"name": "quick_contacts_dialer"
+		},
+		{
+			"codepoint": 57552,
+			"name": "quick_contacts_mail"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 60056,
+			"name": "quora"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_off"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_on"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 60064,
+			"name": "reddit"
+		},
+		{
+			"codepoint": 59569,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 57692,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 57693,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 58391,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 57696,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 59570,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 61524,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 57553,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 59572,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 57713,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 59573,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 57790,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 57791,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 57792,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 57793,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 57794,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59574,
+			"name": "search"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 61528,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61529,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 61530,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 61532,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 57581,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 59580,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_display"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59584,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58660,
+			"name": "share_arrival_time"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 57758,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 60061,
+			"name": "shopify"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 61536,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 57816,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57817,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61539,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61542,
+			"name": "signal_wifi_statusbar_connected_no_internet_4"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 58916,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 61547,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 58156,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 58918,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 60014,
+			"name": "snapchat"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61892,
+			"name": "source"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 59448,
+			"name": "star"
+		},
+		{
+			"codepoint": 59450,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61593,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61551,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 57555,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 57556,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 57557,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 57558,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 58723,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vert_circle"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 61554,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 61556,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 58922,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_tv"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 58400,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 58923,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 60011,
+			"name": "telegram"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 57560,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 59611,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 59414,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 59890,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 59612,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 59415,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 59891,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 60030,
+			"name": "tiktok"
+		},
+		{
+			"codepoint": 58924,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_neutral"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59622,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58163,
+			"name": "tv"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 59624,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 58925,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_collection"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfortable"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 59902,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 59638,
+			"name": "wallet_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "wallet_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "wallet_travel"
+		},
+		{
+			"codepoint": 59231,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 57346,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 59684,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 58413,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 58422,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 57425,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 58615,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 60033,
+			"name": "wechat"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 59230,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61573,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error_rounded"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 60013,
+			"name": "woo_commerce"
+		},
+		{
+			"codepoint": 60063,
+			"name": "wordpress"
+		},
+		{
+			"codepoint": 59641,
+			"name": "work"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 57760,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "font/MaterialIconsOutlined-Regular.codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"sha256": "c57e7279a7ef29925cd98e538c618a037a42b43120576f4660a6732c7a5a4d4a"
+	}
+}

--- a/registry/data/families/google-icons/material-icons-outlined/inspection.json
+++ b/registry/data/families/google-icons/material-icons-outlined/inspection.json
@@ -1,0 +1,17 @@
+{
+	"files": [
+		{
+			"axes": [],
+			"cmap": {
+				"codepointCount": 2195,
+				"sha256": "f27c76d1a3132d9fe140fee2702ffc5dcbddc4247130ea095b089809fe571403"
+			},
+			"colorTables": [],
+			"fontVersion": "2022-08-02T22:00:24.736834",
+			"outline": "cff",
+			"path": "font/MaterialIconsOutlined-Regular.otf",
+			"style": "normal",
+			"weight": 400
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-icons-outlined/license.txt
+++ b/registry/data/families/google-icons/material-icons-outlined/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-icons-outlined/metadata.json
+++ b/registry/data/families/google-icons/material-icons-outlined/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Icons Outlined",
+	"id": "material-icons-outlined",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "font",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "font/MaterialIconsOutlined-Regular.otf",
+			"sha256": "b63fa9edd75e3c20328e04ad31dcc38ce76411f3f9ea1a1ff87f49e5ba874b05",
+			"size": 339168,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2022-09-19",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-icons-round/description.en-US.md
+++ b/registry/data/families/google-icons/material-icons-round/description.en-US.md
@@ -1,0 +1,1 @@
+Material Icons Round is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.

--- a/registry/data/families/google-icons/material-icons-round/icons.json
+++ b/registry/data/families/google-icons/material-icons-round/icons.json
@@ -1,0 +1,8810 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 57744,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 57745,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 57746,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59475,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 61241,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 57747,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 59771,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 57671,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 57672,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 59772,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 57854,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 60054,
+			"name": "adobe"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_off"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_on"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59482,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 61402,
+			"name": "aod"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 61247,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 61249,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 60132,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 60032,
+			"name": "apple"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61250,
+			"name": "article"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 59484,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 58272,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 58273,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 60377,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 60384,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 60381,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 60386,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 60372,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 60370,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 57764,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61252,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 57675,
+			"name": "block"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 57770,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 59493,
+			"name": "book"
+		},
+		{
+			"codepoint": 61975,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 59494,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_outline"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 58278,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 58279,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 59497,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 57519,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 57520,
+			"name": "call"
+		},
+		{
+			"codepoint": 57521,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58288,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 58289,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 58290,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 58825,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 58632,
+			"name": "catching_pokemon"
+		},
+		{
+			"codepoint": 58740,
+			"name": "category"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 61853,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 57527,
+			"name": "chat"
+		},
+		{
+			"codepoint": 57546,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 58826,
+			"name": "check"
+		},
+		{
+			"codepoint": 59444,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 59500,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 59693,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 60226,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 57676,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 57372,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 58045,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 58050,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 58294,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58295,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 57529,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58122,
+			"name": "computer"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_num"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 57551,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 61578,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 61579,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 61592,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 58298,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 61578,
+			"name": "copy"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 57680,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59504,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 58305,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58308,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 57775,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59506,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60018,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 57776,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 58169,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 57777,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 58672,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 58673,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_ferry"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 58675,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61433,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_train"
+		},
+		{
+			"codepoint": 58677,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 60012,
+			"name": "discord"
+		},
+		{
+			"codepoint": 60361,
+			"name": "discount"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 58897,
+			"name": "dnd_forwardslash"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 58898,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 58897,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 58947,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 58948,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 58126,
+			"name": "dock"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 58899,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 58997,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59245,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 61445,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 61446,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 58313,
+			"name": "edit"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57534,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 59930,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 59644,
+			"name": "enhance_photo_translate"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 57344,
+			"name": "error"
+		},
+		{
+			"codepoint": 57345,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 58314,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_minus_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_minus_2"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 58317,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 59516,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62004,
+			"name": "facebook"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 59517,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_outline"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 58052,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 59818,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 58054,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 63729,
+			"name": "fire_hydrant_alt"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 59435,
+			"name": "fitbit"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 57683,
+			"name": "flag"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 61453,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 61453,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61455,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underline"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 57535,
+			"name": "forum"
+		},
+		{
+			"codepoint": 57684,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 57377,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 59524,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 57779,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57780,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57781,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 59525,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 59375,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 58128,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 59527,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_remove"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59529,
+			"name": "history"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59530,
+			"name": "home"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 59913,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58682,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59533,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 58357,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 57539,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 59535,
+			"name": "info_outline"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 57931,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 57962,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 57933,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 57934,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 57935,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 57937,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 60274,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors_on"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 60139,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60129,
+			"name": "keyboard_control"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 59538,
+			"name": "label"
+		},
+		{
+			"codepoint": 59703,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58359,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59540,
+			"name": "language"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59541,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 62011,
+			"name": "leave_bags_at_home"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 57390,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 57584,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57687,
+			"name": "link"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 57582,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58937,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_attraction"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 58689,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 58695,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 58701,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 58702,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 58705,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_print_shop"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_restaurant"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 58714,
+			"name": "location_history"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 57544,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 59543,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 57384,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 57688,
+			"name": "mail"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 57569,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57546,
+			"name": "messenger"
+		},
+		{
+			"codepoint": 57547,
+			"name": "messenger_outline"
+		},
+		{
+			"codepoint": 57385,
+			"name": "mic"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 57386,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61708,
+			"name": "miscellaneous_services"
+		},
+		{
+			"codepoint": 57459,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 57856,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 57575,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 57940,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61493,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 57948,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 59378,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 60129,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 59842,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 57388,
+			"name": "movie"
+		},
+		{
+			"codepoint": 58372,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 57784,
+			"name": "multitrack_audio"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 57390,
+			"name": "my_library_add"
+		},
+		{
+			"codepoint": 57391,
+			"name": "my_library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "my_library_music"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58376,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58377,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 57393,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61278,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 59974,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 61860,
+			"name": "no_cell"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 58945,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57548,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 57395,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 57455,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59380,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_on"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 59231,
+			"name": "now_wallpaper"
+		},
+		{
+			"codepoint": 59230,
+			"name": "now_widgets"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 59845,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 61992,
+			"name": "outbond"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 57710,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 58379,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fisheye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 61280,
+			"name": "panorama_horizontal_select"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 59850,
+			"name": "panorama_photosphere_select"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 61281,
+			"name": "panorama_vertical_select"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 61282,
+			"name": "panorama_wide_angle_select"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 61592,
+			"name": "paste"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57397,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57398,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60045,
+			"name": "paypal"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59387,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59388,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_cal"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_info"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 59558,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 59389,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59390,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 61285,
+			"name": "person_add_alt_1"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 59391,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61287,
+			"name": "person_remove_alt_1"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 57549,
+			"name": "phone"
+		},
+		{
+			"codepoint": 58148,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 58149,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 57563,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 57564,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 58151,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 57565,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 57566,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 58384,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 58418,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 59076,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61508,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 60067,
+			"name": "pix"
+		},
+		{
+			"codepoint": 58719,
+			"name": "place"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_fill"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_filled"
+		},
+		{
+			"codepoint": 57401,
+			"name": "play_circle_outline"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 59393,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 57550,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 58390,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 59564,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 59678,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 59566,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 57551,
+			"name": "quick_contacts_dialer"
+		},
+		{
+			"codepoint": 57552,
+			"name": "quick_contacts_mail"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 60056,
+			"name": "quora"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_off"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_on"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 60064,
+			"name": "reddit"
+		},
+		{
+			"codepoint": 59569,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 57692,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 57693,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 58391,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 57696,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 59570,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 61524,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 57553,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 59572,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 57713,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 59573,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 57790,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 57791,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 57792,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 57793,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 57794,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59574,
+			"name": "search"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 61528,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61529,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 61530,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 61532,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 57581,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 59580,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_display"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59584,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58660,
+			"name": "share_arrival_time"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 57758,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 60061,
+			"name": "shopify"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 61536,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 57816,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57817,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61539,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61542,
+			"name": "signal_wifi_statusbar_connected_no_internet_4"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 58916,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 61547,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 58156,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 58918,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 60014,
+			"name": "snapchat"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61892,
+			"name": "source"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 59448,
+			"name": "star"
+		},
+		{
+			"codepoint": 59450,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61593,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61551,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 57555,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 57556,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 57557,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 57558,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 58723,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vert_circle"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 61554,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 61556,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 58922,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_tv"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 58400,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 58923,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 60011,
+			"name": "telegram"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 57560,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 59611,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 59414,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 59890,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 59612,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 59415,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 59891,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 60030,
+			"name": "tiktok"
+		},
+		{
+			"codepoint": 58924,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_neutral"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59622,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58163,
+			"name": "tv"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 59624,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 58925,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_collection"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfortable"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 59902,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 59638,
+			"name": "wallet_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "wallet_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "wallet_travel"
+		},
+		{
+			"codepoint": 59231,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 57346,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 59684,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 58413,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 58422,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 57425,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 58615,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 60033,
+			"name": "wechat"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 59230,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61573,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error_rounded"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 60013,
+			"name": "woo_commerce"
+		},
+		{
+			"codepoint": 60063,
+			"name": "wordpress"
+		},
+		{
+			"codepoint": 59641,
+			"name": "work"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 57760,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "font/MaterialIconsRound-Regular.codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"sha256": "534fc87caafe6c7529a390fbe5b669c158d560caa5e9358c8e49054b817603d8"
+	}
+}

--- a/registry/data/families/google-icons/material-icons-round/inspection.json
+++ b/registry/data/families/google-icons/material-icons-round/inspection.json
@@ -1,0 +1,17 @@
+{
+	"files": [
+		{
+			"axes": [],
+			"cmap": {
+				"codepointCount": 2200,
+				"sha256": "406d8138c0bab939751ce6189ed07bf4851ad6e112404ad6e4e7198a9009cd7c"
+			},
+			"colorTables": [],
+			"fontVersion": "2022-08-02T22:00:44.367947",
+			"outline": "cff",
+			"path": "font/MaterialIconsRound-Regular.otf",
+			"style": "normal",
+			"weight": 400
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-icons-round/license.txt
+++ b/registry/data/families/google-icons/material-icons-round/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-icons-round/metadata.json
+++ b/registry/data/families/google-icons/material-icons-round/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Icons Round",
+	"id": "material-icons-round",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "font",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "font/MaterialIconsRound-Regular.otf",
+			"sha256": "bad85e5454b6288104ce03806c37323bcd8f145e3094e727860173ac8c91062e",
+			"size": 400092,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2022-09-19",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-icons-sharp/description.en-US.md
+++ b/registry/data/families/google-icons/material-icons-sharp/description.en-US.md
@@ -1,0 +1,1 @@
+Material Icons Sharp is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.

--- a/registry/data/families/google-icons/material-icons-sharp/icons.json
+++ b/registry/data/families/google-icons/material-icons-sharp/icons.json
@@ -1,0 +1,8810 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 57744,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 57745,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 57746,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59475,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 61241,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 57747,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 59771,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 57671,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 57672,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 59772,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 57854,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 60054,
+			"name": "adobe"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_off"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_on"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59482,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 61402,
+			"name": "aod"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 61247,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 61249,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 60132,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 60032,
+			"name": "apple"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61250,
+			"name": "article"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 59484,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 58272,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 58273,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 60377,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 60384,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 60381,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 60386,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 60372,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 60370,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 57764,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61252,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 57675,
+			"name": "block"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 57770,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 59493,
+			"name": "book"
+		},
+		{
+			"codepoint": 61975,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 59494,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_outline"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 58278,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 58279,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 59497,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 57519,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 57520,
+			"name": "call"
+		},
+		{
+			"codepoint": 57521,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58288,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 58289,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 58290,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 58825,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 58632,
+			"name": "catching_pokemon"
+		},
+		{
+			"codepoint": 58740,
+			"name": "category"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 61853,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 57527,
+			"name": "chat"
+		},
+		{
+			"codepoint": 57546,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 58826,
+			"name": "check"
+		},
+		{
+			"codepoint": 59444,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 59500,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 59693,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 60226,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 57676,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 57372,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 58045,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 58050,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 58294,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58295,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 57529,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58122,
+			"name": "computer"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_num"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 57551,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 61578,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 61579,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 61592,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 58298,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 61578,
+			"name": "copy"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 57680,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59504,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 58305,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58308,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 57775,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59506,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60018,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 57776,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 58169,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 57777,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 58672,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 58673,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_ferry"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 58675,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61433,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_train"
+		},
+		{
+			"codepoint": 58677,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 60012,
+			"name": "discord"
+		},
+		{
+			"codepoint": 60361,
+			"name": "discount"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 58897,
+			"name": "dnd_forwardslash"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 58898,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 58897,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 58947,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 58948,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 58126,
+			"name": "dock"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 58899,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 58997,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59245,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 61445,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 61446,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 58313,
+			"name": "edit"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57534,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 59930,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 59644,
+			"name": "enhance_photo_translate"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 57344,
+			"name": "error"
+		},
+		{
+			"codepoint": 57345,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 58314,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_minus_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_minus_2"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 58317,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 59516,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62004,
+			"name": "facebook"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 59517,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_outline"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 58052,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 59818,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 58054,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 63729,
+			"name": "fire_hydrant_alt"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 59435,
+			"name": "fitbit"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 57683,
+			"name": "flag"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 61453,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 61453,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61455,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underline"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 57535,
+			"name": "forum"
+		},
+		{
+			"codepoint": 57684,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 57377,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 59524,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 57779,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57780,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57781,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 59525,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 59375,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 58128,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 59527,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_remove"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59529,
+			"name": "history"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59530,
+			"name": "home"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 59913,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58682,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59533,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 58357,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 57539,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 59535,
+			"name": "info_outline"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 57931,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 57962,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 57933,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 57934,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 57935,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 57937,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 60274,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors_on"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 60139,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60129,
+			"name": "keyboard_control"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 59538,
+			"name": "label"
+		},
+		{
+			"codepoint": 59703,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58359,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59540,
+			"name": "language"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59541,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 62011,
+			"name": "leave_bags_at_home"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 57390,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 57584,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57687,
+			"name": "link"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 57582,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58937,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_attraction"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 58689,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 58695,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 58701,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 58702,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 58705,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_print_shop"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_restaurant"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 58714,
+			"name": "location_history"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 57544,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 59543,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 57384,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 57688,
+			"name": "mail"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 57569,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57546,
+			"name": "messenger"
+		},
+		{
+			"codepoint": 57547,
+			"name": "messenger_outline"
+		},
+		{
+			"codepoint": 57385,
+			"name": "mic"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 57386,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61708,
+			"name": "miscellaneous_services"
+		},
+		{
+			"codepoint": 57459,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 57856,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 57575,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 57940,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61493,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 57948,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 59378,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 60129,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 59842,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 57388,
+			"name": "movie"
+		},
+		{
+			"codepoint": 58372,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 57784,
+			"name": "multitrack_audio"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 57390,
+			"name": "my_library_add"
+		},
+		{
+			"codepoint": 57391,
+			"name": "my_library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "my_library_music"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58376,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58377,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 57393,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61278,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 59974,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 61860,
+			"name": "no_cell"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 58945,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57548,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 57395,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 57455,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59380,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_on"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 59231,
+			"name": "now_wallpaper"
+		},
+		{
+			"codepoint": 59230,
+			"name": "now_widgets"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 59845,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 61992,
+			"name": "outbond"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 57710,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 58379,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fisheye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 61280,
+			"name": "panorama_horizontal_select"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 59850,
+			"name": "panorama_photosphere_select"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 61281,
+			"name": "panorama_vertical_select"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 61282,
+			"name": "panorama_wide_angle_select"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 61592,
+			"name": "paste"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57397,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57398,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60045,
+			"name": "paypal"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59387,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59388,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_cal"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_info"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 59558,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 59389,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59390,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 61285,
+			"name": "person_add_alt_1"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 59391,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61287,
+			"name": "person_remove_alt_1"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 57549,
+			"name": "phone"
+		},
+		{
+			"codepoint": 58148,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 58149,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 57563,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 57564,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 58151,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 57565,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 57566,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 58384,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 58418,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 59076,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61508,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 60067,
+			"name": "pix"
+		},
+		{
+			"codepoint": 58719,
+			"name": "place"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_fill"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_filled"
+		},
+		{
+			"codepoint": 57401,
+			"name": "play_circle_outline"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 59393,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 57550,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 58390,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 59564,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 59678,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 59566,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 57551,
+			"name": "quick_contacts_dialer"
+		},
+		{
+			"codepoint": 57552,
+			"name": "quick_contacts_mail"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 60056,
+			"name": "quora"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_off"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_on"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 60064,
+			"name": "reddit"
+		},
+		{
+			"codepoint": 59569,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 57692,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 57693,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 58391,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 57696,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 59570,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 61524,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 57553,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 59572,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 57713,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 59573,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 57790,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 57791,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 57792,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 57793,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 57794,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59574,
+			"name": "search"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 61528,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61529,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 61530,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 61532,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 57581,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 59580,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_display"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59584,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58660,
+			"name": "share_arrival_time"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 57758,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 60061,
+			"name": "shopify"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 61536,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 57816,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57817,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61539,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61542,
+			"name": "signal_wifi_statusbar_connected_no_internet_4"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 58916,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 61547,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 58156,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 58918,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 60014,
+			"name": "snapchat"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61892,
+			"name": "source"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 59448,
+			"name": "star"
+		},
+		{
+			"codepoint": 59450,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61593,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61551,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 57555,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 57556,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 57557,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 57558,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 58723,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vert_circle"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 61554,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 61556,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 58922,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_tv"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 58400,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 58923,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 60011,
+			"name": "telegram"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 57560,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 59611,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 59414,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 59890,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 59612,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 59415,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 59891,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 60030,
+			"name": "tiktok"
+		},
+		{
+			"codepoint": 58924,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_neutral"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59622,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58163,
+			"name": "tv"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 59624,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 58925,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_collection"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfortable"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 59902,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 59638,
+			"name": "wallet_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "wallet_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "wallet_travel"
+		},
+		{
+			"codepoint": 59231,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 57346,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 59684,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 58413,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 58422,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 57425,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 58615,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 60033,
+			"name": "wechat"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 59230,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61573,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error_rounded"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 60013,
+			"name": "woo_commerce"
+		},
+		{
+			"codepoint": 60063,
+			"name": "wordpress"
+		},
+		{
+			"codepoint": 59641,
+			"name": "work"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 57760,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "font/MaterialIconsSharp-Regular.codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"sha256": "534fc87caafe6c7529a390fbe5b669c158d560caa5e9358c8e49054b817603d8"
+	}
+}

--- a/registry/data/families/google-icons/material-icons-sharp/inspection.json
+++ b/registry/data/families/google-icons/material-icons-sharp/inspection.json
@@ -1,0 +1,17 @@
+{
+	"files": [
+		{
+			"axes": [],
+			"cmap": {
+				"codepointCount": 2200,
+				"sha256": "406d8138c0bab939751ce6189ed07bf4851ad6e112404ad6e4e7198a9009cd7c"
+			},
+			"colorTables": [],
+			"fontVersion": "2022-08-02T22:01:04.450499",
+			"outline": "cff",
+			"path": "font/MaterialIconsSharp-Regular.otf",
+			"style": "normal",
+			"weight": 400
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-icons-sharp/license.txt
+++ b/registry/data/families/google-icons/material-icons-sharp/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-icons-sharp/metadata.json
+++ b/registry/data/families/google-icons/material-icons-sharp/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Icons Sharp",
+	"id": "material-icons-sharp",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "font",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "font/MaterialIconsSharp-Regular.otf",
+			"sha256": "095a95043a8574c90770ecdc0af53f8b8b5043a816320107e55e2d237d8ff9de",
+			"size": 286012,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2022-09-19",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-icons-two-tone/description.en-US.md
+++ b/registry/data/families/google-icons/material-icons-two-tone/description.en-US.md
@@ -1,0 +1,1 @@
+Material Icons Two Tone is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.

--- a/registry/data/families/google-icons/material-icons-two-tone/icons.json
+++ b/registry/data/families/google-icons/material-icons-two-tone/icons.json
@@ -1,0 +1,8962 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 57744,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 57745,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 57746,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59475,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 61241,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 57747,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 59771,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 57671,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 57672,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 59772,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 57854,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 60054,
+			"name": "adobe"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_off"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_on"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59482,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 61402,
+			"name": "aod"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 61247,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 61249,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 60132,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 60032,
+			"name": "apple"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61250,
+			"name": "article"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 59484,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 58272,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 58273,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 60377,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_20"
+		},
+		{
+			"codepoint": 60384,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_30"
+		},
+		{
+			"codepoint": 60381,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 60386,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_50"
+		},
+		{
+			"codepoint": 60372,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_60"
+		},
+		{
+			"codepoint": 60370,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_80"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_90"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 61602,
+			"name": "battery_charging_20"
+		},
+		{
+			"codepoint": 61603,
+			"name": "battery_charging_30"
+		},
+		{
+			"codepoint": 61604,
+			"name": "battery_charging_50"
+		},
+		{
+			"codepoint": 61605,
+			"name": "battery_charging_60"
+		},
+		{
+			"codepoint": 61606,
+			"name": "battery_charging_80"
+		},
+		{
+			"codepoint": 61607,
+			"name": "battery_charging_90"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 57764,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61252,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 57675,
+			"name": "block"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 57770,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 59493,
+			"name": "book"
+		},
+		{
+			"codepoint": 61975,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 59494,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_outline"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 58278,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 58279,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 59497,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 57519,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 57520,
+			"name": "call"
+		},
+		{
+			"codepoint": 57521,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58288,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 58289,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 58290,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 58825,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 58632,
+			"name": "catching_pokemon"
+		},
+		{
+			"codepoint": 58740,
+			"name": "category"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 61853,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 57527,
+			"name": "chat"
+		},
+		{
+			"codepoint": 57546,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 58826,
+			"name": "check"
+		},
+		{
+			"codepoint": 59444,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 59500,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 59693,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 60226,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 57676,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 57372,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 58045,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 58050,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 58294,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58295,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 57529,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58122,
+			"name": "computer"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_num"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 57551,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 61578,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 61579,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 61592,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 58298,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 61578,
+			"name": "copy"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 57680,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59504,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 58305,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58308,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 57775,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59506,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60018,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 57776,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 58169,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 57777,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 58672,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 58673,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_ferry"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 58675,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61433,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_train"
+		},
+		{
+			"codepoint": 58677,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 60012,
+			"name": "discord"
+		},
+		{
+			"codepoint": 60361,
+			"name": "discount"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 58897,
+			"name": "dnd_forwardslash"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 58898,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 58897,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 58947,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 58948,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 58126,
+			"name": "dock"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 58899,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 58997,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59245,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 61445,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 61446,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 58313,
+			"name": "edit"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57534,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 59930,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 59644,
+			"name": "enhance_photo_translate"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 57344,
+			"name": "error"
+		},
+		{
+			"codepoint": 57345,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 58314,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_minus_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_minus_2"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 58317,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 59516,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62004,
+			"name": "facebook"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 59517,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_outline"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 58052,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 59818,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 58054,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 63729,
+			"name": "fire_hydrant_alt"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 59435,
+			"name": "fitbit"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 57683,
+			"name": "flag"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 61453,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 61453,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61455,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underline"
+		},
+		{
+			"codepoint": 59237,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 57535,
+			"name": "forum"
+		},
+		{
+			"codepoint": 57684,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 57377,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 59524,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 57779,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57780,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57781,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 59525,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 59375,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 58128,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 59527,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_remove"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59529,
+			"name": "history"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59530,
+			"name": "home"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 59913,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58682,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59533,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 58357,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 57539,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 59535,
+			"name": "info_outline"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 57931,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 57962,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 57933,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 57934,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 57935,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 57937,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 60274,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors_on"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 60139,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60129,
+			"name": "keyboard_control"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 59538,
+			"name": "label"
+		},
+		{
+			"codepoint": 59703,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58359,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59540,
+			"name": "language"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59541,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 62011,
+			"name": "leave_bags_at_home"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 57390,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 57584,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57687,
+			"name": "link"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 57582,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58937,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_attraction"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 58689,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 58695,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 58701,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 58702,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 58705,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_print_shop"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_restaurant"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 58714,
+			"name": "location_history"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 57544,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 59543,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 57384,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 57688,
+			"name": "mail"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 57569,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57546,
+			"name": "messenger"
+		},
+		{
+			"codepoint": 57547,
+			"name": "messenger_outline"
+		},
+		{
+			"codepoint": 57385,
+			"name": "mic"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 57386,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61708,
+			"name": "miscellaneous_services"
+		},
+		{
+			"codepoint": 57459,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 57856,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 57575,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 57940,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61493,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 57948,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 59378,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 60129,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 59842,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 57388,
+			"name": "movie"
+		},
+		{
+			"codepoint": 58372,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 57784,
+			"name": "multitrack_audio"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 57390,
+			"name": "my_library_add"
+		},
+		{
+			"codepoint": 57391,
+			"name": "my_library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "my_library_music"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58376,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58377,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 57393,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61278,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 59974,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 61860,
+			"name": "no_cell"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 58945,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57548,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 57395,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 57455,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59380,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_on"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 59231,
+			"name": "now_wallpaper"
+		},
+		{
+			"codepoint": 59230,
+			"name": "now_widgets"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 59845,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 61992,
+			"name": "outbond"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 57710,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 58379,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fisheye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 61280,
+			"name": "panorama_horizontal_select"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 59850,
+			"name": "panorama_photosphere_select"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 61281,
+			"name": "panorama_vertical_select"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 61282,
+			"name": "panorama_wide_angle_select"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 61592,
+			"name": "paste"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57397,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57398,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60045,
+			"name": "paypal"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59387,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59388,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_cal"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_info"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 59558,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 59389,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59390,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 61285,
+			"name": "person_add_alt_1"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 59391,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61287,
+			"name": "person_remove_alt_1"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 57549,
+			"name": "phone"
+		},
+		{
+			"codepoint": 58148,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 58149,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 57563,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 57564,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 58151,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 57565,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 57566,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 58384,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 58418,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 59076,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61508,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 60067,
+			"name": "pix"
+		},
+		{
+			"codepoint": 58719,
+			"name": "place"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_fill"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_filled"
+		},
+		{
+			"codepoint": 57401,
+			"name": "play_circle_outline"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 59393,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 57550,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 58390,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 59564,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 59678,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 59566,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 57551,
+			"name": "quick_contacts_dialer"
+		},
+		{
+			"codepoint": 57552,
+			"name": "quick_contacts_mail"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 60056,
+			"name": "quora"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_off"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_on"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 60064,
+			"name": "reddit"
+		},
+		{
+			"codepoint": 59569,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 57692,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 57693,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 58391,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 57696,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 59570,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 61524,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 57553,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 59572,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 57713,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 59573,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 57790,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 57791,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 57792,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 57793,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 57794,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59574,
+			"name": "search"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 61528,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61529,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 61530,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 61532,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 57581,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 59580,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_display"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59584,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58660,
+			"name": "share_arrival_time"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 57758,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 60061,
+			"name": "shopify"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 61536,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 61609,
+			"name": "signal_cellular_1_bar"
+		},
+		{
+			"codepoint": 61610,
+			"name": "signal_cellular_2_bar"
+		},
+		{
+			"codepoint": 61611,
+			"name": "signal_cellular_3_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 61613,
+			"name": "signal_cellular_connected_no_internet_1_bar"
+		},
+		{
+			"codepoint": 61614,
+			"name": "signal_cellular_connected_no_internet_2_bar"
+		},
+		{
+			"codepoint": 61615,
+			"name": "signal_cellular_connected_no_internet_3_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 61617,
+			"name": "signal_wifi_1_bar"
+		},
+		{
+			"codepoint": 61618,
+			"name": "signal_wifi_1_bar_lock"
+		},
+		{
+			"codepoint": 61619,
+			"name": "signal_wifi_2_bar"
+		},
+		{
+			"codepoint": 61620,
+			"name": "signal_wifi_2_bar_lock"
+		},
+		{
+			"codepoint": 61621,
+			"name": "signal_wifi_3_bar"
+		},
+		{
+			"codepoint": 61622,
+			"name": "signal_wifi_3_bar_lock"
+		},
+		{
+			"codepoint": 57816,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57817,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61539,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61682,
+			"name": "signal_wifi_connected_no_internet_0"
+		},
+		{
+			"codepoint": 61678,
+			"name": "signal_wifi_connected_no_internet_1"
+		},
+		{
+			"codepoint": 61681,
+			"name": "signal_wifi_connected_no_internet_2"
+		},
+		{
+			"codepoint": 61677,
+			"name": "signal_wifi_connected_no_internet_3"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61670,
+			"name": "signal_wifi_statusbar_1_bar"
+		},
+		{
+			"codepoint": 61680,
+			"name": "signal_wifi_statusbar_2_bar"
+		},
+		{
+			"codepoint": 61674,
+			"name": "signal_wifi_statusbar_3_bar"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61688,
+			"name": "signal_wifi_statusbar_connected_no_internet"
+		},
+		{
+			"codepoint": 61673,
+			"name": "signal_wifi_statusbar_connected_no_internet_1"
+		},
+		{
+			"codepoint": 61687,
+			"name": "signal_wifi_statusbar_connected_no_internet_2"
+		},
+		{
+			"codepoint": 61672,
+			"name": "signal_wifi_statusbar_connected_no_internet_3"
+		},
+		{
+			"codepoint": 61542,
+			"name": "signal_wifi_statusbar_connected_no_internet_4"
+		},
+		{
+			"codepoint": 61679,
+			"name": "signal_wifi_statusbar_not_connected"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 58916,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 61547,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 58156,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 58918,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 60014,
+			"name": "snapchat"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61892,
+			"name": "source"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 59448,
+			"name": "star"
+		},
+		{
+			"codepoint": 59450,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61593,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61551,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 57555,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 57556,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 57557,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 57558,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 58723,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vert_circle"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 61554,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 61556,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 58922,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_tv"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 58400,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 58923,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 60011,
+			"name": "telegram"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 57560,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 59611,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 59414,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 59890,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 59612,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 59415,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 59891,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 60030,
+			"name": "tiktok"
+		},
+		{
+			"codepoint": 58924,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_neutral"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59622,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58163,
+			"name": "tv"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 59624,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 58925,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_collection"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfortable"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 59902,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 59638,
+			"name": "wallet_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "wallet_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "wallet_travel"
+		},
+		{
+			"codepoint": 59231,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 57346,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 59684,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 58413,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 58422,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 57425,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 58615,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 60033,
+			"name": "wechat"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 59230,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_1"
+		},
+		{
+			"codepoint": 61686,
+			"name": "wifi_calling_2"
+		},
+		{
+			"codepoint": 61573,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error_rounded"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 60013,
+			"name": "woo_commerce"
+		},
+		{
+			"codepoint": 60063,
+			"name": "wordpress"
+		},
+		{
+			"codepoint": 59641,
+			"name": "work"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 57760,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "font/MaterialIconsTwoTone-Regular.codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"sha256": "94dec6e86fb1263300bd7dbd0af2b55c9cecd1cfdfcf19df0816db8f303ba26e"
+	}
+}

--- a/registry/data/families/google-icons/material-icons-two-tone/inspection.json
+++ b/registry/data/families/google-icons/material-icons-two-tone/inspection.json
@@ -1,0 +1,20 @@
+{
+	"files": [
+		{
+			"axes": [],
+			"cmap": {
+				"codepointCount": 2238,
+				"sha256": "d43ceb57065fd31be54349b1ca24d00bac49f95087559448aff0d6d25baf84de"
+			},
+			"colorTables": [
+				"COLR",
+				"CPAL"
+			],
+			"fontVersion": "2022-08-03T09:48:23.867249",
+			"outline": "cff",
+			"path": "font/MaterialIconsTwoTone-Regular.otf",
+			"style": "normal",
+			"weight": 400
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-icons-two-tone/license.txt
+++ b/registry/data/families/google-icons/material-icons-two-tone/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-icons-two-tone/metadata.json
+++ b/registry/data/families/google-icons/material-icons-two-tone/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Icons Two Tone",
+	"id": "material-icons-two-tone",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "font",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "font/MaterialIconsTwoTone-Regular.otf",
+			"sha256": "03ccf13774af5b5cbbad641dfa33038d4e9f4b7979eedc2c0a15f06bf9eb33cd",
+			"size": 675852,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2022-09-19",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-icons/description.en-US.md
+++ b/registry/data/families/google-icons/material-icons/description.en-US.md
@@ -1,0 +1,1 @@
+Material Icons is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.

--- a/registry/data/families/google-icons/material-icons/icons.json
+++ b/registry/data/families/google-icons/material-icons/icons.json
@@ -1,0 +1,8950 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 57744,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 57745,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 57746,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59475,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 61241,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 57747,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 57576,
+			"name": "add_call"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 59771,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 57671,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 57672,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 59772,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 57854,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 60054,
+			"name": "adobe"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_off"
+		},
+		{
+			"codepoint": 57749,
+			"name": "airplanemode_on"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59482,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 61402,
+			"name": "aod"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 61247,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 61249,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 60132,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 60032,
+			"name": "apple"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61250,
+			"name": "article"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 59484,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 63560,
+			"name": "assignment_add"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 59785,
+			"name": "assistant_navigation"
+		},
+		{
+			"codepoint": 58272,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 58273,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 63580,
+			"name": "barcode_reader"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 60377,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 60384,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 60381,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 60386,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 60372,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 60370,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 57764,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61252,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 57675,
+			"name": "block"
+		},
+		{
+			"codepoint": 61254,
+			"name": "block_flipped"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 57770,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 59493,
+			"name": "book"
+		},
+		{
+			"codepoint": 61975,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 59494,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 59495,
+			"name": "bookmark_outline"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 58278,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 58279,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 59497,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 57519,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 57520,
+			"name": "call"
+		},
+		{
+			"codepoint": 57521,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58288,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 58289,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 58290,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 58825,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 58632,
+			"name": "catching_pokemon"
+		},
+		{
+			"codepoint": 58740,
+			"name": "category"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 61853,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 57527,
+			"name": "chat"
+		},
+		{
+			"codepoint": 57546,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 58826,
+			"name": "check"
+		},
+		{
+			"codepoint": 59444,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 59500,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 59693,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 60226,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 57676,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 57372,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 58045,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 58050,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 59408,
+			"name": "cloudy_snowing"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 58294,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58295,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 57529,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58122,
+			"name": "computer"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_num"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 57551,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 57677,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 57678,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 57679,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 58298,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 63591,
+			"name": "conveyor_belt"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 57680,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59504,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 58305,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58308,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 57775,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59506,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60018,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 57776,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 58169,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 57777,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 63609,
+			"name": "dew_point"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 58672,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 58673,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 58674,
+			"name": "directions_ferry"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 58675,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61433,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 58676,
+			"name": "directions_train"
+		},
+		{
+			"codepoint": 58677,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 60012,
+			"name": "discord"
+		},
+		{
+			"codepoint": 60361,
+			"name": "discount"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 58897,
+			"name": "dnd_forwardslash"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 58898,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 58897,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 58947,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 58948,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 58126,
+			"name": "dock"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 58899,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 58997,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_outline"
+		},
+		{
+			"codepoint": 59245,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 61445,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 61446,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 58313,
+			"name": "edit"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 63628,
+			"name": "edit_document"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 63629,
+			"name": "edit_square"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57534,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 59930,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 59644,
+			"name": "enhance_photo_translate"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 57344,
+			"name": "error"
+		},
+		{
+			"codepoint": 57345,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 58314,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_minus_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_minus_2"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 58317,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 59516,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 62004,
+			"name": "facebook"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 59517,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_outline"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 58052,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 59818,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 58054,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 63622,
+			"name": "file_upload_off"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 59726,
+			"name": "filter_list_alt"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 61859,
+			"name": "fire_hydrant"
+		},
+		{
+			"codepoint": 63729,
+			"name": "fire_hydrant_alt"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 59435,
+			"name": "fitbit"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 57683,
+			"name": "flag"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 60465,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 61453,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 60465,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61455,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 59416,
+			"name": "foggy"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 63592,
+			"name": "forklift"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 63561,
+			"name": "format_list_bulleted_add"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 57929,
+			"name": "format_underline"
+		},
+		{
+			"codepoint": 57929,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 57535,
+			"name": "forum"
+		},
+		{
+			"codepoint": 57684,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 63593,
+			"name": "front_loader"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 57377,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 59524,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 1114109,
+			"name": "goat"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 57779,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57780,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57781,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 59525,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 59375,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 58128,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 59527,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_remove"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59529,
+			"name": "history"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59530,
+			"name": "home"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home_filled"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 59913,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58682,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59533,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 58357,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 57539,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 59535,
+			"name": "info_outline"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 57931,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 57962,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 57933,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 57934,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 57935,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 57937,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 60274,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors_on"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 60139,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 60128,
+			"name": "keyboard_command"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 58835,
+			"name": "keyboard_control"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 60127,
+			"name": "keyboard_option"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 59538,
+			"name": "label"
+		},
+		{
+			"codepoint": 59703,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58359,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59540,
+			"name": "language"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59541,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 61979,
+			"name": "leave_bags_at_home"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 57390,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 57584,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57687,
+			"name": "link"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 57582,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58937,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58687,
+			"name": "local_attraction"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 58689,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 58695,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 58701,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 58702,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 58705,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_print_shop"
+		},
+		{
+			"codepoint": 58709,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58710,
+			"name": "local_restaurant"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 58714,
+			"name": "location_history"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 57544,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_pin"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 59543,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 57384,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 57688,
+			"name": "mail"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 57569,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57546,
+			"name": "messenger"
+		},
+		{
+			"codepoint": 57547,
+			"name": "messenger_outline"
+		},
+		{
+			"codepoint": 57385,
+			"name": "mic"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 57386,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61708,
+			"name": "miscellaneous_services"
+		},
+		{
+			"codepoint": 57459,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 57856,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 57575,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 57940,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61493,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 57948,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 59378,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 58835,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 59842,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 57388,
+			"name": "movie"
+		},
+		{
+			"codepoint": 58372,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 63552,
+			"name": "movie_edit"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 57784,
+			"name": "multitrack_audio"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 57390,
+			"name": "my_library_add"
+		},
+		{
+			"codepoint": 57391,
+			"name": "my_library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "my_library_music"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58376,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58377,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 57393,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61278,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 59974,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 61860,
+			"name": "no_cell"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 58945,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 61993,
+			"name": "no_meals_ouline"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57548,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 57395,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 57455,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59380,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_on"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 57788,
+			"name": "now_wallpaper"
+		},
+		{
+			"codepoint": 57789,
+			"name": "now_widgets"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 59845,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 61992,
+			"name": "outbond"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61650,
+			"name": "outgoing_mail"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 57710,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 63594,
+			"name": "pallet"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 58379,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fisheye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 61280,
+			"name": "panorama_horizontal_select"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 59850,
+			"name": "panorama_photosphere_select"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 61281,
+			"name": "panorama_vertical_select"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 61282,
+			"name": "panorama_wide_angle_select"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57397,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57398,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60045,
+			"name": "paypal"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59387,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59388,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_cal"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_info"
+		},
+		{
+			"codepoint": 59557,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 59558,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 59389,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59390,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 61285,
+			"name": "person_add_alt_1"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 59391,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61287,
+			"name": "person_remove_alt_1"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 57549,
+			"name": "phone"
+		},
+		{
+			"codepoint": 58148,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 58149,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 57563,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 57564,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 58151,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 57565,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 57566,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 58384,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 58418,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 59076,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61508,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 59077,
+			"name": "pie_chart_outlined"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 60067,
+			"name": "pix"
+		},
+		{
+			"codepoint": 58719,
+			"name": "place"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_fill"
+		},
+		{
+			"codepoint": 57400,
+			"name": "play_circle_filled"
+		},
+		{
+			"codepoint": 57401,
+			"name": "play_circle_outline"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 59393,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 57550,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 58390,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 59564,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 59678,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 59566,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 57551,
+			"name": "quick_contacts_dialer"
+		},
+		{
+			"codepoint": 57552,
+			"name": "quick_contacts_mail"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 60056,
+			"name": "quora"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_off"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_on"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 63558,
+			"name": "rebase_edit"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 60064,
+			"name": "reddit"
+		},
+		{
+			"codepoint": 59569,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 57692,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 57693,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 58391,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 57696,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 59570,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 61524,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 57553,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 59572,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 57713,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 59573,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 57790,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 57791,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 57792,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 57793,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 57794,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59574,
+			"name": "search"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 61528,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61529,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 61530,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 61532,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 57581,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 59580,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_display"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59584,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58660,
+			"name": "share_arrival_time"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 63598,
+			"name": "shelves"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 57758,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 60061,
+			"name": "shopify"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 61536,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 57816,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57817,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61539,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61542,
+			"name": "signal_wifi_statusbar_connected_no_internet_4"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 58916,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 61547,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 58156,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 58918,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 60014,
+			"name": "snapchat"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 59407,
+			"name": "snowing"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61892,
+			"name": "source"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 59448,
+			"name": "star"
+		},
+		{
+			"codepoint": 59450,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61593,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61551,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 57555,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 57556,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 57557,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 57558,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 58723,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 59418,
+			"name": "sunny"
+		},
+		{
+			"codepoint": 59417,
+			"name": "sunny_snowing"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vert_circle"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 61554,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 61556,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 58922,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_tv"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 58400,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 58923,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 60011,
+			"name": "telegram"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 57560,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 59611,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 59414,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 59890,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 59612,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 59415,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 59891,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 60030,
+			"name": "tiktok"
+		},
+		{
+			"codepoint": 58924,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_neutral"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 63595,
+			"name": "trolley"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59622,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58163,
+			"name": "tv"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 59624,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 58925,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_collection"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfortable"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 59902,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 59292,
+			"name": "volume_down_alt"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 59638,
+			"name": "wallet_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "wallet_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "wallet_travel"
+		},
+		{
+			"codepoint": 57788,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 57346,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 59684,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 58413,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 58422,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 59906,
+			"name": "wb_twighlight"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 57425,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 58615,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 60033,
+			"name": "wechat"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 57789,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61573,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 60121,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61574,
+			"name": "wifi_tethering_error_rounded"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 60013,
+			"name": "woo_commerce"
+		},
+		{
+			"codepoint": 60063,
+			"name": "wordpress"
+		},
+		{
+			"codepoint": 59641,
+			"name": "work"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 57760,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 59917,
+			"name": "workspaces_filled"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces_outline"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "font/MaterialIcons-Regular.codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"sha256": "530f25bf7b2d71c8e1da9476d53f9a9bb6b7e187bff69bb7128bb679b8194894"
+	}
+}

--- a/registry/data/families/google-icons/material-icons/inspection.json
+++ b/registry/data/families/google-icons/material-icons/inspection.json
@@ -1,0 +1,17 @@
+{
+	"files": [
+		{
+			"axes": [],
+			"cmap": {
+				"codepointCount": 2226,
+				"sha256": "f528c2c213a34af7ffaead3eb535e4273e8bf13dd94bc562c3de8892c2ea1d19"
+			},
+			"colorTables": [],
+			"fontVersion": "Version 1.017",
+			"outline": "glyf",
+			"path": "font/MaterialIcons-Regular.ttf",
+			"style": "normal",
+			"weight": 400
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-icons/license.txt
+++ b/registry/data/families/google-icons/material-icons/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-icons/metadata.json
+++ b/registry/data/families/google-icons/material-icons/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Icons",
+	"id": "material-icons",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "font",
+		"repository": "google/material-design-icons",
+		"revision": "f7bd4f25f3764883717c09a1fd867f560c9a9581",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "font/MaterialIcons-Regular.ttf",
+			"sha256": "ef149f08bdd2ff09a4e2c8573476b7b0f3fbb15b623954ade59899e7175bedda",
+			"size": 356840,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2022-09-19",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-outlined/description.en-US.md
+++ b/registry/data/families/google-icons/material-symbols-outlined/description.en-US.md
@@ -1,0 +1,1 @@
+Material Symbols Outlined is part of Google's current Material Symbols collection. It is a variable icon font with fill, weight, grade, and optical size axes.

--- a/registry/data/families/google-icons/material-symbols-outlined/icons.json
+++ b/registry/data/families/google-icons/material-symbols-outlined/icons.json
@@ -1,0 +1,17078 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 63473,
+			"name": "1x_mobiledata_badge"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 62450,
+			"name": "24fps_select"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 61239,
+			"name": "2d"
+		},
+		{
+			"codepoint": 1048334,
+			"name": "2d_2"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 60728,
+			"name": "3d"
+		},
+		{
+			"codepoint": 1048335,
+			"name": "3d_2"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 63472,
+			"name": "3g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 63471,
+			"name": "4g_mobiledata_badge"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 63219,
+			"name": "50mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 63470,
+			"name": "5g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 62286,
+			"name": "accessible_menu"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59474,
+			"name": "account_child"
+		},
+		{
+			"codepoint": 58969,
+			"name": "account_child_invert"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle_filled"
+		},
+		{
+			"codepoint": 63411,
+			"name": "account_circle_off"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 62722,
+			"name": "action_key"
+		},
+		{
+			"codepoint": 57830,
+			"name": "activity_zone"
+		},
+		{
+			"codepoint": 62148,
+			"name": "acupuncture"
+		},
+		{
+			"codepoint": 58571,
+			"name": "acute"
+		},
+		{
+			"codepoint": 58970,
+			"name": "ad"
+		},
+		{
+			"codepoint": 58971,
+			"name": "ad_group"
+		},
+		{
+			"codepoint": 60133,
+			"name": "ad_group_off"
+		},
+		{
+			"codepoint": 63410,
+			"name": "ad_off"
+		},
+		{
+			"codepoint": 62187,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 62668,
+			"name": "adaptive_audio_mic"
+		},
+		{
+			"codepoint": 62667,
+			"name": "adaptive_audio_mic_off"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 62429,
+			"name": "add_2"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 59178,
+			"name": "add_ad"
+		},
+		{
+			"codepoint": 59478,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_call"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 61244,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 62501,
+			"name": "add_column_left"
+		},
+		{
+			"codepoint": 62500,
+			"name": "add_column_right"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 62620,
+			"name": "add_diamond"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 57489,
+			"name": "add_notes"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 62499,
+			"name": "add_row_above"
+		},
+		{
+			"codepoint": 62498,
+			"name": "add_row_below"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 62137,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 62606,
+			"name": "add_triangle"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 58509,
+			"name": "admin_meds"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 63624,
+			"name": "agender"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58058,
+			"name": "air_freshener"
+		},
+		{
+			"codepoint": 59774,
+			"name": "air_purifier"
+		},
+		{
+			"codepoint": 59433,
+			"name": "air_purifier_gen"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 58685,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airware"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airwave"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 62299,
+			"name": "alarm_pause"
+		},
+		{
+			"codepoint": 63152,
+			"name": "alarm_smart_wake"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 58198,
+			"name": "align_center"
+		},
+		{
+			"codepoint": 63383,
+			"name": "align_end"
+		},
+		{
+			"codepoint": 63382,
+			"name": "align_flex_center"
+		},
+		{
+			"codepoint": 63381,
+			"name": "align_flex_end"
+		},
+		{
+			"codepoint": 63380,
+			"name": "align_flex_start"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 63379,
+			"name": "align_items_stretch"
+		},
+		{
+			"codepoint": 63378,
+			"name": "align_justify_center"
+		},
+		{
+			"codepoint": 63377,
+			"name": "align_justify_flex_end"
+		},
+		{
+			"codepoint": 63376,
+			"name": "align_justify_flex_start"
+		},
+		{
+			"codepoint": 63375,
+			"name": "align_justify_space_around"
+		},
+		{
+			"codepoint": 63374,
+			"name": "align_justify_space_between"
+		},
+		{
+			"codepoint": 63373,
+			"name": "align_justify_space_even"
+		},
+		{
+			"codepoint": 63372,
+			"name": "align_justify_stretch"
+		},
+		{
+			"codepoint": 63371,
+			"name": "align_self_stretch"
+		},
+		{
+			"codepoint": 63370,
+			"name": "align_space_around"
+		},
+		{
+			"codepoint": 63369,
+			"name": "align_space_between"
+		},
+		{
+			"codepoint": 63368,
+			"name": "align_space_even"
+		},
+		{
+			"codepoint": 63367,
+			"name": "align_start"
+		},
+		{
+			"codepoint": 63366,
+			"name": "align_stretch"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 57491,
+			"name": "all_match"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 57492,
+			"name": "allergies"
+		},
+		{
+			"codepoint": 58958,
+			"name": "allergy"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 63603,
+			"name": "altitude"
+		},
+		{
+			"codepoint": 63172,
+			"name": "ambient_screen"
+		},
+		{
+			"codepoint": 63491,
+			"name": "ambulance"
+		},
+		{
+			"codepoint": 63490,
+			"name": "amend"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 61190,
+			"name": "android_cell_4_bar"
+		},
+		{
+			"codepoint": 61193,
+			"name": "android_cell_4_bar_alert"
+		},
+		{
+			"codepoint": 61192,
+			"name": "android_cell_4_bar_off"
+		},
+		{
+			"codepoint": 61191,
+			"name": "android_cell_4_bar_plus"
+		},
+		{
+			"codepoint": 61186,
+			"name": "android_cell_5_bar"
+		},
+		{
+			"codepoint": 61189,
+			"name": "android_cell_5_bar_alert"
+		},
+		{
+			"codepoint": 61188,
+			"name": "android_cell_5_bar_off"
+		},
+		{
+			"codepoint": 61187,
+			"name": "android_cell_5_bar_plus"
+		},
+		{
+			"codepoint": 61197,
+			"name": "android_cell_dual_4_bar"
+		},
+		{
+			"codepoint": 61199,
+			"name": "android_cell_dual_4_bar_alert"
+		},
+		{
+			"codepoint": 61198,
+			"name": "android_cell_dual_4_bar_plus"
+		},
+		{
+			"codepoint": 61194,
+			"name": "android_cell_dual_5_bar"
+		},
+		{
+			"codepoint": 61196,
+			"name": "android_cell_dual_5_bar_alert"
+		},
+		{
+			"codepoint": 61195,
+			"name": "android_cell_dual_5_bar_plus"
+		},
+		{
+			"codepoint": 61206,
+			"name": "android_wifi_3_bar"
+		},
+		{
+			"codepoint": 61211,
+			"name": "android_wifi_3_bar_alert"
+		},
+		{
+			"codepoint": 61210,
+			"name": "android_wifi_3_bar_lock"
+		},
+		{
+			"codepoint": 61209,
+			"name": "android_wifi_3_bar_off"
+		},
+		{
+			"codepoint": 61208,
+			"name": "android_wifi_3_bar_plus"
+		},
+		{
+			"codepoint": 61207,
+			"name": "android_wifi_3_bar_question"
+		},
+		{
+			"codepoint": 61200,
+			"name": "android_wifi_4_bar"
+		},
+		{
+			"codepoint": 61205,
+			"name": "android_wifi_4_bar_alert"
+		},
+		{
+			"codepoint": 61204,
+			"name": "android_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61203,
+			"name": "android_wifi_4_bar_off"
+		},
+		{
+			"codepoint": 61202,
+			"name": "android_wifi_4_bar_plus"
+		},
+		{
+			"codepoint": 61201,
+			"name": "android_wifi_4_bar_question"
+		},
+		{
+			"codepoint": 62618,
+			"name": "animated_images"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59519,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 1048530,
+			"name": "antigravity"
+		},
+		{
+			"codepoint": 62182,
+			"name": "aod"
+		},
+		{
+			"codepoint": 63647,
+			"name": "aod_tablet"
+		},
+		{
+			"codepoint": 63148,
+			"name": "aod_watch"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 63630,
+			"name": "apk_document"
+		},
+		{
+			"codepoint": 63631,
+			"name": "apk_install"
+		},
+		{
+			"codepoint": 63279,
+			"name": "app_badging"
+		},
+		{
+			"codepoint": 62181,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 62157,
+			"name": "app_promo"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 62169,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 62175,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 61307,
+			"name": "apparel"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 63562,
+			"name": "approval_delegation"
+		},
+		{
+			"codepoint": 62149,
+			"name": "approval_delegation_off"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 62810,
+			"name": "aq"
+		},
+		{
+			"codepoint": 62811,
+			"name": "aq_indoor"
+		},
+		{
+			"codepoint": 61308,
+			"name": "ar_on_you"
+		},
+		{
+			"codepoint": 59779,
+			"name": "ar_stickers"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 59274,
+			"name": "arming_countdown"
+		},
+		{
+			"codepoint": 62935,
+			"name": "arrow_and_edge"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 62522,
+			"name": "arrow_back_2"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 62646,
+			"name": "arrow_cool_down"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 59780,
+			"name": "arrow_downward_alt"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 63543,
+			"name": "arrow_insert"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 61309,
+			"name": "arrow_left_alt"
+		},
+		{
+			"codepoint": 62419,
+			"name": "arrow_menu_close"
+		},
+		{
+			"codepoint": 62418,
+			"name": "arrow_menu_open"
+		},
+		{
+			"codepoint": 62934,
+			"name": "arrow_or_edge"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 63131,
+			"name": "arrow_range"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 63535,
+			"name": "arrow_selector_tool"
+		},
+		{
+			"codepoint": 61174,
+			"name": "arrow_shape_up"
+		},
+		{
+			"codepoint": 61175,
+			"name": "arrow_shape_up_stack"
+		},
+		{
+			"codepoint": 61176,
+			"name": "arrow_shape_up_stack_2"
+		},
+		{
+			"codepoint": 59908,
+			"name": "arrow_split"
+		},
+		{
+			"codepoint": 63278,
+			"name": "arrow_top_left"
+		},
+		{
+			"codepoint": 63277,
+			"name": "arrow_top_right"
+		},
+		{
+			"codepoint": 62452,
+			"name": "arrow_upload_progress"
+		},
+		{
+			"codepoint": 62453,
+			"name": "arrow_upload_ready"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 59782,
+			"name": "arrow_upward_alt"
+		},
+		{
+			"codepoint": 62645,
+			"name": "arrow_warm_up"
+		},
+		{
+			"codepoint": 62356,
+			"name": "arrows_input"
+		},
+		{
+			"codepoint": 61156,
+			"name": "arrows_left_right_circle"
+		},
+		{
+			"codepoint": 63659,
+			"name": "arrows_more_down"
+		},
+		{
+			"codepoint": 63660,
+			"name": "arrows_more_up"
+		},
+		{
+			"codepoint": 62355,
+			"name": "arrows_output"
+		},
+		{
+			"codepoint": 63276,
+			"name": "arrows_outward"
+		},
+		{
+			"codepoint": 61155,
+			"name": "arrows_up_down_circle"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61319,
+			"name": "article"
+		},
+		{
+			"codepoint": 62312,
+			"name": "article_person"
+		},
+		{
+			"codepoint": 62855,
+			"name": "article_shortcut"
+		},
+		{
+			"codepoint": 57370,
+			"name": "artist"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 61644,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 63560,
+			"name": "assignment_add"
+		},
+		{
+			"codepoint": 61164,
+			"name": "assignment_globe"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59783,
+			"name": "assistant_device"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 59785,
+			"name": "assistant_navigation"
+		},
+		{
+			"codepoint": 63169,
+			"name": "assistant_on_hub"
+		},
+		{
+			"codepoint": 61638,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 62757,
+			"name": "asterisk"
+		},
+		{
+			"codepoint": 61913,
+			"name": "astrophotography_auto"
+		},
+		{
+			"codepoint": 61914,
+			"name": "astrophotography_off"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 60359,
+			"name": "atr"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 63553,
+			"name": "attach_file_add"
+		},
+		{
+			"codepoint": 62681,
+			"name": "attach_file_off"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 1048323,
+			"name": "audio_capture"
+		},
+		{
+			"codepoint": 62860,
+			"name": "audio_description"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 62931,
+			"name": "audio_video_receiver"
+		},
+		{
+			"codepoint": 58373,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 63661,
+			"name": "auto_activity_zone"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 63550,
+			"name": "auto_detect_voice"
+		},
+		{
+			"codepoint": 59786,
+			"name": "auto_draw_solid"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 63166,
+			"name": "auto_label"
+		},
+		{
+			"codepoint": 63167,
+			"name": "auto_meeting_room"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 61977,
+			"name": "auto_read_pause"
+		},
+		{
+			"codepoint": 61974,
+			"name": "auto_read_play"
+		},
+		{
+			"codepoint": 57876,
+			"name": "auto_schedule"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 62055,
+			"name": "auto_stories_off"
+		},
+		{
+			"codepoint": 61311,
+			"name": "auto_timer"
+		},
+		{
+			"codepoint": 59166,
+			"name": "auto_towing"
+		},
+		{
+			"codepoint": 62783,
+			"name": "auto_transmission"
+		},
+		{
+			"codepoint": 63168,
+			"name": "auto_videocam"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 62497,
+			"name": "automation"
+		},
+		{
+			"codepoint": 63158,
+			"name": "autopause"
+		},
+		{
+			"codepoint": 63563,
+			"name": "autopay"
+		},
+		{
+			"codepoint": 63157,
+			"name": "autoplay"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 63106,
+			"name": "autostop"
+		},
+		{
+			"codepoint": 62640,
+			"name": "av1"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 62639,
+			"name": "avc"
+		},
+		{
+			"codepoint": 63163,
+			"name": "avg_pace"
+		},
+		{
+			"codepoint": 63507,
+			"name": "avg_time"
+		},
+		{
+			"codepoint": 1048487,
+			"name": "avocado_bean"
+		},
+		{
+			"codepoint": 62017,
+			"name": "award_meal"
+		},
+		{
+			"codepoint": 62994,
+			"name": "award_star"
+		},
+		{
+			"codepoint": 63212,
+			"name": "azm"
+		},
+		{
+			"codepoint": 61154,
+			"name": "b_circle"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 63275,
+			"name": "back_to_tab"
+		},
+		{
+			"codepoint": 63390,
+			"name": "background_dot_large"
+		},
+		{
+			"codepoint": 62740,
+			"name": "background_dot_small"
+		},
+		{
+			"codepoint": 63389,
+			"name": "background_grid_small"
+		},
+		{
+			"codepoint": 61962,
+			"name": "background_replace"
+		},
+		{
+			"codepoint": 63469,
+			"name": "backlight_high"
+		},
+		{
+			"codepoint": 62703,
+			"name": "backlight_high_off"
+		},
+		{
+			"codepoint": 63468,
+			"name": "backlight_low"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 61782,
+			"name": "badge_critical_battery"
+		},
+		{
+			"codepoint": 62120,
+			"name": "badminton"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 63105,
+			"name": "bar_chart_4_bars"
+		},
+		{
+			"codepoint": 62481,
+			"name": "bar_chart_off"
+		},
+		{
+			"codepoint": 59147,
+			"name": "barcode"
+		},
+		{
+			"codepoint": 63580,
+			"name": "barcode_reader"
+		},
+		{
+			"codepoint": 59148,
+			"name": "barcode_scanner"
+		},
+		{
+			"codepoint": 63601,
+			"name": "barefoot"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 62086,
+			"name": "bath_bedrock"
+		},
+		{
+			"codepoint": 63227,
+			"name": "bath_outdoor"
+		},
+		{
+			"codepoint": 63226,
+			"name": "bath_private"
+		},
+		{
+			"codepoint": 63225,
+			"name": "bath_public_large"
+		},
+		{
+			"codepoint": 62112,
+			"name": "bath_soak"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_20"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_30"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_50"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_60"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_80"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_90"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 62221,
+			"name": "battery_android_0"
+		},
+		{
+			"codepoint": 62220,
+			"name": "battery_android_1"
+		},
+		{
+			"codepoint": 62219,
+			"name": "battery_android_2"
+		},
+		{
+			"codepoint": 62218,
+			"name": "battery_android_3"
+		},
+		{
+			"codepoint": 62217,
+			"name": "battery_android_4"
+		},
+		{
+			"codepoint": 62216,
+			"name": "battery_android_5"
+		},
+		{
+			"codepoint": 62215,
+			"name": "battery_android_6"
+		},
+		{
+			"codepoint": 62214,
+			"name": "battery_android_alert"
+		},
+		{
+			"codepoint": 62213,
+			"name": "battery_android_bolt"
+		},
+		{
+			"codepoint": 62039,
+			"name": "battery_android_frame_1"
+		},
+		{
+			"codepoint": 62038,
+			"name": "battery_android_frame_2"
+		},
+		{
+			"codepoint": 62037,
+			"name": "battery_android_frame_3"
+		},
+		{
+			"codepoint": 62036,
+			"name": "battery_android_frame_4"
+		},
+		{
+			"codepoint": 62035,
+			"name": "battery_android_frame_5"
+		},
+		{
+			"codepoint": 62034,
+			"name": "battery_android_frame_6"
+		},
+		{
+			"codepoint": 62033,
+			"name": "battery_android_frame_alert"
+		},
+		{
+			"codepoint": 62032,
+			"name": "battery_android_frame_bolt"
+		},
+		{
+			"codepoint": 62031,
+			"name": "battery_android_frame_full"
+		},
+		{
+			"codepoint": 62030,
+			"name": "battery_android_frame_plus"
+		},
+		{
+			"codepoint": 62029,
+			"name": "battery_android_frame_question"
+		},
+		{
+			"codepoint": 62028,
+			"name": "battery_android_frame_share"
+		},
+		{
+			"codepoint": 62027,
+			"name": "battery_android_frame_shield"
+		},
+		{
+			"codepoint": 62212,
+			"name": "battery_android_full"
+		},
+		{
+			"codepoint": 62211,
+			"name": "battery_android_plus"
+		},
+		{
+			"codepoint": 62210,
+			"name": "battery_android_question"
+		},
+		{
+			"codepoint": 62209,
+			"name": "battery_android_share"
+		},
+		{
+			"codepoint": 62208,
+			"name": "battery_android_shield"
+		},
+		{
+			"codepoint": 63467,
+			"name": "battery_change"
+		},
+		{
+			"codepoint": 61602,
+			"name": "battery_charging_20"
+		},
+		{
+			"codepoint": 1048382,
+			"name": "battery_charging_20_2"
+		},
+		{
+			"codepoint": 61603,
+			"name": "battery_charging_30"
+		},
+		{
+			"codepoint": 1048381,
+			"name": "battery_charging_30_2"
+		},
+		{
+			"codepoint": 61604,
+			"name": "battery_charging_50"
+		},
+		{
+			"codepoint": 1048380,
+			"name": "battery_charging_50_2"
+		},
+		{
+			"codepoint": 61605,
+			"name": "battery_charging_60"
+		},
+		{
+			"codepoint": 1048379,
+			"name": "battery_charging_60_2"
+		},
+		{
+			"codepoint": 61606,
+			"name": "battery_charging_80"
+		},
+		{
+			"codepoint": 1048378,
+			"name": "battery_charging_80_2"
+		},
+		{
+			"codepoint": 61607,
+			"name": "battery_charging_90"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 1048377,
+			"name": "battery_charging_full_2"
+		},
+		{
+			"codepoint": 63466,
+			"name": "battery_error"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61755,
+			"name": "battery_full_alt"
+		},
+		{
+			"codepoint": 63662,
+			"name": "battery_horiz_000"
+		},
+		{
+			"codepoint": 63663,
+			"name": "battery_horiz_050"
+		},
+		{
+			"codepoint": 63664,
+			"name": "battery_horiz_075"
+		},
+		{
+			"codepoint": 61781,
+			"name": "battery_low"
+		},
+		{
+			"codepoint": 63465,
+			"name": "battery_plus"
+		},
+		{
+			"codepoint": 57862,
+			"name": "battery_profile"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 63102,
+			"name": "battery_share"
+		},
+		{
+			"codepoint": 63101,
+			"name": "battery_status_good"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 63665,
+			"name": "battery_vert_005"
+		},
+		{
+			"codepoint": 63666,
+			"name": "battery_vert_020"
+		},
+		{
+			"codepoint": 63667,
+			"name": "battery_vert_050"
+		},
+		{
+			"codepoint": 61782,
+			"name": "battery_very_low"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61785,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 62085,
+			"name": "beer_meal"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 63211,
+			"name": "bia"
+		},
+		{
+			"codepoint": 59000,
+			"name": "bid_landscape"
+		},
+		{
+			"codepoint": 61313,
+			"name": "bid_landscape_disabled"
+		},
+		{
+			"codepoint": 58985,
+			"name": "bigtop_updates"
+		},
+		{
+			"codepoint": 62587,
+			"name": "bike_dock"
+		},
+		{
+			"codepoint": 62586,
+			"name": "bike_lane"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 59432,
+			"name": "blanket"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 1048440,
+			"name": "blinds_2"
+		},
+		{
+			"codepoint": 1048441,
+			"name": "blinds_2_closed"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 61580,
+			"name": "block"
+		},
+		{
+			"codepoint": 57495,
+			"name": "blood_pressure"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 59468,
+			"name": "blur_medium"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59599,
+			"name": "blur_short"
+		},
+		{
+			"codepoint": 62317,
+			"name": "boat_bus"
+		},
+		{
+			"codepoint": 62316,
+			"name": "boat_railway"
+		},
+		{
+			"codepoint": 57496,
+			"name": "body_fat"
+		},
+		{
+			"codepoint": 57497,
+			"name": "body_system"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 1048426,
+			"name": "bolt_boost"
+		},
+		{
+			"codepoint": 62824,
+			"name": "bomb"
+		},
+		{
+			"codepoint": 59502,
+			"name": "book"
+		},
+		{
+			"codepoint": 62782,
+			"name": "book_2"
+		},
+		{
+			"codepoint": 62781,
+			"name": "book_3"
+		},
+		{
+			"codepoint": 62780,
+			"name": "book_4"
+		},
+		{
+			"codepoint": 62779,
+			"name": "book_5"
+		},
+		{
+			"codepoint": 62431,
+			"name": "book_6"
+		},
+		{
+			"codepoint": 62180,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 62439,
+			"name": "book_ribbon"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 62480,
+			"name": "bookmark_bag"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 62551,
+			"name": "bookmark_check"
+		},
+		{
+			"codepoint": 62550,
+			"name": "bookmark_flag"
+		},
+		{
+			"codepoint": 62549,
+			"name": "bookmark_heart"
+		},
+		{
+			"codepoint": 63409,
+			"name": "bookmark_manager"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 61160,
+			"name": "bookmark_stacks"
+		},
+		{
+			"codepoint": 62548,
+			"name": "bookmark_star"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 61314,
+			"name": "books_movies_and_music"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 62477,
+			"name": "borg"
+		},
+		{
+			"codepoint": 59184,
+			"name": "bottom_app_bar"
+		},
+		{
+			"codepoint": 59181,
+			"name": "bottom_drawer"
+		},
+		{
+			"codepoint": 59788,
+			"name": "bottom_navigation"
+		},
+		{
+			"codepoint": 63274,
+			"name": "bottom_panel_close"
+		},
+		{
+			"codepoint": 63273,
+			"name": "bottom_panel_open"
+		},
+		{
+			"codepoint": 63108,
+			"name": "bottom_right_click"
+		},
+		{
+			"codepoint": 59789,
+			"name": "bottom_sheets"
+		},
+		{
+			"codepoint": 62884,
+			"name": "box"
+		},
+		{
+			"codepoint": 62885,
+			"name": "box_add"
+		},
+		{
+			"codepoint": 62886,
+			"name": "box_edit"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 59790,
+			"name": "brand_awareness"
+		},
+		{
+			"codepoint": 62705,
+			"name": "brand_family"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 59912,
+			"name": "breaking_news"
+		},
+		{
+			"codepoint": 61626,
+			"name": "breaking_news_alt_1"
+		},
+		{
+			"codepoint": 63574,
+			"name": "breastfeeding"
+		},
+		{
+			"codepoint": 62344,
+			"name": "brick"
+		},
+		{
+			"codepoint": 62022,
+			"name": "briefcase_meal"
+		},
+		{
+			"codepoint": 58362,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 61494,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 62927,
+			"name": "brightness_alert"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 63464,
+			"name": "brightness_empty"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 57366,
+			"name": "bring_your_own_ip"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60179,
+			"name": "browse"
+		},
+		{
+			"codepoint": 63653,
+			"name": "browse_activity"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 61315,
+			"name": "bubble"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 63054,
+			"name": "bubbles"
+		},
+		{
+			"codepoint": 61226,
+			"name": "bucket_check"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 63693,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 1048482,
+			"name": "bus_map_pin"
+		},
+		{
+			"codepoint": 62315,
+			"name": "bus_railway"
+		},
+		{
+			"codepoint": 59374,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 63564,
+			"name": "business_chip"
+		},
+		{
+			"codepoint": 61316,
+			"name": "business_messages"
+		},
+		{
+			"codepoint": 59183,
+			"name": "buttons_alt"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 62585,
+			"name": "cable_car"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 62644,
+			"name": "cadence"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 63579,
+			"name": "cake_add"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 61317,
+			"name": "calendar_add_on"
+		},
+		{
+			"codepoint": 61627,
+			"name": "calendar_apps_script"
+		},
+		{
+			"codepoint": 62019,
+			"name": "calendar_check"
+		},
+		{
+			"codepoint": 62784,
+			"name": "calendar_clock"
+		},
+		{
+			"codepoint": 62018,
+			"name": "calendar_lock"
+		},
+		{
+			"codepoint": 62102,
+			"name": "calendar_meal"
+		},
+		{
+			"codepoint": 62016,
+			"name": "calendar_meal_2"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 61652,
+			"name": "call"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end_alt"
+		},
+		{
+			"codepoint": 57486,
+			"name": "call_log"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 63058,
+			"name": "call_quality"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58386,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 62153,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 62152,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 63398,
+			"name": "camera_video"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 63650,
+			"name": "camping"
+		},
+		{
+			"codepoint": 59528,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 62856,
+			"name": "candle"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 62195,
+			"name": "cannabis"
+		},
+		{
+			"codepoint": 63272,
+			"name": "captive_portal"
+		},
+		{
+			"codepoint": 63271,
+			"name": "capture"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 62276,
+			"name": "car_defrost_left"
+		},
+		{
+			"codepoint": 62275,
+			"name": "car_defrost_low_left"
+		},
+		{
+			"codepoint": 62274,
+			"name": "car_defrost_low_right"
+		},
+		{
+			"codepoint": 62072,
+			"name": "car_defrost_mid_left"
+		},
+		{
+			"codepoint": 62273,
+			"name": "car_defrost_mid_low_left"
+		},
+		{
+			"codepoint": 62071,
+			"name": "car_defrost_mid_low_right"
+		},
+		{
+			"codepoint": 62272,
+			"name": "car_defrost_mid_right"
+		},
+		{
+			"codepoint": 62271,
+			"name": "car_defrost_right"
+		},
+		{
+			"codepoint": 62270,
+			"name": "car_fan_low_left"
+		},
+		{
+			"codepoint": 62269,
+			"name": "car_fan_low_mid_left"
+		},
+		{
+			"codepoint": 62268,
+			"name": "car_fan_low_right"
+		},
+		{
+			"codepoint": 62267,
+			"name": "car_fan_mid_left"
+		},
+		{
+			"codepoint": 62266,
+			"name": "car_fan_mid_low_right"
+		},
+		{
+			"codepoint": 62265,
+			"name": "car_fan_mid_right"
+		},
+		{
+			"codepoint": 62264,
+			"name": "car_fan_recirculate"
+		},
+		{
+			"codepoint": 1048384,
+			"name": "car_fan_recirculate_2"
+		},
+		{
+			"codepoint": 62263,
+			"name": "car_gear"
+		},
+		{
+			"codepoint": 62262,
+			"name": "car_lock"
+		},
+		{
+			"codepoint": 62261,
+			"name": "car_mirror_heat"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 62691,
+			"name": "car_tag"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 62649,
+			"name": "cardio_load"
+		},
+		{
+			"codepoint": 57500,
+			"name": "cardiology"
+		},
+		{
+			"codepoint": 59793,
+			"name": "cards"
+		},
+		{
+			"codepoint": 62351,
+			"name": "cards_stack"
+		},
+		{
+			"codepoint": 62325,
+			"name": "cards_star"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 60168,
+			"name": "carry_on_bag"
+		},
+		{
+			"codepoint": 60171,
+			"name": "carry_on_bag_checked"
+		},
+		{
+			"codepoint": 60170,
+			"name": "carry_on_bag_inactive"
+		},
+		{
+			"codepoint": 60169,
+			"name": "carry_on_bag_question"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 62960,
+			"name": "cast_pause"
+		},
+		{
+			"codepoint": 62959,
+			"name": "cast_warning"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 59180,
+			"name": "category"
+		},
+		{
+			"codepoint": 62519,
+			"name": "category_search"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 63534,
+			"name": "cell_merge"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 62111,
+			"name": "chair_counter"
+		},
+		{
+			"codepoint": 62110,
+			"name": "chair_fireplace"
+		},
+		{
+			"codepoint": 62109,
+			"name": "chair_umbrella"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 58030,
+			"name": "charger"
+		},
+		{
+			"codepoint": 62179,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 58483,
+			"name": "chart_data"
+		},
+		{
+			"codepoint": 57545,
+			"name": "chat"
+		},
+		{
+			"codepoint": 61683,
+			"name": "chat_add_on"
+		},
+		{
+			"codepoint": 61629,
+			"name": "chat_apps_script"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 1048507,
+			"name": "chat_bubble_off"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 61165,
+			"name": "chat_dashed"
+		},
+		{
+			"codepoint": 63404,
+			"name": "chat_error"
+		},
+		{
+			"codepoint": 62763,
+			"name": "chat_info"
+		},
+		{
+			"codepoint": 63165,
+			"name": "chat_paste_go"
+		},
+		{
+			"codepoint": 62411,
+			"name": "chat_paste_go_2"
+		},
+		{
+			"codepoint": 58984,
+			"name": "check"
+		},
+		{
+			"codepoint": 1048453,
+			"name": "check_alert"
+		},
+		{
+			"codepoint": 59870,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_filled"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 62078,
+			"name": "check_circle_unread"
+		},
+		{
+			"codepoint": 63222,
+			"name": "check_in_out"
+		},
+		{
+			"codepoint": 63626,
+			"name": "check_indeterminate_small"
+		},
+		{
+			"codepoint": 63627,
+			"name": "check_small"
+		},
+		{
+			"codepoint": 59149,
+			"name": "checkbook"
+		},
+		{
+			"codepoint": 60172,
+			"name": "checked_bag"
+		},
+		{
+			"codepoint": 60173,
+			"name": "checked_bag_question"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 63144,
+			"name": "cheer"
+		},
+		{
+			"codepoint": 62295,
+			"name": "chef_hat"
+		},
+		{
+			"codepoint": 62951,
+			"name": "chess"
+		},
+		{
+			"codepoint": 62049,
+			"name": "chess_bishop"
+		},
+		{
+			"codepoint": 62050,
+			"name": "chess_bishop_2"
+		},
+		{
+			"codepoint": 62047,
+			"name": "chess_king"
+		},
+		{
+			"codepoint": 62048,
+			"name": "chess_king_2"
+		},
+		{
+			"codepoint": 62046,
+			"name": "chess_knight"
+		},
+		{
+			"codepoint": 62390,
+			"name": "chess_pawn"
+		},
+		{
+			"codepoint": 62045,
+			"name": "chess_pawn_2"
+		},
+		{
+			"codepoint": 62044,
+			"name": "chess_queen"
+		},
+		{
+			"codepoint": 62043,
+			"name": "chess_rook"
+		},
+		{
+			"codepoint": 62571,
+			"name": "chevron_backward"
+		},
+		{
+			"codepoint": 62570,
+			"name": "chevron_forward"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 61123,
+			"name": "chevron_line_up"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 61312,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 61232,
+			"name": "child_hat"
+		},
+		{
+			"codepoint": 63521,
+			"name": "chip_extraction"
+		},
+		{
+			"codepoint": 59795,
+			"name": "chips"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 61819,
+			"name": "chromecast_2"
+		},
+		{
+			"codepoint": 59452,
+			"name": "chromecast_device"
+		},
+		{
+			"codepoint": 60338,
+			"name": "chronic"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 63571,
+			"name": "cinematic_blur"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 61153,
+			"name": "circle_circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59370,
+			"name": "circles"
+		},
+		{
+			"codepoint": 59372,
+			"name": "circles_ext"
+		},
+		{
+			"codepoint": 61631,
+			"name": "clarify"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 59797,
+			"name": "cleaning"
+		},
+		{
+			"codepoint": 63668,
+			"name": "cleaning_bucket"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 58829,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 61783,
+			"name": "clear_day"
+		},
+		{
+			"codepoint": 61785,
+			"name": "clear_night"
+		},
+		{
+			"codepoint": 63669,
+			"name": "climate_mini_split"
+		},
+		{
+			"codepoint": 57502,
+			"name": "clinical_notes"
+		},
+		{
+			"codepoint": 62338,
+			"name": "clock_arrow_down"
+		},
+		{
+			"codepoint": 62337,
+			"name": "clock_arrow_up"
+		},
+		{
+			"codepoint": 63270,
+			"name": "clock_loader_10"
+		},
+		{
+			"codepoint": 63269,
+			"name": "clock_loader_20"
+		},
+		{
+			"codepoint": 63268,
+			"name": "clock_loader_40"
+		},
+		{
+			"codepoint": 63267,
+			"name": "clock_loader_60"
+		},
+		{
+			"codepoint": 63266,
+			"name": "clock_loader_80"
+		},
+		{
+			"codepoint": 63265,
+			"name": "clock_loader_90"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 62728,
+			"name": "close_small"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 62638,
+			"name": "closed_caption_add"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 62412,
+			"name": "cloud_alert"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 62342,
+			"name": "cloud_lock"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy_filled"
+		},
+		{
+			"codepoint": 59408,
+			"name": "cloudy_snowing"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 63565,
+			"name": "code_blocks"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 1048459,
+			"name": "code_xml"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 57503,
+			"name": "cognition"
+		},
+		{
+			"codepoint": 62389,
+			"name": "cognition_2"
+		},
+		{
+			"codepoint": 59716,
+			"name": "collapse_all"
+		},
+		{
+			"codepoint": 62727,
+			"name": "collapse_content"
+		},
+		{
+			"codepoint": 58323,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58378,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 59799,
+			"name": "colors"
+		},
+		{
+			"codepoint": 62496,
+			"name": "combine_columns"
+		},
+		{
+			"codepoint": 62678,
+			"name": "comedy_mask"
+		},
+		{
+			"codepoint": 62941,
+			"name": "comic_bubble"
+		},
+		{
+			"codepoint": 57932,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 57980,
+			"name": "communication"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities_filled"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 61927,
+			"name": "component_exchange"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58142,
+			"name": "computer"
+		},
+		{
+			"codepoint": 62199,
+			"name": "computer_arrow_up"
+		},
+		{
+			"codepoint": 62198,
+			"name": "computer_cancel"
+		},
+		{
+			"codepoint": 61108,
+			"name": "computer_sound"
+		},
+		{
+			"codepoint": 62817,
+			"name": "concierge"
+		},
+		{
+			"codepoint": 57504,
+			"name": "conditions"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 57505,
+			"name": "congenital"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone_filled"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 63576,
+			"name": "contactless_off"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 59801,
+			"name": "contacts_product"
+		},
+		{
+			"codepoint": 57677,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 57678,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 57679,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 62598,
+			"name": "contextual_token"
+		},
+		{
+			"codepoint": 62597,
+			"name": "contextual_token_add"
+		},
+		{
+			"codepoint": 62880,
+			"name": "contract"
+		},
+		{
+			"codepoint": 62882,
+			"name": "contract_delete"
+		},
+		{
+			"codepoint": 62881,
+			"name": "contract_edit"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 62623,
+			"name": "contrast_circle"
+		},
+		{
+			"codepoint": 60530,
+			"name": "contrast_rtl_off"
+		},
+		{
+			"codepoint": 62624,
+			"name": "contrast_square"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 59792,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 59453,
+			"name": "controller_gen"
+		},
+		{
+			"codepoint": 61231,
+			"name": "conversation"
+		},
+		{
+			"codepoint": 61633,
+			"name": "conversion_path"
+		},
+		{
+			"codepoint": 63412,
+			"name": "conversion_path_off"
+		},
+		{
+			"codepoint": 62495,
+			"name": "convert_to_text"
+		},
+		{
+			"codepoint": 63591,
+			"name": "conveyor_belt"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 63386,
+			"name": "cookie_off"
+		},
+		{
+			"codepoint": 58038,
+			"name": "cooking"
+		},
+		{
+			"codepoint": 57974,
+			"name": "cool_to_dry"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 63365,
+			"name": "counter_0"
+		},
+		{
+			"codepoint": 63364,
+			"name": "counter_1"
+		},
+		{
+			"codepoint": 63363,
+			"name": "counter_2"
+		},
+		{
+			"codepoint": 63362,
+			"name": "counter_3"
+		},
+		{
+			"codepoint": 63361,
+			"name": "counter_4"
+		},
+		{
+			"codepoint": 63360,
+			"name": "counter_5"
+		},
+		{
+			"codepoint": 63359,
+			"name": "counter_6"
+		},
+		{
+			"codepoint": 63358,
+			"name": "counter_7"
+		},
+		{
+			"codepoint": 63357,
+			"name": "counter_8"
+		},
+		{
+			"codepoint": 63356,
+			"name": "counter_9"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 61591,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59553,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 62520,
+			"name": "credit_card_clock"
+		},
+		{
+			"codepoint": 62765,
+			"name": "credit_card_gear"
+		},
+		{
+			"codepoint": 62764,
+			"name": "credit_card_heart"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 1048330,
+			"name": "crop_21_9"
+		},
+		{
+			"codepoint": 1048331,
+			"name": "crop_2_3"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 62793,
+			"name": "crop_9_16"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58356,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 62949,
+			"name": "crossword"
+		},
+		{
+			"codepoint": 60184,
+			"name": "crowdsource"
+		},
+		{
+			"codepoint": 60595,
+			"name": "crown"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 59087,
+			"name": "csv"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 62560,
+			"name": "currency_rupee_circle"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 59186,
+			"name": "custom_typography"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 63572,
+			"name": "cycle"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 62442,
+			"name": "dashboard_2"
+		},
+		{
+			"codepoint": 1048297,
+			"name": "dashboard_2_add"
+		},
+		{
+			"codepoint": 1048535,
+			"name": "dashboard_2_edit"
+		},
+		{
+			"codepoint": 1048534,
+			"name": "dashboard_2_gear"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 63478,
+			"name": "data_alert"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 63474,
+			"name": "data_check"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 63477,
+			"name": "data_info_alert"
+		},
+		{
+			"codepoint": 58076,
+			"name": "data_loss_prevention"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 59804,
+			"name": "data_table"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 61966,
+			"name": "database"
+		},
+		{
+			"codepoint": 62484,
+			"name": "database_off"
+		},
+		{
+			"codepoint": 62350,
+			"name": "database_search"
+		},
+		{
+			"codepoint": 62428,
+			"name": "database_upload"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 57509,
+			"name": "deceased"
+		},
+		{
+			"codepoint": 63533,
+			"name": "decimal_decrease"
+		},
+		{
+			"codepoint": 63532,
+			"name": "decimal_increase"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 62744,
+			"name": "delete_history"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60200,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 62370,
+			"name": "delivery_truck_bolt"
+		},
+		{
+			"codepoint": 62369,
+			"name": "delivery_truck_speed"
+		},
+		{
+			"codepoint": 58505,
+			"name": "demography"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 57510,
+			"name": "dentistry"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 63264,
+			"name": "deployed_code"
+		},
+		{
+			"codepoint": 62747,
+			"name": "deployed_code_account"
+		},
+		{
+			"codepoint": 62962,
+			"name": "deployed_code_alert"
+		},
+		{
+			"codepoint": 62963,
+			"name": "deployed_code_history"
+		},
+		{
+			"codepoint": 62964,
+			"name": "deployed_code_update"
+		},
+		{
+			"codepoint": 57511,
+			"name": "dermatology"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 63482,
+			"name": "deskphone"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 62427,
+			"name": "desktop_cloud"
+		},
+		{
+			"codepoint": 62398,
+			"name": "desktop_cloud_stack"
+		},
+		{
+			"codepoint": 62558,
+			"name": "desktop_landscape"
+		},
+		{
+			"codepoint": 62521,
+			"name": "desktop_landscape_add"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 62557,
+			"name": "desktop_portrait"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 62853,
+			"name": "destruction"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58015,
+			"name": "detection_and_zone"
+		},
+		{
+			"codepoint": 61119,
+			"name": "detection_and_zone_off"
+		},
+		{
+			"codepoint": 57986,
+			"name": "detector"
+		},
+		{
+			"codepoint": 57847,
+			"name": "detector_alarm"
+		},
+		{
+			"codepoint": 57860,
+			"name": "detector_battery"
+		},
+		{
+			"codepoint": 58031,
+			"name": "detector_co"
+		},
+		{
+			"codepoint": 57891,
+			"name": "detector_offline"
+		},
+		{
+			"codepoint": 57989,
+			"name": "detector_smoke"
+		},
+		{
+			"codepoint": 57832,
+			"name": "detector_status"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 59806,
+			"name": "developer_guide"
+		},
+		{
+			"codepoint": 62178,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 59508,
+			"name": "developer_mode_tv"
+		},
+		{
+			"codepoint": 62197,
+			"name": "device_band"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 59571,
+			"name": "device_reset"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 62177,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 58150,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 62470,
+			"name": "devices_fold_2"
+		},
+		{
+			"codepoint": 63397,
+			"name": "devices_off"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 63147,
+			"name": "devices_wearables"
+		},
+		{
+			"codepoint": 63609,
+			"name": "dew_point"
+		},
+		{
+			"codepoint": 57512,
+			"name": "diagnosis"
+		},
+		{
+			"codepoint": 62494,
+			"name": "diagonal_line"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 59807,
+			"name": "dialogs"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 62130,
+			"name": "diamond_shine"
+		},
+		{
+			"codepoint": 62777,
+			"name": "dictionary"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61918,
+			"name": "digital_out_of_home"
+		},
+		{
+			"codepoint": 61318,
+			"name": "digital_wellbeing"
+		},
+		{
+			"codepoint": 62108,
+			"name": "dine_heart"
+		},
+		{
+			"codepoint": 62101,
+			"name": "dine_in"
+		},
+		{
+			"codepoint": 62107,
+			"name": "dine_lamp"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 63616,
+			"name": "directions_alt"
+		},
+		{
+			"codepoint": 63617,
+			"name": "directions_alt_off"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 62562,
+			"name": "directions_railway_2"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 58260,
+			"name": "directory_sync"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 57368,
+			"name": "discover_tune"
+		},
+		{
+			"codepoint": 59808,
+			"name": "dishwasher"
+		},
+		{
+			"codepoint": 59442,
+			"name": "dishwasher_gen"
+		},
+		{
+			"codepoint": 63463,
+			"name": "display_external_input"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63210,
+			"name": "distance"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 63575,
+			"name": "diversity_4"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 62176,
+			"name": "dock"
+		},
+		{
+			"codepoint": 63462,
+			"name": "dock_to_bottom"
+		},
+		{
+			"codepoint": 63461,
+			"name": "dock_to_left"
+		},
+		{
+			"codepoint": 63460,
+			"name": "dock_to_right"
+		},
+		{
+			"codepoint": 60029,
+			"name": "docs"
+		},
+		{
+			"codepoint": 61634,
+			"name": "docs_add_on"
+		},
+		{
+			"codepoint": 61635,
+			"name": "docs_apps_script"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 62341,
+			"name": "document_search"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 63408,
+			"name": "domain_verification_off"
+		},
+		{
+			"codepoint": 62948,
+			"name": "domino_mask"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 59260,
+			"name": "door_open"
+		},
+		{
+			"codepoint": 57994,
+			"name": "door_sensor"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 57831,
+			"name": "doorbell_3p"
+		},
+		{
+			"codepoint": 57843,
+			"name": "doorbell_chime"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 62755,
+			"name": "download_2"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 58996,
+			"name": "draft"
+		},
+		{
+			"codepoint": 59315,
+			"name": "draft_orders"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 63263,
+			"name": "drag_click"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 63262,
+			"name": "drag_pan"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 63480,
+			"name": "draw_abstract"
+		},
+		{
+			"codepoint": 63479,
+			"name": "draw_collage"
+		},
+		{
+			"codepoint": 60160,
+			"name": "drawing_recognition"
+		},
+		{
+			"codepoint": 57872,
+			"name": "dresser"
+		},
+		{
+			"codepoint": 61431,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 62493,
+			"name": "drive_export"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_outline"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 58998,
+			"name": "drive_file_rename"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 59000,
+			"name": "drive_fusiontable"
+		},
+		{
+			"codepoint": 62042,
+			"name": "drone"
+		},
+		{
+			"codepoint": 62041,
+			"name": "drone_2"
+		},
+		{
+			"codepoint": 59812,
+			"name": "dropdown"
+		},
+		{
+			"codepoint": 1048304,
+			"name": "dropdown_menu"
+		},
+		{
+			"codepoint": 62289,
+			"name": "dropper_eye"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 63183,
+			"name": "dual_screen"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61722,
+			"name": "e911_avatar"
+		},
+		{
+			"codepoint": 61721,
+			"name": "e911_emergency"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 63459,
+			"name": "e_mobiledata_badge"
+		},
+		{
+			"codepoint": 62294,
+			"name": "ear_sound"
+		},
+		{
+			"codepoint": 62247,
+			"name": "earbud_case"
+		},
+		{
+			"codepoint": 62246,
+			"name": "earbud_left"
+		},
+		{
+			"codepoint": 62245,
+			"name": "earbud_right"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 62244,
+			"name": "earbuds_2"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 58042,
+			"name": "early_on"
+		},
+		{
+			"codepoint": 63055,
+			"name": "earthquake"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 63503,
+			"name": "ecg"
+		},
+		{
+			"codepoint": 63209,
+			"name": "ecg_heart"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 63208,
+			"name": "eda"
+		},
+		{
+			"codepoint": 62191,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 62190,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 61591,
+			"name": "edit"
+		},
+		{
+			"codepoint": 62336,
+			"name": "edit_arrow_down"
+		},
+		{
+			"codepoint": 62335,
+			"name": "edit_arrow_up"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 62509,
+			"name": "edit_audio"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 63628,
+			"name": "edit_document"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 63629,
+			"name": "edit_square"
+		},
+		{
+			"codepoint": 62760,
+			"name": "editor_choice"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 63207,
+			"name": "elevation"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57689,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 61789,
+			"name": "emergency_heat"
+		},
+		{
+			"codepoint": 62693,
+			"name": "emergency_heat_2"
+		},
+		{
+			"codepoint": 59434,
+			"name": "emergency_home"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 62878,
+			"name": "emergency_share_off"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 61638,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 62669,
+			"name": "emoji_language"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 58867,
+			"name": "emoticon"
+		},
+		{
+			"codepoint": 63556,
+			"name": "empty_dashboard"
+		},
+		{
+			"codepoint": 61832,
+			"name": "enable"
+		},
+		{
+			"codepoint": 58771,
+			"name": "encrypted"
+		},
+		{
+			"codepoint": 62505,
+			"name": "encrypted_add"
+		},
+		{
+			"codepoint": 62506,
+			"name": "encrypted_add_circle"
+		},
+		{
+			"codepoint": 62504,
+			"name": "encrypted_minus_circle"
+		},
+		{
+			"codepoint": 62503,
+			"name": "encrypted_off"
+		},
+		{
+			"codepoint": 57513,
+			"name": "endocrinology"
+		},
+		{
+			"codepoint": 59814,
+			"name": "energy"
+		},
+		{
+			"codepoint": 61791,
+			"name": "energy_program_saving"
+		},
+		{
+			"codepoint": 61793,
+			"name": "energy_program_time_used"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57514,
+			"name": "ent"
+		},
+		{
+			"codepoint": 59150,
+			"name": "enterprise"
+		},
+		{
+			"codepoint": 60237,
+			"name": "enterprise_off"
+		},
+		{
+			"codepoint": 63355,
+			"name": "equal"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 62460,
+			"name": "eraser_size_1"
+		},
+		{
+			"codepoint": 62459,
+			"name": "eraser_size_2"
+		},
+		{
+			"codepoint": 62458,
+			"name": "eraser_size_3"
+		},
+		{
+			"codepoint": 62457,
+			"name": "eraser_size_4"
+		},
+		{
+			"codepoint": 62456,
+			"name": "eraser_size_5"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_circle_rounded"
+		},
+		{
+			"codepoint": 58523,
+			"name": "error_med"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_charger"
+		},
+		{
+			"codepoint": 63458,
+			"name": "ev_mobiledata_badge"
+		},
+		{
+			"codepoint": 61327,
+			"name": "ev_shadow"
+		},
+		{
+			"codepoint": 62848,
+			"name": "ev_shadow_add"
+		},
+		{
+			"codepoint": 62847,
+			"name": "ev_shadow_minus"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 63107,
+			"name": "event_list"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 62008,
+			"name": "event_upcoming"
+		},
+		{
+			"codepoint": 61999,
+			"name": "exclamation"
+		},
+		{
+			"codepoint": 63206,
+			"name": "exercise"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59718,
+			"name": "expand_all"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 62865,
+			"name": "expand_circle_right"
+		},
+		{
+			"codepoint": 62930,
+			"name": "expand_circle_up"
+		},
+		{
+			"codepoint": 63536,
+			"name": "expand_content"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expansion_panels"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expension_panels"
+		},
+		{
+			"codepoint": 59014,
+			"name": "experiment"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 58680,
+			"name": "explore_nearby"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 63109,
+			"name": "explosion"
+		},
+		{
+			"codepoint": 57516,
+			"name": "export_notes"
+		},
+		{
+			"codepoint": 58358,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 59392,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 62665,
+			"name": "eye_tracking"
+		},
+		{
+			"codepoint": 61107,
+			"name": "eyebrow"
+		},
+		{
+			"codepoint": 63214,
+			"name": "eyeglasses"
+		},
+		{
+			"codepoint": 62151,
+			"name": "eyeglasses_2"
+		},
+		{
+			"codepoint": 62053,
+			"name": "eyeglasses_2_sound"
+		},
+		{
+			"codepoint": 1048305,
+			"name": "eyeglasses_3"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 62466,
+			"name": "face_down"
+		},
+		{
+			"codepoint": 62465,
+			"name": "face_left"
+		},
+		{
+			"codepoint": 62464,
+			"name": "face_nod"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 62463,
+			"name": "face_right"
+		},
+		{
+			"codepoint": 62462,
+			"name": "face_shake"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62461,
+			"name": "face_up"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 62989,
+			"name": "falling"
+		},
+		{
+			"codepoint": 57884,
+			"name": "familiar_face_and_zone"
+		},
+		{
+			"codepoint": 61170,
+			"name": "family_group"
+		},
+		{
+			"codepoint": 57517,
+			"name": "family_history"
+		},
+		{
+			"codepoint": 60198,
+			"name": "family_home"
+		},
+		{
+			"codepoint": 60185,
+			"name": "family_link"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 62759,
+			"name": "family_star"
+		},
+		{
+			"codepoint": 62260,
+			"name": "fan_focus"
+		},
+		{
+			"codepoint": 62259,
+			"name": "fan_indirect"
+		},
+		{
+			"codepoint": 62809,
+			"name": "farsight_digital"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 57976,
+			"name": "faucet"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 59817,
+			"name": "feature_search"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 61329,
+			"name": "featured_seasonal_and_gifts"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 63633,
+			"name": "femur"
+		},
+		{
+			"codepoint": 63634,
+			"name": "femur_alt"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 63205,
+			"name": "fertile"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 62680,
+			"name": "file_copy_off"
+		},
+		{
+			"codepoint": 61584,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 62386,
+			"name": "file_export"
+		},
+		{
+			"codepoint": 62395,
+			"name": "file_json"
+		},
+		{
+			"codepoint": 58053,
+			"name": "file_map"
+		},
+		{
+			"codepoint": 62434,
+			"name": "file_map_stack"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 62396,
+			"name": "file_png"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 61823,
+			"name": "file_save"
+		},
+		{
+			"codepoint": 58629,
+			"name": "file_save_off"
+		},
+		{
+			"codepoint": 61595,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 63622,
+			"name": "file_upload_off"
+		},
+		{
+			"codepoint": 60037,
+			"name": "files"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 62417,
+			"name": "filter_arrow_right"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 59726,
+			"name": "filter_list_alt"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58337,
+			"name": "filter_retrolux"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59071,
+			"name": "finance"
+		},
+		{
+			"codepoint": 63566,
+			"name": "finance_chip"
+		},
+		{
+			"codepoint": 61330,
+			"name": "finance_mode"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 62621,
+			"name": "fingerprint_off"
+		},
+		{
+			"codepoint": 1048488,
+			"name": "fire_check"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 61859,
+			"name": "fire_hydrant"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 63354,
+			"name": "fit_page"
+		},
+		{
+			"codepoint": 62359,
+			"name": "fit_page_height"
+		},
+		{
+			"codepoint": 62358,
+			"name": "fit_page_width"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 63353,
+			"name": "fit_width"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 62563,
+			"name": "fitness_tracker"
+		},
+		{
+			"codepoint": 61169,
+			"name": "fitness_trackers"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag"
+		},
+		{
+			"codepoint": 62479,
+			"name": "flag_2"
+		},
+		{
+			"codepoint": 62424,
+			"name": "flag_check"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag_filled"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 63352,
+			"name": "flex_direction"
+		},
+		{
+			"codepoint": 63351,
+			"name": "flex_no_wrap"
+		},
+		{
+			"codepoint": 63350,
+			"name": "flex_wrap"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 59819,
+			"name": "flights_and_hotels"
+		},
+		{
+			"codepoint": 61331,
+			"name": "flightsmode"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 62556,
+			"name": "float_landscape_2"
+		},
+		{
+			"codepoint": 62555,
+			"name": "float_portrait_2"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 63204,
+			"name": "floor"
+		},
+		{
+			"codepoint": 57886,
+			"name": "floor_lamp"
+		},
+		{
+			"codepoint": 61565,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 62349,
+			"name": "flowchart"
+		},
+		{
+			"codepoint": 57518,
+			"name": "flowsheet"
+		},
+		{
+			"codepoint": 58499,
+			"name": "fluid"
+		},
+		{
+			"codepoint": 63501,
+			"name": "fluid_balance"
+		},
+		{
+			"codepoint": 63500,
+			"name": "fluid_med"
+		},
+		{
+			"codepoint": 61565,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 61917,
+			"name": "flutter"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 62584,
+			"name": "flyover"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61915,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 59416,
+			"name": "foggy"
+		},
+		{
+			"codepoint": 62957,
+			"name": "folded_hands"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 62423,
+			"name": "folder_check"
+		},
+		{
+			"codepoint": 62422,
+			"name": "folder_check_2"
+		},
+		{
+			"codepoint": 62408,
+			"name": "folder_code"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 62854,
+			"name": "folder_data"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 62421,
+			"name": "folder_eye"
+		},
+		{
+			"codepoint": 62357,
+			"name": "folder_info"
+		},
+		{
+			"codepoint": 62692,
+			"name": "folder_limited"
+		},
+		{
+			"codepoint": 63349,
+			"name": "folder_managed"
+		},
+		{
+			"codepoint": 62420,
+			"name": "folder_match"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 63348,
+			"name": "folder_supervised"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 63635,
+			"name": "foot_bones"
+		},
+		{
+			"codepoint": 63613,
+			"name": "footprint"
+		},
+		{
+			"codepoint": 59820,
+			"name": "for_you"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 1048486,
+			"name": "fork_chart"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 62436,
+			"name": "fork_spoon"
+		},
+		{
+			"codepoint": 63592,
+			"name": "forklift"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 63581,
+			"name": "format_h1"
+		},
+		{
+			"codepoint": 63582,
+			"name": "format_h2"
+		},
+		{
+			"codepoint": 63583,
+			"name": "format_h3"
+		},
+		{
+			"codepoint": 63584,
+			"name": "format_h4"
+		},
+		{
+			"codepoint": 63585,
+			"name": "format_h5"
+		},
+		{
+			"codepoint": 63586,
+			"name": "format_h6"
+		},
+		{
+			"codepoint": 61104,
+			"name": "format_image_back"
+		},
+		{
+			"codepoint": 61103,
+			"name": "format_image_break_left"
+		},
+		{
+			"codepoint": 61102,
+			"name": "format_image_break_right"
+		},
+		{
+			"codepoint": 61101,
+			"name": "format_image_front"
+		},
+		{
+			"codepoint": 61100,
+			"name": "format_image_inline_left"
+		},
+		{
+			"codepoint": 1048573,
+			"name": "format_image_inline_right"
+		},
+		{
+			"codepoint": 63587,
+			"name": "format_image_left"
+		},
+		{
+			"codepoint": 63588,
+			"name": "format_image_right"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 63531,
+			"name": "format_ink_highlighter"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 63347,
+			"name": "format_letter_spacing"
+		},
+		{
+			"codepoint": 63000,
+			"name": "format_letter_spacing_2"
+		},
+		{
+			"codepoint": 62999,
+			"name": "format_letter_spacing_standard"
+		},
+		{
+			"codepoint": 62998,
+			"name": "format_letter_spacing_wide"
+		},
+		{
+			"codepoint": 62997,
+			"name": "format_letter_spacing_wider"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 63561,
+			"name": "format_list_bulleted_add"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 1048471,
+			"name": "format_paint_off"
+		},
+		{
+			"codepoint": 63589,
+			"name": "format_paragraph"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 62483,
+			"name": "format_quote_off"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 63530,
+			"name": "format_text_clip"
+		},
+		{
+			"codepoint": 63529,
+			"name": "format_text_overflow"
+		},
+		{
+			"codepoint": 63528,
+			"name": "format_text_wrap"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 62648,
+			"name": "format_textdirection_vertical"
+		},
+		{
+			"codepoint": 57929,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 63621,
+			"name": "format_underlined_squiggle"
+		},
+		{
+			"codepoint": 61639,
+			"name": "forms_add_on"
+		},
+		{
+			"codepoint": 61640,
+			"name": "forms_apps_script"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 59567,
+			"name": "forum"
+		},
+		{
+			"codepoint": 62842,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 63221,
+			"name": "forward_circle"
+		},
+		{
+			"codepoint": 63220,
+			"name": "forward_media"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 62277,
+			"name": "fragrance"
+		},
+		{
+			"codepoint": 61167,
+			"name": "frame_bug"
+		},
+		{
+			"codepoint": 61166,
+			"name": "frame_exclamation"
+		},
+		{
+			"codepoint": 63346,
+			"name": "frame_inspect"
+		},
+		{
+			"codepoint": 63654,
+			"name": "frame_person"
+		},
+		{
+			"codepoint": 62677,
+			"name": "frame_person_mic"
+		},
+		{
+			"codepoint": 63441,
+			"name": "frame_person_off"
+		},
+		{
+			"codepoint": 63345,
+			"name": "frame_reload"
+		},
+		{
+			"codepoint": 63344,
+			"name": "frame_source"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 63593,
+			"name": "front_loader"
+		},
+		{
+			"codepoint": 60178,
+			"name": "full_coverage"
+		},
+		{
+			"codepoint": 62859,
+			"name": "full_hd"
+		},
+		{
+			"codepoint": 61970,
+			"name": "full_stacked_bar_chart"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 62554,
+			"name": "fullscreen_portrait"
+		},
+		{
+			"codepoint": 63590,
+			"name": "function"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 62583,
+			"name": "funicular"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 63457,
+			"name": "g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 63599,
+			"name": "gallery_thumbnail"
+		},
+		{
+			"codepoint": 61152,
+			"name": "game_bumper_left"
+		},
+		{
+			"codepoint": 61151,
+			"name": "game_bumper_right"
+		},
+		{
+			"codepoint": 61150,
+			"name": "game_button_l"
+		},
+		{
+			"codepoint": 61149,
+			"name": "game_button_l1"
+		},
+		{
+			"codepoint": 61148,
+			"name": "game_button_l2"
+		},
+		{
+			"codepoint": 61147,
+			"name": "game_button_r"
+		},
+		{
+			"codepoint": 61146,
+			"name": "game_button_r1"
+		},
+		{
+			"codepoint": 61145,
+			"name": "game_button_r2"
+		},
+		{
+			"codepoint": 61144,
+			"name": "game_button_zl"
+		},
+		{
+			"codepoint": 61143,
+			"name": "game_button_zr"
+		},
+		{
+			"codepoint": 61142,
+			"name": "game_stick_l3"
+		},
+		{
+			"codepoint": 61141,
+			"name": "game_stick_left"
+		},
+		{
+			"codepoint": 61140,
+			"name": "game_stick_r3"
+		},
+		{
+			"codepoint": 61139,
+			"name": "game_stick_right"
+		},
+		{
+			"codepoint": 61138,
+			"name": "game_trigger_left"
+		},
+		{
+			"codepoint": 61137,
+			"name": "game_trigger_right"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 61136,
+			"name": "gamepad_circle_down"
+		},
+		{
+			"codepoint": 61135,
+			"name": "gamepad_circle_left"
+		},
+		{
+			"codepoint": 61134,
+			"name": "gamepad_circle_right"
+		},
+		{
+			"codepoint": 61133,
+			"name": "gamepad_circle_up"
+		},
+		{
+			"codepoint": 61132,
+			"name": "gamepad_down"
+		},
+		{
+			"codepoint": 61131,
+			"name": "gamepad_left"
+		},
+		{
+			"codepoint": 61130,
+			"name": "gamepad_right"
+		},
+		{
+			"codepoint": 61129,
+			"name": "gamepad_up"
+		},
+		{
+			"codepoint": 58127,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 62093,
+			"name": "garage_check"
+		},
+		{
+			"codepoint": 59156,
+			"name": "garage_door"
+		},
+		{
+			"codepoint": 1048439,
+			"name": "garage_door_open"
+		},
+		{
+			"codepoint": 59437,
+			"name": "garage_home"
+		},
+		{
+			"codepoint": 62092,
+			"name": "garage_money"
+		},
+		{
+			"codepoint": 63657,
+			"name": "garden_cart"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 57585,
+			"name": "gastroenterology"
+		},
+		{
+			"codepoint": 57975,
+			"name": "gate"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59102,
+			"name": "general_device"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57587,
+			"name": "genetics"
+		},
+		{
+			"codepoint": 59118,
+			"name": "genres"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 63063,
+			"name": "gesture_select"
+		},
+		{
+			"codepoint": 61584,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 62478,
+			"name": "gif_2"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 63203,
+			"name": "glass_cup"
+		},
+		{
+			"codepoint": 58956,
+			"name": "globe"
+		},
+		{
+			"codepoint": 1048503,
+			"name": "globe_2_cancel"
+		},
+		{
+			"codepoint": 1048502,
+			"name": "globe_2_question"
+		},
+		{
+			"codepoint": 63385,
+			"name": "globe_asia"
+		},
+		{
+			"codepoint": 62409,
+			"name": "globe_book"
+		},
+		{
+			"codepoint": 62301,
+			"name": "globe_location_pin"
+		},
+		{
+			"codepoint": 63384,
+			"name": "globe_uk"
+		},
+		{
+			"codepoint": 58528,
+			"name": "glucose"
+		},
+		{
+			"codepoint": 63651,
+			"name": "glyphs"
+		},
+		{
+			"codepoint": 63261,
+			"name": "go_to_line"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 62582,
+			"name": "gondola_lift"
+		},
+		{
+			"codepoint": 59157,
+			"name": "google_home_devices"
+		},
+		{
+			"codepoint": 62842,
+			"name": "google_plus_reshare"
+		},
+		{
+			"codepoint": 62939,
+			"name": "google_tv_remote"
+		},
+		{
+			"codepoint": 62841,
+			"name": "google_wifi"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 58716,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57783,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57782,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 61594,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 62368,
+			"name": "graph_1"
+		},
+		{
+			"codepoint": 62367,
+			"name": "graph_2"
+		},
+		{
+			"codepoint": 62366,
+			"name": "graph_3"
+		},
+		{
+			"codepoint": 62365,
+			"name": "graph_4"
+		},
+		{
+			"codepoint": 62364,
+			"name": "graph_5"
+		},
+		{
+			"codepoint": 62363,
+			"name": "graph_6"
+		},
+		{
+			"codepoint": 62278,
+			"name": "graph_7"
+		},
+		{
+			"codepoint": 1048556,
+			"name": "graph_8"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 1048472,
+			"name": "graphic_eq_off"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 63100,
+			"name": "grid_3x3_off"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 63343,
+			"name": "grid_guides"
+		},
+		{
+			"codepoint": 1048461,
+			"name": "grid_layout_side"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 61335,
+			"name": "grocery"
+		},
+		{
+			"codepoint": 59937,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 62414,
+			"name": "group_search"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 61969,
+			"name": "grouped_bar_chart"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 62657,
+			"name": "guardian"
+		},
+		{
+			"codepoint": 57588,
+			"name": "gynecology"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 63456,
+			"name": "h_mobiledata_badge"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 63455,
+			"name": "h_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 59128,
+			"name": "hallway"
+		},
+		{
+			"codepoint": 62015,
+			"name": "hanami_dango"
+		},
+		{
+			"codepoint": 63636,
+			"name": "hand_bones"
+		},
+		{
+			"codepoint": 61340,
+			"name": "hand_gesture"
+		},
+		{
+			"codepoint": 62451,
+			"name": "hand_gesture_off"
+		},
+		{
+			"codepoint": 62100,
+			"name": "hand_meal"
+		},
+		{
+			"codepoint": 62099,
+			"name": "hand_package"
+		},
+		{
+			"codepoint": 62662,
+			"name": "handheld_controller"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 60162,
+			"name": "handwriting_recognition"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 57537,
+			"name": "hangout_video"
+		},
+		{
+			"codepoint": 57538,
+			"name": "hangout_video_off"
+		},
+		{
+			"codepoint": 62426,
+			"name": "hard_disk"
+		},
+		{
+			"codepoint": 63502,
+			"name": "hard_drive"
+		},
+		{
+			"codepoint": 63396,
+			"name": "hard_drive_2"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58351,
+			"name": "hdr_plus_off"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 62661,
+			"name": "head_mounted_device"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 61341,
+			"name": "health_and_beauty"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 62147,
+			"name": "health_cross"
+		},
+		{
+			"codepoint": 63202,
+			"name": "health_metrics"
+		},
+		{
+			"codepoint": 63342,
+			"name": "heap_snapshot_large"
+		},
+		{
+			"codepoint": 63341,
+			"name": "heap_snapshot_multiple"
+		},
+		{
+			"codepoint": 63340,
+			"name": "heap_snapshot_thumbnail"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 62564,
+			"name": "hearing_aid"
+		},
+		{
+			"codepoint": 62384,
+			"name": "hearing_aid_disabled"
+		},
+		{
+			"codepoint": 62188,
+			"name": "hearing_aid_disabled_left"
+		},
+		{
+			"codepoint": 62189,
+			"name": "hearing_aid_left"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 62986,
+			"name": "heart_check"
+		},
+		{
+			"codepoint": 63619,
+			"name": "heart_minus"
+		},
+		{
+			"codepoint": 63620,
+			"name": "heart_plus"
+		},
+		{
+			"codepoint": 62098,
+			"name": "heart_smile"
+		},
+		{
+			"codepoint": 62775,
+			"name": "heat"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 57982,
+			"name": "heat_pump_balance"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 62988,
+			"name": "helicopter"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 63504,
+			"name": "help_clinic"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 57590,
+			"name": "hematology"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61342,
+			"name": "hide"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 62106,
+			"name": "high_chair"
+		},
+		{
+			"codepoint": 63388,
+			"name": "high_density"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 62795,
+			"name": "high_res"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 62736,
+			"name": "highlight_keyboard_focus"
+		},
+		{
+			"codepoint": 62737,
+			"name": "highlight_mouse_cursor"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 62738,
+			"name": "highlight_text_cursor"
+		},
+		{
+			"codepoint": 63339,
+			"name": "highlighter_size_1"
+		},
+		{
+			"codepoint": 63338,
+			"name": "highlighter_size_2"
+		},
+		{
+			"codepoint": 63337,
+			"name": "highlighter_size_3"
+		},
+		{
+			"codepoint": 63336,
+			"name": "highlighter_size_4"
+		},
+		{
+			"codepoint": 63335,
+			"name": "highlighter_size_5"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59571,
+			"name": "history"
+		},
+		{
+			"codepoint": 62438,
+			"name": "history_2"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 62682,
+			"name": "history_off"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home"
+		},
+		{
+			"codepoint": 61343,
+			"name": "home_and_garden"
+		},
+		{
+			"codepoint": 58005,
+			"name": "home_app_logo"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home_filled"
+		},
+		{
+			"codepoint": 58553,
+			"name": "home_health"
+		},
+		{
+			"codepoint": 61344,
+			"name": "home_improvement_and_tools"
+		},
+		{
+			"codepoint": 57987,
+			"name": "home_iot_device"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 59465,
+			"name": "home_max_dots"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61773,
+			"name": "home_pin"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 61724,
+			"name": "home_speaker"
+		},
+		{
+			"codepoint": 63596,
+			"name": "home_storage"
+		},
+		{
+			"codepoint": 1048446,
+			"name": "home_storage_gear"
+		},
+		{
+			"codepoint": 61488,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 1048476,
+			"name": "horizontal_align_center"
+		},
+		{
+			"codepoint": 1048475,
+			"name": "horizontal_align_left"
+		},
+		{
+			"codepoint": 1048474,
+			"name": "horizontal_align_right"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 62425,
+			"name": "host"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58697,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 60415,
+			"name": "hourglass"
+		},
+		{
+			"codepoint": 62334,
+			"name": "hourglass_arrow_down"
+		},
+		{
+			"codepoint": 62333,
+			"name": "hourglass_arrow_up"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 1048557,
+			"name": "hourglass_check"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 62348,
+			"name": "hourglass_pause"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 59270,
+			"name": "house_with_shield"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 61345,
+			"name": "household_supplies"
+		},
+		{
+			"codepoint": 62581,
+			"name": "hov"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 63162,
+			"name": "hr_resting"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59545,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 63637,
+			"name": "humerus"
+		},
+		{
+			"codepoint": 63638,
+			"name": "humerus_alt"
+		},
+		{
+			"codepoint": 61795,
+			"name": "humidity_high"
+		},
+		{
+			"codepoint": 62808,
+			"name": "humidity_indoor"
+		},
+		{
+			"codepoint": 61796,
+			"name": "humidity_low"
+		},
+		{
+			"codepoint": 61797,
+			"name": "humidity_mid"
+		},
+		{
+			"codepoint": 63614,
+			"name": "humidity_percentage"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 62258,
+			"name": "hvac_max_defrost"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 62666,
+			"name": "id_card"
+		},
+		{
+			"codepoint": 1048298,
+			"name": "id_card_2"
+		},
+		{
+			"codepoint": 58077,
+			"name": "identity_aware_proxy"
+		},
+		{
+			"codepoint": 60343,
+			"name": "identity_platform"
+		},
+		{
+			"codepoint": 57381,
+			"name": "ifl"
+		},
+		{
+			"codepoint": 63259,
+			"name": "iframe"
+		},
+		{
+			"codepoint": 63260,
+			"name": "iframe_off"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 62231,
+			"name": "image_arrow_up"
+		},
+		{
+			"codepoint": 59046,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 62023,
+			"name": "image_inset"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 61346,
+			"name": "imagesmode"
+		},
+		{
+			"codepoint": 57595,
+			"name": "immunology"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 59605,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 59443,
+			"name": "in_home_mode"
+		},
+		{
+			"codepoint": 57596,
+			"name": "inactive_order"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 63577,
+			"name": "inbox_customize"
+		},
+		{
+			"codepoint": 62361,
+			"name": "inbox_text"
+		},
+		{
+			"codepoint": 62304,
+			"name": "inbox_text_asterisk"
+		},
+		{
+			"codepoint": 62302,
+			"name": "inbox_text_person"
+		},
+		{
+			"codepoint": 62300,
+			"name": "inbox_text_share"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 62829,
+			"name": "indeterminate_question_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 62875,
+			"name": "info_i"
+		},
+		{
+			"codepoint": 63612,
+			"name": "infrared"
+		},
+		{
+			"codepoint": 59088,
+			"name": "ink_eraser"
+		},
+		{
+			"codepoint": 59363,
+			"name": "ink_eraser_off"
+		},
+		{
+			"codepoint": 59089,
+			"name": "ink_highlighter"
+		},
+		{
+			"codepoint": 62756,
+			"name": "ink_highlighter_move"
+		},
+		{
+			"codepoint": 1048340,
+			"name": "ink_highlighter_off"
+		},
+		{
+			"codepoint": 59090,
+			"name": "ink_marker"
+		},
+		{
+			"codepoint": 59091,
+			"name": "ink_pen"
+		},
+		{
+			"codepoint": 61266,
+			"name": "ink_selection"
+		},
+		{
+			"codepoint": 57598,
+			"name": "inpatient"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 63258,
+			"name": "input_circle"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_filled"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 58996,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 59938,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 59512,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 58356,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 63527,
+			"name": "insert_text"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 62157,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 57382,
+			"name": "instant_mix"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 63487,
+			"name": "interactive_space"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 57383,
+			"name": "ios"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 59829,
+			"name": "jamboard_kiosk"
+		},
+		{
+			"codepoint": 62084,
+			"name": "japanese_curry"
+		},
+		{
+			"codepoint": 62083,
+			"name": "japanese_flag"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 1048283,
+			"name": "jewelry"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 62958,
+			"name": "joystick"
+		},
+		{
+			"codepoint": 63257,
+			"name": "jump_to_element"
+		},
+		{
+			"codepoint": 62014,
+			"name": "kanji_alcohol"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep"
+		},
+		{
+			"codepoint": 59129,
+			"name": "keep_off"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep_pin"
+		},
+		{
+			"codepoint": 62831,
+			"name": "keep_public"
+		},
+		{
+			"codepoint": 58041,
+			"name": "kettle"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 62746,
+			"name": "key_vertical"
+		},
+		{
+			"codepoint": 61849,
+			"name": "key_visualizer"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 63454,
+			"name": "keyboard_capslock_badge"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 63453,
+			"name": "keyboard_external_input"
+		},
+		{
+			"codepoint": 63452,
+			"name": "keyboard_full"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 63099,
+			"name": "keyboard_keys"
+		},
+		{
+			"codepoint": 62610,
+			"name": "keyboard_lock"
+		},
+		{
+			"codepoint": 62609,
+			"name": "keyboard_lock_off"
+		},
+		{
+			"codepoint": 63098,
+			"name": "keyboard_off"
+		},
+		{
+			"codepoint": 63451,
+			"name": "keyboard_onscreen"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 63450,
+			"name": "keyboard_previous_language"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 60531,
+			"name": "keyboard_tab_rtl"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 62758,
+			"name": "kid_star"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 57603,
+			"name": "lab_panel"
+		},
+		{
+			"codepoint": 57604,
+			"name": "lab_profile"
+		},
+		{
+			"codepoint": 63499,
+			"name": "lab_research"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 57605,
+			"name": "labs"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58724,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 62660,
+			"name": "landscape_2"
+		},
+		{
+			"codepoint": 62224,
+			"name": "landscape_2_edit"
+		},
+		{
+			"codepoint": 62659,
+			"name": "landscape_2_off"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59911,
+			"name": "language"
+		},
+		{
+			"codepoint": 63334,
+			"name": "language_chinese_array"
+		},
+		{
+			"codepoint": 63333,
+			"name": "language_chinese_cangjie"
+		},
+		{
+			"codepoint": 63332,
+			"name": "language_chinese_dayi"
+		},
+		{
+			"codepoint": 63331,
+			"name": "language_chinese_pinyin"
+		},
+		{
+			"codepoint": 63330,
+			"name": "language_chinese_quick"
+		},
+		{
+			"codepoint": 63329,
+			"name": "language_chinese_wubi"
+		},
+		{
+			"codepoint": 63328,
+			"name": "language_french"
+		},
+		{
+			"codepoint": 63327,
+			"name": "language_gb_english"
+		},
+		{
+			"codepoint": 63326,
+			"name": "language_international"
+		},
+		{
+			"codepoint": 62739,
+			"name": "language_japanese_kana"
+		},
+		{
+			"codepoint": 63325,
+			"name": "language_korean_latin"
+		},
+		{
+			"codepoint": 63324,
+			"name": "language_pinyin"
+		},
+		{
+			"codepoint": 62953,
+			"name": "language_spanish"
+		},
+		{
+			"codepoint": 63321,
+			"name": "language_us"
+		},
+		{
+			"codepoint": 63323,
+			"name": "language_us_colemak"
+		},
+		{
+			"codepoint": 63322,
+			"name": "language_us_dvorak"
+		},
+		{
+			"codepoint": 63161,
+			"name": "laps"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 62413,
+			"name": "laptop_car"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 60163,
+			"name": "lasso_select"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59550,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58024,
+			"name": "laundry"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 57606,
+			"name": "lda"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 63256,
+			"name": "left_click"
+		},
+		{
+			"codepoint": 63255,
+			"name": "left_panel_close"
+		},
+		{
+			"codepoint": 63254,
+			"name": "left_panel_open"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 63320,
+			"name": "letter_switch"
+		},
+		{
+			"codepoint": 57404,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 60164,
+			"name": "license"
+		},
+		{
+			"codepoint": 61347,
+			"name": "lift_to_talk"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 57995,
+			"name": "light_group"
+		},
+		{
+			"codepoint": 1048438,
+			"name": "light_group_2"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 1048320,
+			"name": "light_mode_auto"
+		},
+		{
+			"codepoint": 59832,
+			"name": "light_off"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 62435,
+			"name": "lightbulb_2"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 61348,
+			"name": "lightning_stand"
+		},
+		{
+			"codepoint": 1048437,
+			"name": "lightstrip"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 63319,
+			"name": "line_curve"
+		},
+		{
+			"codepoint": 63526,
+			"name": "line_end"
+		},
+		{
+			"codepoint": 63517,
+			"name": "line_end_arrow"
+		},
+		{
+			"codepoint": 63516,
+			"name": "line_end_arrow_notch"
+		},
+		{
+			"codepoint": 63515,
+			"name": "line_end_circle"
+		},
+		{
+			"codepoint": 63514,
+			"name": "line_end_diamond"
+		},
+		{
+			"codepoint": 63513,
+			"name": "line_end_square"
+		},
+		{
+			"codepoint": 63525,
+			"name": "line_start"
+		},
+		{
+			"codepoint": 63512,
+			"name": "line_start_arrow"
+		},
+		{
+			"codepoint": 63511,
+			"name": "line_start_arrow_notch"
+		},
+		{
+			"codepoint": 63510,
+			"name": "line_start_circle"
+		},
+		{
+			"codepoint": 63509,
+			"name": "line_start_diamond"
+		},
+		{
+			"codepoint": 63508,
+			"name": "line_start_square"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57936,
+			"name": "link"
+		},
+		{
+			"codepoint": 1048501,
+			"name": "link_2"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 62773,
+			"name": "linked_services"
+		},
+		{
+			"codepoint": 61106,
+			"name": "lips"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 58999,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 63318,
+			"name": "list_alt_add"
+		},
+		{
+			"codepoint": 62430,
+			"name": "list_alt_check"
+		},
+		{
+			"codepoint": 1048371,
+			"name": "list_arrow"
+		},
+		{
+			"codepoint": 59833,
+			"name": "lists"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58938,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 60228,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58721,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 59596,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 59610,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 61531,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 61652,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 59565,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 61775,
+			"name": "location_automation"
+		},
+		{
+			"codepoint": 61776,
+			"name": "location_away"
+		},
+		{
+			"codepoint": 63568,
+			"name": "location_chip"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 61778,
+			"name": "location_home"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_pin"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 63681,
+			"name": "locator_tag"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 62305,
+			"name": "lock_open_circle"
+		},
+		{
+			"codepoint": 63062,
+			"name": "lock_open_right"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 59491,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 63387,
+			"name": "low_density"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 62602,
+			"name": "lowercase"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 63449,
+			"name": "lte_mobiledata_badge"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 63448,
+			"name": "lte_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63218,
+			"name": "macro_auto"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 61750,
+			"name": "magic_button"
+		},
+		{
+			"codepoint": 63476,
+			"name": "magic_exchange"
+		},
+		{
+			"codepoint": 63447,
+			"name": "magic_tether"
+		},
+		{
+			"codepoint": 63549,
+			"name": "magnification_large"
+		},
+		{
+			"codepoint": 63548,
+			"name": "magnification_small"
+		},
+		{
+			"codepoint": 63446,
+			"name": "magnify_docked"
+		},
+		{
+			"codepoint": 63445,
+			"name": "magnify_fullscreen"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail"
+		},
+		{
+			"codepoint": 61172,
+			"name": "mail_asterisk"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 62603,
+			"name": "mail_off"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 62025,
+			"name": "mail_shield"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 62947,
+			"name": "manga"
+		},
+		{
+			"codepoint": 59174,
+			"name": "manufacturing"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 62104,
+			"name": "map_pin_heart"
+		},
+		{
+			"codepoint": 62103,
+			"name": "map_pin_review"
+		},
+		{
+			"codepoint": 62410,
+			"name": "map_search"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 62802,
+			"name": "markdown"
+		},
+		{
+			"codepoint": 62803,
+			"name": "markdown_copy"
+		},
+		{
+			"codepoint": 62804,
+			"name": "markdown_paste"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 59182,
+			"name": "masked_transitions"
+		},
+		{
+			"codepoint": 62507,
+			"name": "masked_transitions_add"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 62146,
+			"name": "massage"
+		},
+		{
+			"codepoint": 63217,
+			"name": "match_case"
+		},
+		{
+			"codepoint": 62319,
+			"name": "match_case_off"
+		},
+		{
+			"codepoint": 63216,
+			"name": "match_word"
+		},
+		{
+			"codepoint": 59655,
+			"name": "matter"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 62013,
+			"name": "meal_dinner"
+		},
+		{
+			"codepoint": 62012,
+			"name": "meal_lunch"
+		},
+		{
+			"codepoint": 63151,
+			"name": "measuring_tape"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 63551,
+			"name": "media_link"
+		},
+		{
+			"codepoint": 62706,
+			"name": "media_output"
+		},
+		{
+			"codepoint": 62707,
+			"name": "media_output_off"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 63498,
+			"name": "medical_mask"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 63395,
+			"name": "memory_alt"
+		},
+		{
+			"codepoint": 63201,
+			"name": "menstrual_health"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 62097,
+			"name": "menu_book_2"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57611,
+			"name": "metabolism"
+		},
+		{
+			"codepoint": 62580,
+			"name": "metro"
+		},
+		{
+			"codepoint": 61725,
+			"name": "mfg_nest_yale_lock"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic"
+		},
+		{
+			"codepoint": 62354,
+			"name": "mic_alert"
+		},
+		{
+			"codepoint": 62929,
+			"name": "mic_double"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 61114,
+			"name": "mic_gear"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 57612,
+			"name": "microbiology"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59463,
+			"name": "microwave_gen"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59838,
+			"name": "mimo"
+		},
+		{
+			"codepoint": 59839,
+			"name": "mimo_disconnect"
+		},
+		{
+			"codepoint": 63200,
+			"name": "mindfulness"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61353,
+			"name": "mintmark"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call_filled"
+		},
+		{
+			"codepoint": 59137,
+			"name": "missing_controller"
+		},
+		{
+			"codepoint": 57736,
+			"name": "mist"
+		},
+		{
+			"codepoint": 62791,
+			"name": "mitre"
+		},
+		{
+			"codepoint": 58568,
+			"name": "mixture_med"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 59322,
+			"name": "mobile"
+		},
+		{
+			"codepoint": 62171,
+			"name": "mobile_2"
+		},
+		{
+			"codepoint": 62170,
+			"name": "mobile_3"
+		},
+		{
+			"codepoint": 62163,
+			"name": "mobile_alert"
+		},
+		{
+			"codepoint": 62157,
+			"name": "mobile_arrow_down"
+		},
+		{
+			"codepoint": 62162,
+			"name": "mobile_arrow_right"
+		},
+		{
+			"codepoint": 62137,
+			"name": "mobile_arrow_up_right"
+		},
+		{
+			"codepoint": 62181,
+			"name": "mobile_block"
+		},
+		{
+			"codepoint": 62542,
+			"name": "mobile_camera"
+		},
+		{
+			"codepoint": 62153,
+			"name": "mobile_camera_front"
+		},
+		{
+			"codepoint": 62152,
+			"name": "mobile_camera_rear"
+		},
+		{
+			"codepoint": 62186,
+			"name": "mobile_cancel"
+		},
+		{
+			"codepoint": 62156,
+			"name": "mobile_cast"
+		},
+		{
+			"codepoint": 62179,
+			"name": "mobile_charge"
+		},
+		{
+			"codepoint": 63391,
+			"name": "mobile_chat"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_check"
+		},
+		{
+			"codepoint": 62178,
+			"name": "mobile_code"
+		},
+		{
+			"codepoint": 62176,
+			"name": "mobile_dock"
+		},
+		{
+			"codepoint": 62160,
+			"name": "mobile_dots"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 62169,
+			"name": "mobile_gear"
+		},
+		{
+			"codepoint": 62243,
+			"name": "mobile_hand"
+		},
+		{
+			"codepoint": 62227,
+			"name": "mobile_hand_left"
+		},
+		{
+			"codepoint": 62226,
+			"name": "mobile_hand_left_off"
+		},
+		{
+			"codepoint": 62228,
+			"name": "mobile_hand_off"
+		},
+		{
+			"codepoint": 62172,
+			"name": "mobile_info"
+		},
+		{
+			"codepoint": 60734,
+			"name": "mobile_landscape"
+		},
+		{
+			"codepoint": 62143,
+			"name": "mobile_layout"
+		},
+		{
+			"codepoint": 62168,
+			"name": "mobile_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "mobile_lock_portrait"
+		},
+		{
+			"codepoint": 62242,
+			"name": "mobile_loupe"
+		},
+		{
+			"codepoint": 62161,
+			"name": "mobile_menu"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 62177,
+			"name": "mobile_question"
+		},
+		{
+			"codepoint": 62165,
+			"name": "mobile_rotate"
+		},
+		{
+			"codepoint": 62166,
+			"name": "mobile_rotate_lock"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 62241,
+			"name": "mobile_screensaver"
+		},
+		{
+			"codepoint": 62191,
+			"name": "mobile_sensor_hi"
+		},
+		{
+			"codepoint": 62190,
+			"name": "mobile_sensor_lo"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_share"
+		},
+		{
+			"codepoint": 62174,
+			"name": "mobile_share_stack"
+		},
+		{
+			"codepoint": 62184,
+			"name": "mobile_sound"
+		},
+		{
+			"codepoint": 62232,
+			"name": "mobile_sound_2"
+		},
+		{
+			"codepoint": 63402,
+			"name": "mobile_sound_off"
+		},
+		{
+			"codepoint": 62240,
+			"name": "mobile_speaker"
+		},
+		{
+			"codepoint": 62187,
+			"name": "mobile_text"
+		},
+		{
+			"codepoint": 62182,
+			"name": "mobile_text_2"
+		},
+		{
+			"codepoint": 62121,
+			"name": "mobile_theft"
+		},
+		{
+			"codepoint": 62180,
+			"name": "mobile_ticket"
+		},
+		{
+			"codepoint": 61162,
+			"name": "mobile_unlock"
+		},
+		{
+			"codepoint": 62155,
+			"name": "mobile_vibrate"
+		},
+		{
+			"codepoint": 62128,
+			"name": "mobile_wrench"
+		},
+		{
+			"codepoint": 1048483,
+			"name": "mobiledata_arrows"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 61798,
+			"name": "mode_cool"
+		},
+		{
+			"codepoint": 61799,
+			"name": "mode_cool_off"
+		},
+		{
+			"codepoint": 62807,
+			"name": "mode_dual"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 61800,
+			"name": "mode_fan"
+		},
+		{
+			"codepoint": 1048528,
+			"name": "mode_fan_2"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61802,
+			"name": "mode_heat"
+		},
+		{
+			"codepoint": 61803,
+			"name": "mode_heat_cool"
+		},
+		{
+			"codepoint": 61805,
+			"name": "mode_heat_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61807,
+			"name": "mode_off_on"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 62378,
+			"name": "modeling"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 62446,
+			"name": "money_bag"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 62021,
+			"name": "money_range"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 63199,
+			"name": "monitor_weight_gain"
+		},
+		{
+			"codepoint": 63198,
+			"name": "monitor_weight_loss"
+		},
+		{
+			"codepoint": 61840,
+			"name": "monitoring"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 62579,
+			"name": "monorail"
+		},
+		{
+			"codepoint": 59938,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 1048500,
+			"name": "mood_heart"
+		},
+		{
+			"codepoint": 62287,
+			"name": "moon_stars"
+		},
+		{
+			"codepoint": 57997,
+			"name": "mop"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 62091,
+			"name": "moped_package"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 61846,
+			"name": "more_down"
+		},
+		{
+			"codepoint": 58835,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 61847,
+			"name": "more_up"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61648,
+			"name": "motion_blur"
+		},
+		{
+			"codepoint": 63554,
+			"name": "motion_mode"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 62475,
+			"name": "motion_play"
+		},
+		{
+			"codepoint": 59282,
+			"name": "motion_sensor_active"
+		},
+		{
+			"codepoint": 59268,
+			"name": "motion_sensor_alert"
+		},
+		{
+			"codepoint": 59267,
+			"name": "motion_sensor_idle"
+		},
+		{
+			"codepoint": 59278,
+			"name": "motion_sensor_urgent"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 62946,
+			"name": "mountain_flag"
+		},
+		{
+			"codepoint": 62082,
+			"name": "mountain_steam"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 62608,
+			"name": "mouse_lock"
+		},
+		{
+			"codepoint": 62607,
+			"name": "mouse_lock_off"
+		},
+		{
+			"codepoint": 59200,
+			"name": "move"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 63253,
+			"name": "move_group"
+		},
+		{
+			"codepoint": 61951,
+			"name": "move_item"
+		},
+		{
+			"codepoint": 59201,
+			"name": "move_location"
+		},
+		{
+			"codepoint": 63252,
+			"name": "move_selection_down"
+		},
+		{
+			"codepoint": 63251,
+			"name": "move_selection_left"
+		},
+		{
+			"codepoint": 63250,
+			"name": "move_selection_right"
+		},
+		{
+			"codepoint": 63249,
+			"name": "move_selection_up"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 58772,
+			"name": "moved_location"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 63552,
+			"name": "movie_edit"
+		},
+		{
+			"codepoint": 1048445,
+			"name": "movie_edit_off"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 57389,
+			"name": "movie_info"
+		},
+		{
+			"codepoint": 62617,
+			"name": "movie_off"
+		},
+		{
+			"codepoint": 62115,
+			"name": "movie_speaker"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59197,
+			"name": "moving_beds"
+		},
+		{
+			"codepoint": 59198,
+			"name": "moving_ministry"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 58003,
+			"name": "multicooker"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 62491,
+			"name": "multimodal_hand_eye"
+		},
+		{
+			"codepoint": 61355,
+			"name": "multiple_airports"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 60186,
+			"name": "music_cast"
+		},
+		{
+			"codepoint": 62145,
+			"name": "music_history"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 1048536,
+			"name": "music_note_2"
+		},
+		{
+			"codepoint": 62353,
+			"name": "music_note_add"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 62945,
+			"name": "mystery"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58827,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58828,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 59063,
+			"name": "nearby"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 57613,
+			"name": "nephrology"
+		},
+		{
+			"codepoint": 60351,
+			"name": "nest_audio"
+		},
+		{
+			"codepoint": 63671,
+			"name": "nest_cam_floodlight"
+		},
+		{
+			"codepoint": 61726,
+			"name": "nest_cam_indoor"
+		},
+		{
+			"codepoint": 61727,
+			"name": "nest_cam_iq"
+		},
+		{
+			"codepoint": 61728,
+			"name": "nest_cam_iq_outdoor"
+		},
+		{
+			"codepoint": 63672,
+			"name": "nest_cam_magnet_mount"
+		},
+		{
+			"codepoint": 61729,
+			"name": "nest_cam_outdoor"
+		},
+		{
+			"codepoint": 63673,
+			"name": "nest_cam_stand"
+		},
+		{
+			"codepoint": 63674,
+			"name": "nest_cam_wall_mount"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 63675,
+			"name": "nest_clock_farsight_analog"
+		},
+		{
+			"codepoint": 63676,
+			"name": "nest_clock_farsight_digital"
+		},
+		{
+			"codepoint": 61730,
+			"name": "nest_connect"
+		},
+		{
+			"codepoint": 61731,
+			"name": "nest_detect"
+		},
+		{
+			"codepoint": 61732,
+			"name": "nest_display"
+		},
+		{
+			"codepoint": 61733,
+			"name": "nest_display_max"
+		},
+		{
+			"codepoint": 63677,
+			"name": "nest_doorbell_visitor"
+		},
+		{
+			"codepoint": 63678,
+			"name": "nest_eco_leaf"
+		},
+		{
+			"codepoint": 62077,
+			"name": "nest_farsight_cool"
+		},
+		{
+			"codepoint": 62076,
+			"name": "nest_farsight_dual"
+		},
+		{
+			"codepoint": 62075,
+			"name": "nest_farsight_eco"
+		},
+		{
+			"codepoint": 62074,
+			"name": "nest_farsight_heat"
+		},
+		{
+			"codepoint": 62073,
+			"name": "nest_farsight_seasonal"
+		},
+		{
+			"codepoint": 63679,
+			"name": "nest_farsight_weather"
+		},
+		{
+			"codepoint": 63680,
+			"name": "nest_found_savings"
+		},
+		{
+			"codepoint": 62841,
+			"name": "nest_gale_wifi"
+		},
+		{
+			"codepoint": 61734,
+			"name": "nest_heat_link_e"
+		},
+		{
+			"codepoint": 61735,
+			"name": "nest_heat_link_gen_3"
+		},
+		{
+			"codepoint": 59436,
+			"name": "nest_hello_doorbell"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_locator_tag"
+		},
+		{
+			"codepoint": 59273,
+			"name": "nest_mini"
+		},
+		{
+			"codepoint": 63682,
+			"name": "nest_multi_room"
+		},
+		{
+			"codepoint": 59022,
+			"name": "nest_protect"
+		},
+		{
+			"codepoint": 62939,
+			"name": "nest_remote"
+		},
+		{
+			"codepoint": 61738,
+			"name": "nest_remote_comfort_sensor"
+		},
+		{
+			"codepoint": 61739,
+			"name": "nest_secure_alarm"
+		},
+		{
+			"codepoint": 63683,
+			"name": "nest_sunblock"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_tag"
+		},
+		{
+			"codepoint": 59023,
+			"name": "nest_thermostat"
+		},
+		{
+			"codepoint": 61741,
+			"name": "nest_thermostat_e_eu"
+		},
+		{
+			"codepoint": 61742,
+			"name": "nest_thermostat_gen_3"
+		},
+		{
+			"codepoint": 61743,
+			"name": "nest_thermostat_sensor"
+		},
+		{
+			"codepoint": 61744,
+			"name": "nest_thermostat_sensor_eu"
+		},
+		{
+			"codepoint": 61745,
+			"name": "nest_thermostat_zirconium_eu"
+		},
+		{
+			"codepoint": 63684,
+			"name": "nest_true_radiant"
+		},
+		{
+			"codepoint": 63685,
+			"name": "nest_wake_on_approach"
+		},
+		{
+			"codepoint": 63686,
+			"name": "nest_wake_on_press"
+		},
+		{
+			"codepoint": 61746,
+			"name": "nest_wifi_gale"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_mistral"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point_vento"
+		},
+		{
+			"codepoint": 62827,
+			"name": "nest_wifi_pro"
+		},
+		{
+			"codepoint": 62826,
+			"name": "nest_wifi_pro_2"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_router"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 62321,
+			"name": "network_intel_node"
+		},
+		{
+			"codepoint": 61356,
+			"name": "network_intelligence"
+		},
+		{
+			"codepoint": 62966,
+			"name": "network_intelligence_history"
+		},
+		{
+			"codepoint": 62965,
+			"name": "network_intelligence_update"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 63403,
+			"name": "network_manage"
+		},
+		{
+			"codepoint": 62830,
+			"name": "network_node"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 62863,
+			"name": "network_wifi_1_bar_locked"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 62862,
+			"name": "network_wifi_2_bar_locked"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 62861,
+			"name": "network_wifi_3_bar_locked"
+		},
+		{
+			"codepoint": 62770,
+			"name": "network_wifi_locked"
+		},
+		{
+			"codepoint": 57614,
+			"name": "neurology"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 61302,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 63248,
+			"name": "new_window"
+		},
+		{
+			"codepoint": 57394,
+			"name": "news"
+		},
+		{
+			"codepoint": 61357,
+			"name": "newsmode"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 59844,
+			"name": "newsstand"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 62313,
+			"name": "nfc_off"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 61911,
+			"name": "night_sight_auto"
+		},
+		{
+			"codepoint": 61945,
+			"name": "night_sight_auto_off"
+		},
+		{
+			"codepoint": 63171,
+			"name": "night_sight_max"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 61812,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57806,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 59152,
+			"name": "no_sound"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 63656,
+			"name": "noise_control_on"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 62794,
+			"name": "not_accessible_forward"
+		},
+		{
+			"codepoint": 61580,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 58996,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 62818,
+			"name": "note_stack"
+		},
+		{
+			"codepoint": 62819,
+			"name": "note_stack_add"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 61121,
+			"name": "notification_audio"
+		},
+		{
+			"codepoint": 61120,
+			"name": "notification_audio_off"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59074,
+			"name": "notification_multiple"
+		},
+		{
+			"codepoint": 62311,
+			"name": "notification_settings"
+		},
+		{
+			"codepoint": 62291,
+			"name": "notification_sound"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 62718,
+			"name": "notifications_unread"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 57616,
+			"name": "nutrition"
+		},
+		{
+			"codepoint": 59112,
+			"name": "ods"
+		},
+		{
+			"codepoint": 59113,
+			"name": "odt"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 62672,
+			"name": "offline_pin_off"
+		},
+		{
+			"codepoint": 62174,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 62081,
+			"name": "okonomiyaki"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 59075,
+			"name": "on_hub_device"
+		},
+		{
+			"codepoint": 57620,
+			"name": "oncology"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 63224,
+			"name": "onsen"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 63247,
+			"name": "open_in_new_down"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 62162,
+			"name": "open_in_phone"
+		},
+		{
+			"codepoint": 61358,
+			"name": "open_jam"
+		},
+		{
+			"codepoint": 62647,
+			"name": "open_run"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 57621,
+			"name": "ophthalmology"
+		},
+		{
+			"codepoint": 57622,
+			"name": "oral_disease"
+		},
+		{
+			"codepoint": 62502,
+			"name": "orbit"
+		},
+		{
+			"codepoint": 63506,
+			"name": "order_approve"
+		},
+		{
+			"codepoint": 63505,
+			"name": "order_play"
+		},
+		{
+			"codepoint": 60180,
+			"name": "orders"
+		},
+		{
+			"codepoint": 63639,
+			"name": "orthopedics"
+		},
+		{
+			"codepoint": 58491,
+			"name": "other_admission"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 60183,
+			"name": "outbox_alt"
+		},
+		{
+			"codepoint": 57861,
+			"name": "outdoor_garden"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61650,
+			"name": "outgoing_mail"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 61638,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 57624,
+			"name": "outpatient"
+		},
+		{
+			"codepoint": 57625,
+			"name": "outpatient_med"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 63246,
+			"name": "output_circle"
+		},
+		{
+			"codepoint": 59847,
+			"name": "oven"
+		},
+		{
+			"codepoint": 59459,
+			"name": "oven_gen"
+		},
+		{
+			"codepoint": 58535,
+			"name": "overview"
+		},
+		{
+			"codepoint": 63444,
+			"name": "overview_key"
+		},
+		{
+			"codepoint": 62388,
+			"name": "owl"
+		},
+		{
+			"codepoint": 58590,
+			"name": "oxygen_saturation"
+		},
+		{
+			"codepoint": 62762,
+			"name": "p2p"
+		},
+		{
+			"codepoint": 63160,
+			"name": "pace"
+		},
+		{
+			"codepoint": 58966,
+			"name": "pacemaker"
+		},
+		{
+			"codepoint": 58511,
+			"name": "package"
+		},
+		{
+			"codepoint": 62825,
+			"name": "package_2"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 62119,
+			"name": "padel"
+		},
+		{
+			"codepoint": 59185,
+			"name": "page_control"
+		},
+		{
+			"codepoint": 62339,
+			"name": "page_footer"
+		},
+		{
+			"codepoint": 62340,
+			"name": "page_header"
+		},
+		{
+			"codepoint": 62996,
+			"name": "page_info"
+		},
+		{
+			"codepoint": 61179,
+			"name": "page_menu_ios"
+		},
+		{
+			"codepoint": 62729,
+			"name": "pageless"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 63594,
+			"name": "pallet"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 63061,
+			"name": "pan_zoom"
+		},
+		{
+			"codepoint": 59025,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 61997,
+			"name": "parent_child_dining"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 62090,
+			"name": "parking_meter"
+		},
+		{
+			"codepoint": 62089,
+			"name": "parking_sign"
+		},
+		{
+			"codepoint": 62088,
+			"name": "parking_valet"
+		},
+		{
+			"codepoint": 61810,
+			"name": "partly_cloudy_day"
+		},
+		{
+			"codepoint": 61812,
+			"name": "partly_cloudy_night"
+		},
+		{
+			"codepoint": 63481,
+			"name": "partner_exchange"
+		},
+		{
+			"codepoint": 61230,
+			"name": "partner_heart"
+		},
+		{
+			"codepoint": 61359,
+			"name": "partner_reports"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 63615,
+			"name": "passkey"
+		},
+		{
+			"codepoint": 61124,
+			"name": "passport"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 62633,
+			"name": "password_2"
+		},
+		{
+			"codepoint": 62632,
+			"name": "password_2_off"
+		},
+		{
+			"codepoint": 58963,
+			"name": "patient_list"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 62144,
+			"name": "payment_arrow_down"
+		},
+		{
+			"codepoint": 62113,
+			"name": "payment_card"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 57629,
+			"name": "pediatrics"
+		},
+		{
+			"codepoint": 63317,
+			"name": "pen_size_1"
+		},
+		{
+			"codepoint": 63316,
+			"name": "pen_size_2"
+		},
+		{
+			"codepoint": 63315,
+			"name": "pen_size_3"
+		},
+		{
+			"codepoint": 63314,
+			"name": "pen_size_4"
+		},
+		{
+			"codepoint": 63313,
+			"name": "pen_size_5"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 62020,
+			"name": "percent_discount"
+		},
+		{
+			"codepoint": 58650,
+			"name": "performance_max"
+		},
+		{
+			"codepoint": 57859,
+			"name": "pergola"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 62172,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 61651,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 62823,
+			"name": "person_alert"
+		},
+		{
+			"codepoint": 62883,
+			"name": "person_apron"
+		},
+		{
+			"codepoint": 62952,
+			"name": "person_book"
+		},
+		{
+			"codepoint": 62822,
+			"name": "person_cancel"
+		},
+		{
+			"codepoint": 63486,
+			"name": "person_celebrate"
+		},
+		{
+			"codepoint": 62821,
+			"name": "person_check"
+		},
+		{
+			"codepoint": 62714,
+			"name": "person_edit"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_filled"
+		},
+		{
+			"codepoint": 62096,
+			"name": "person_heart"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 63485,
+			"name": "person_play"
+		},
+		{
+			"codepoint": 62874,
+			"name": "person_raised_hand"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 58244,
+			"name": "person_shield"
+		},
+		{
+			"codepoint": 61117,
+			"name": "person_text"
+		},
+		{
+			"codepoint": 60174,
+			"name": "personal_bag"
+		},
+		{
+			"codepoint": 60175,
+			"name": "personal_bag_off"
+		},
+		{
+			"codepoint": 60176,
+			"name": "personal_bag_question"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 59139,
+			"name": "personal_places"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 61361,
+			"name": "pet_supplies"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone_alt"
+		},
+		{
+			"codepoint": 62171,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 1048477,
+			"name": "phone_cancel"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 62170,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 62186,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 62142,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 63397,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 62184,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 63402,
+			"name": "phonelink_ring_off"
+		},
+		{
+			"codepoint": 62169,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 62768,
+			"name": "photo_auto_merge"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 61657,
+			"name": "photo_frame"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 61362,
+			"name": "photo_prints"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 57630,
+			"name": "physical_therapy"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 62118,
+			"name": "pickleball"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 62800,
+			"name": "picture_in_picture_center"
+		},
+		{
+			"codepoint": 62799,
+			"name": "picture_in_picture_large"
+		},
+		{
+			"codepoint": 62798,
+			"name": "picture_in_picture_medium"
+		},
+		{
+			"codepoint": 62743,
+			"name": "picture_in_picture_mobile"
+		},
+		{
+			"codepoint": 62767,
+			"name": "picture_in_picture_off"
+		},
+		{
+			"codepoint": 62797,
+			"name": "picture_in_picture_small"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_filled"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outlined"
+		},
+		{
+			"codepoint": 57631,
+			"name": "pill"
+		},
+		{
+			"codepoint": 63497,
+			"name": "pill_off"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 1048366,
+			"name": "pin_history"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 1048365,
+			"name": "pin_road"
+		},
+		{
+			"codepoint": 1048299,
+			"name": "pin_road_2"
+		},
+		{
+			"codepoint": 62379,
+			"name": "pinboard"
+		},
+		{
+			"codepoint": 62380,
+			"name": "pinboard_unread"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 61946,
+			"name": "pinch_zoom_in"
+		},
+		{
+			"codepoint": 61947,
+			"name": "pinch_zoom_out"
+		},
+		{
+			"codepoint": 63053,
+			"name": "pip"
+		},
+		{
+			"codepoint": 63245,
+			"name": "pip_exit"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 61915,
+			"name": "place"
+		},
+		{
+			"codepoint": 61936,
+			"name": "place_item"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 62124,
+			"name": "plane_contrails"
+		},
+		{
+			"codepoint": 62343,
+			"name": "planet"
+		},
+		{
+			"codepoint": 59026,
+			"name": "planner_banner_ad_pt"
+		},
+		{
+			"codepoint": 59028,
+			"name": "planner_review"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 59118,
+			"name": "play_music"
+		},
+		{
+			"codepoint": 61751,
+			"name": "play_pause"
+		},
+		{
+			"codepoint": 63484,
+			"name": "play_shapes"
+		},
+		{
+			"codepoint": 62094,
+			"name": "playground"
+		},
+		{
+			"codepoint": 62095,
+			"name": "playground_2"
+		},
+		{
+			"codepoint": 62940,
+			"name": "playing_cards"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 62298,
+			"name": "plug_connect"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 57632,
+			"name": "podiatry"
+		},
+		{
+			"codepoint": 63483,
+			"name": "podium"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 63244,
+			"name": "point_scan"
+		},
+		{
+			"codepoint": 62619,
+			"name": "poker_chip"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 62471,
+			"name": "policy_alert"
+		},
+		{
+			"codepoint": 61644,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 61575,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 59473,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 63243,
+			"name": "position_bottom_left"
+		},
+		{
+			"codepoint": 63242,
+			"name": "position_bottom_right"
+		},
+		{
+			"codepoint": 63241,
+			"name": "position_top_right"
+		},
+		{
+			"codepoint": 59141,
+			"name": "post"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 63658,
+			"name": "potted_plant"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_rounded"
+		},
+		{
+			"codepoint": 62488,
+			"name": "power_settings_circle"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 63544,
+			"name": "prayer_times"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnancy"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 59352,
+			"name": "preliminary"
+		},
+		{
+			"codepoint": 57633,
+			"name": "prescriptions"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 63407,
+			"name": "preview_off"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 63394,
+			"name": "print_add"
+		},
+		{
+			"codepoint": 63393,
+			"name": "print_connect"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 63392,
+			"name": "print_error"
+		},
+		{
+			"codepoint": 63057,
+			"name": "print_lock"
+		},
+		{
+			"codepoint": 61364,
+			"name": "priority"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61768,
+			"name": "privacy"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57634,
+			"name": "problem"
+		},
+		{
+			"codepoint": 58961,
+			"name": "procedure"
+		},
+		{
+			"codepoint": 63573,
+			"name": "process_chart"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 58006,
+			"name": "productivity"
+		},
+		{
+			"codepoint": 59856,
+			"name": "progress_activity"
+		},
+		{
+			"codepoint": 62710,
+			"name": "prompt_suggestion"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 57635,
+			"name": "psychiatry"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 57636,
+			"name": "pulmonology"
+		},
+		{
+			"codepoint": 62721,
+			"name": "pulse_alert"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 63064,
+			"name": "qr_code_2_add"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 61398,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 63475,
+			"name": "question_exchange"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 59345,
+			"name": "quick_phrases"
+		},
+		{
+			"codepoint": 58478,
+			"name": "quick_reference"
+		},
+		{
+			"codepoint": 63489,
+			"name": "quick_reference_all"
+		},
+		{
+			"codepoint": 60181,
+			"name": "quick_reorder"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61785,
+			"name": "quiet_time"
+		},
+		{
+			"codepoint": 60278,
+			"name": "quiet_time_active"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 62816,
+			"name": "radio_button_partial"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 57637,
+			"name": "radiology"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 62561,
+			"name": "railway_alert_2"
+		},
+		{
+			"codepoint": 61814,
+			"name": "rainy"
+		},
+		{
+			"codepoint": 63007,
+			"name": "rainy_heavy"
+		},
+		{
+			"codepoint": 63006,
+			"name": "rainy_light"
+		},
+		{
+			"codepoint": 63005,
+			"name": "rainy_snow"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 57834,
+			"name": "range_hood"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 59142,
+			"name": "rate_review_rtl"
+		},
+		{
+			"codepoint": 62805,
+			"name": "raven"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 63197,
+			"name": "readiness_score"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 63170,
+			"name": "rear_camera"
+		},
+		{
+			"codepoint": 63557,
+			"name": "rebase"
+		},
+		{
+			"codepoint": 63558,
+			"name": "rebase_edit"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 62474,
+			"name": "receipt_long_off"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 63496,
+			"name": "recent_patient"
+		},
+		{
+			"codepoint": 62656,
+			"name": "recenter"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 61128,
+			"name": "rectangle_add"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 59638,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 63312,
+			"name": "regular_expression"
+		},
+		{
+			"codepoint": 63196,
+			"name": "relax"
+		},
+		{
+			"codepoint": 63060,
+			"name": "release_alert"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminder"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminders_alt"
+		},
+		{
+			"codepoint": 59454,
+			"name": "remote_gen"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 59636,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59861,
+			"name": "remove_selection"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 63240,
+			"name": "reopen_window"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 62545,
+			"name": "replace_audio"
+		},
+		{
+			"codepoint": 62544,
+			"name": "replace_image"
+		},
+		{
+			"codepoint": 62543,
+			"name": "replace_video"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 61571,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 62594,
+			"name": "reset_brightness"
+		},
+		{
+			"codepoint": 1048290,
+			"name": "reset_colors"
+		},
+		{
+			"codepoint": 62054,
+			"name": "reset_exposure"
+		},
+		{
+			"codepoint": 62593,
+			"name": "reset_focus"
+		},
+		{
+			"codepoint": 63524,
+			"name": "reset_image"
+		},
+		{
+			"codepoint": 62592,
+			"name": "reset_iso"
+		},
+		{
+			"codepoint": 62591,
+			"name": "reset_settings"
+		},
+		{
+			"codepoint": 62590,
+			"name": "reset_shadow"
+		},
+		{
+			"codepoint": 62589,
+			"name": "reset_shutter_speed"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 62588,
+			"name": "reset_white_balance"
+		},
+		{
+			"codepoint": 62828,
+			"name": "reset_wrench"
+		},
+		{
+			"codepoint": 63239,
+			"name": "resize"
+		},
+		{
+			"codepoint": 1048473,
+			"name": "resize_window"
+		},
+		{
+			"codepoint": 57639,
+			"name": "respiratory_rate"
+		},
+		{
+			"codepoint": 59866,
+			"name": "responsive_layout"
+		},
+		{
+			"codepoint": 61994,
+			"name": "rest_area"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 63440,
+			"name": "resume"
+		},
+		{
+			"codepoint": 61564,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61366,
+			"name": "rewarded_ads"
+		},
+		{
+			"codepoint": 57640,
+			"name": "rheumatology"
+		},
+		{
+			"codepoint": 63640,
+			"name": "rib_cage"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 63238,
+			"name": "right_click"
+		},
+		{
+			"codepoint": 63237,
+			"name": "right_panel_close"
+		},
+		{
+			"codepoint": 63236,
+			"name": "right_panel_open"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume_filled"
+		},
+		{
+			"codepoint": 59867,
+			"name": "ripples"
+		},
+		{
+			"codepoint": 62578,
+			"name": "road"
+		},
+		{
+			"codepoint": 63618,
+			"name": "robot"
+		},
+		{
+			"codepoint": 62928,
+			"name": "robot_2"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 61915,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 62487,
+			"name": "rotate_auto"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 62196,
+			"name": "router_off"
+		},
+		{
+			"codepoint": 57868,
+			"name": "routine"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 60199,
+			"name": "rubric"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 63052,
+			"name": "rule_settings"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 62877,
+			"name": "safety_check_off"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 63606,
+			"name": "salinity"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 63223,
+			"name": "sauna"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 61584,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 62360,
+			"name": "save_clock"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 63310,
+			"name": "scan"
+		},
+		{
+			"codepoint": 63311,
+			"name": "scan_delete"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 58023,
+			"name": "scene"
+		},
+		{
+			"codepoint": 61398,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 62786,
+			"name": "science_off"
+		},
+		{
+			"codepoint": 62577,
+			"name": "scooter"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 62168,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 62166,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 63097,
+			"name": "screen_record"
+		},
+		{
+			"codepoint": 62165,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 63096,
+			"name": "screen_rotation_up"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 63095,
+			"name": "screenshot_frame"
+		},
+		{
+			"codepoint": 62324,
+			"name": "screenshot_frame_2"
+		},
+		{
+			"codepoint": 63443,
+			"name": "screenshot_keyboard"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 63442,
+			"name": "screenshot_region"
+		},
+		{
+			"codepoint": 63127,
+			"name": "screenshot_tablet"
+		},
+		{
+			"codepoint": 62559,
+			"name": "script"
+		},
+		{
+			"codepoint": 59868,
+			"name": "scrollable_header"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59168,
+			"name": "sdk"
+		},
+		{
+			"codepoint": 61306,
+			"name": "search"
+		},
+		{
+			"codepoint": 62437,
+			"name": "search_activity"
+		},
+		{
+			"codepoint": 63488,
+			"name": "search_check"
+		},
+		{
+			"codepoint": 62569,
+			"name": "search_check_2"
+		},
+		{
+			"codepoint": 61178,
+			"name": "search_gear"
+		},
+		{
+			"codepoint": 59030,
+			"name": "search_hands_free"
+		},
+		{
+			"codepoint": 62652,
+			"name": "search_insights"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 62257,
+			"name": "seat_cool_left"
+		},
+		{
+			"codepoint": 62256,
+			"name": "seat_cool_right"
+		},
+		{
+			"codepoint": 62255,
+			"name": "seat_heat_left"
+		},
+		{
+			"codepoint": 62254,
+			"name": "seat_heat_right"
+		},
+		{
+			"codepoint": 1048282,
+			"name": "seat_read"
+		},
+		{
+			"codepoint": 62253,
+			"name": "seat_vent_left"
+		},
+		{
+			"codepoint": 62252,
+			"name": "seat_vent_right"
+		},
+		{
+			"codepoint": 1048289,
+			"name": "seat_window"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 62723,
+			"name": "security_key"
+		},
+		{
+			"codepoint": 62157,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 63309,
+			"name": "select"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 61950,
+			"name": "select_check_box"
+		},
+		{
+			"codepoint": 63439,
+			"name": "select_to_speak"
+		},
+		{
+			"codepoint": 59130,
+			"name": "select_window"
+		},
+		{
+			"codepoint": 62664,
+			"name": "select_window_2"
+		},
+		{
+			"codepoint": 58630,
+			"name": "select_window_off"
+		},
+		{
+			"codepoint": 63597,
+			"name": "self_care"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 1048443,
+			"name": "sell_cloud"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 59575,
+			"name": "send_money"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 62162,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 62806,
+			"name": "sensors_krx"
+		},
+		{
+			"codepoint": 62741,
+			"name": "sensors_krx_off"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 63143,
+			"name": "sentiment_calm"
+		},
+		{
+			"codepoint": 63142,
+			"name": "sentiment_content"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 63141,
+			"name": "sentiment_excited"
+		},
+		{
+			"codepoint": 61844,
+			"name": "sentiment_extremely_dissatisfied"
+		},
+		{
+			"codepoint": 63140,
+			"name": "sentiment_frustrated"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 63139,
+			"name": "sentiment_sad"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 63138,
+			"name": "sentiment_stressed"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 63137,
+			"name": "sentiment_worried"
+		},
+		{
+			"codepoint": 62636,
+			"name": "serif"
+		},
+		{
+			"codepoint": 62397,
+			"name": "server_person"
+		},
+		{
+			"codepoint": 59159,
+			"name": "service_toolbox"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 63541,
+			"name": "settings_account_box"
+		},
+		{
+			"codepoint": 61763,
+			"name": "settings_alert"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 63013,
+			"name": "settings_b_roll"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 62161,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 63012,
+			"name": "settings_cinematic_blur"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 62754,
+			"name": "settings_heart"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 63539,
+			"name": "settings_motion_mode"
+		},
+		{
+			"codepoint": 63538,
+			"name": "settings_night_sight"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 63537,
+			"name": "settings_panorama"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 63540,
+			"name": "settings_photo_camera"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 1048287,
+			"name": "settings_screen"
+		},
+		{
+			"codepoint": 61229,
+			"name": "settings_seating"
+		},
+		{
+			"codepoint": 63011,
+			"name": "settings_slow_motion"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 63010,
+			"name": "settings_timelapse"
+		},
+		{
+			"codepoint": 63009,
+			"name": "settings_video_camera"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 58028,
+			"name": "settop_component"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 1048435,
+			"name": "shades"
+		},
+		{
+			"codepoint": 1048436,
+			"name": "shades_closed"
+		},
+		{
+			"codepoint": 59871,
+			"name": "shadow"
+		},
+		{
+			"codepoint": 62852,
+			"name": "shadow_add"
+		},
+		{
+			"codepoint": 62851,
+			"name": "shadow_minus"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 60161,
+			"name": "shape_recognition"
+		},
+		{
+			"codepoint": 58882,
+			"name": "shapes"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58871,
+			"name": "share_eta"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 63179,
+			"name": "share_off"
+		},
+		{
+			"codepoint": 63652,
+			"name": "share_reviews"
+		},
+		{
+			"codepoint": 62995,
+			"name": "share_windows"
+		},
+		{
+			"codepoint": 61989,
+			"name": "shaved_ice"
+		},
+		{
+			"codepoint": 63523,
+			"name": "sheets_rtl"
+		},
+		{
+			"codepoint": 63235,
+			"name": "shelf_auto_hide"
+		},
+		{
+			"codepoint": 63234,
+			"name": "shelf_position"
+		},
+		{
+			"codepoint": 63598,
+			"name": "shelves"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 1048368,
+			"name": "shield_card"
+		},
+		{
+			"codepoint": 63110,
+			"name": "shield_lock"
+		},
+		{
+			"codepoint": 62866,
+			"name": "shield_locked"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 63056,
+			"name": "shield_person"
+		},
+		{
+			"codepoint": 62761,
+			"name": "shield_question"
+		},
+		{
+			"codepoint": 1048367,
+			"name": "shield_radar"
+		},
+		{
+			"codepoint": 62125,
+			"name": "shield_toggle"
+		},
+		{
+			"codepoint": 62223,
+			"name": "shield_watch"
+		},
+		{
+			"codepoint": 59279,
+			"name": "shield_with_heart"
+		},
+		{
+			"codepoint": 59277,
+			"name": "shield_with_house"
+		},
+		{
+			"codepoint": 58866,
+			"name": "shift"
+		},
+		{
+			"codepoint": 63406,
+			"name": "shift_lock"
+		},
+		{
+			"codepoint": 62595,
+			"name": "shift_lock_off"
+		},
+		{
+			"codepoint": 1048499,
+			"name": "shoe_cleats"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 62362,
+			"name": "shopping_bag_speed"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 62711,
+			"name": "shopping_cart_off"
+		},
+		{
+			"codepoint": 61367,
+			"name": "shoppingmode"
+		},
+		{
+			"codepoint": 58576,
+			"name": "short_stay"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 62842,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 62846,
+			"name": "shutter_speed_add"
+		},
+		{
+			"codepoint": 62845,
+			"name": "shutter_speed_minus"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 59874,
+			"name": "side_navigation"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 62040,
+			"name": "sign_language_2"
+		},
+		{
+			"codepoint": 1048292,
+			"name": "sign_language_off"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 61609,
+			"name": "signal_cellular_1_bar"
+		},
+		{
+			"codepoint": 61610,
+			"name": "signal_cellular_2_bar"
+		},
+		{
+			"codepoint": 61611,
+			"name": "signal_cellular_3_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 63401,
+			"name": "signal_cellular_add"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 1048458,
+			"name": "signal_cellular_alt_off"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 62887,
+			"name": "signal_cellular_pause"
+		},
+		{
+			"codepoint": 62009,
+			"name": "signal_disconnected"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57825,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61679,
+			"name": "signal_wifi_statusbar_not_connected"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 63308,
+			"name": "signature"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 62433,
+			"name": "simulation"
+		},
+		{
+			"codepoint": 1048281,
+			"name": "single_arrow"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 62375,
+			"name": "siren"
+		},
+		{
+			"codepoint": 62374,
+			"name": "siren_check"
+		},
+		{
+			"codepoint": 62373,
+			"name": "siren_open"
+		},
+		{
+			"codepoint": 62372,
+			"name": "siren_question"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 63641,
+			"name": "skeleton"
+		},
+		{
+			"codepoint": 62787,
+			"name": "skillet"
+		},
+		{
+			"codepoint": 62788,
+			"name": "skillet_cooktop"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 63642,
+			"name": "skull"
+		},
+		{
+			"codepoint": 62320,
+			"name": "skull_list"
+		},
+		{
+			"codepoint": 62635,
+			"name": "slab_serif"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 57875,
+			"name": "sleep"
+		},
+		{
+			"codepoint": 63159,
+			"name": "sleep_score"
+		},
+		{
+			"codepoint": 63522,
+			"name": "slide_library"
+		},
+		{
+			"codepoint": 59875,
+			"name": "sliders"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 62629,
+			"name": "smart_card_reader"
+		},
+		{
+			"codepoint": 62630,
+			"name": "smart_card_reader_off"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 59460,
+			"name": "smart_outlet"
+		},
+		{
+			"codepoint": 62160,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 59322,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 62542,
+			"name": "smartphone_camera"
+		},
+		{
+			"codepoint": 63307,
+			"name": "smb_share"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 59519,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 1048286,
+			"name": "snail"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 60763,
+			"name": "snowflake"
+		},
+		{
+			"codepoint": 59407,
+			"name": "snowing"
+		},
+		{
+			"codepoint": 63004,
+			"name": "snowing_heavy"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 61238,
+			"name": "soba"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 63136,
+			"name": "social_leaderboard"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 61237,
+			"name": "solo_dining"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 61769,
+			"name": "sound_detection_dog_barking"
+		},
+		{
+			"codepoint": 61770,
+			"name": "sound_detection_glass_break"
+		},
+		{
+			"codepoint": 61771,
+			"name": "sound_detection_loud_sound"
+		},
+		{
+			"codepoint": 63156,
+			"name": "sound_sampler"
+		},
+		{
+			"codepoint": 1048434,
+			"name": "soundbar"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61896,
+			"name": "source"
+		},
+		{
+			"codepoint": 58663,
+			"name": "source_environment"
+		},
+		{
+			"codepoint": 57645,
+			"name": "source_notes"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 1048460,
+			"name": "space_dashboard_2"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 62671,
+			"name": "spatial_speaker"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 1048433,
+			"name": "speaker_2"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 63306,
+			"name": "special_character"
+		},
+		{
+			"codepoint": 63602,
+			"name": "specific_gravity"
+		},
+		{
+			"codepoint": 63655,
+			"name": "speech_to_text"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 62676,
+			"name": "speed_0_25"
+		},
+		{
+			"codepoint": 62616,
+			"name": "speed_0_2x"
+		},
+		{
+			"codepoint": 62690,
+			"name": "speed_0_5"
+		},
+		{
+			"codepoint": 62615,
+			"name": "speed_0_5x"
+		},
+		{
+			"codepoint": 62675,
+			"name": "speed_0_75"
+		},
+		{
+			"codepoint": 62614,
+			"name": "speed_0_7x"
+		},
+		{
+			"codepoint": 62689,
+			"name": "speed_1_2"
+		},
+		{
+			"codepoint": 62674,
+			"name": "speed_1_25"
+		},
+		{
+			"codepoint": 62613,
+			"name": "speed_1_2x"
+		},
+		{
+			"codepoint": 62688,
+			"name": "speed_1_5"
+		},
+		{
+			"codepoint": 62612,
+			"name": "speed_1_5x"
+		},
+		{
+			"codepoint": 62673,
+			"name": "speed_1_75"
+		},
+		{
+			"codepoint": 62611,
+			"name": "speed_1_7x"
+		},
+		{
+			"codepoint": 1048376,
+			"name": "speed_2"
+		},
+		{
+			"codepoint": 62699,
+			"name": "speed_2x"
+		},
+		{
+			"codepoint": 1048375,
+			"name": "speed_3"
+		},
+		{
+			"codepoint": 1048374,
+			"name": "speed_4"
+		},
+		{
+			"codepoint": 62576,
+			"name": "speed_camera"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 62399,
+			"name": "split_scene"
+		},
+		{
+			"codepoint": 1048311,
+			"name": "split_scene_2"
+		},
+		{
+			"codepoint": 62207,
+			"name": "split_scene_down"
+		},
+		{
+			"codepoint": 62206,
+			"name": "split_scene_left"
+		},
+		{
+			"codepoint": 62205,
+			"name": "split_scene_right"
+		},
+		{
+			"codepoint": 62204,
+			"name": "split_scene_up"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 62717,
+			"name": "splitscreen_add"
+		},
+		{
+			"codepoint": 63094,
+			"name": "splitscreen_bottom"
+		},
+		{
+			"codepoint": 62553,
+			"name": "splitscreen_landscape"
+		},
+		{
+			"codepoint": 1048506,
+			"name": "splitscreen_landscape_add"
+		},
+		{
+			"codepoint": 63093,
+			"name": "splitscreen_left"
+		},
+		{
+			"codepoint": 62552,
+			"name": "splitscreen_portrait"
+		},
+		{
+			"codepoint": 63092,
+			"name": "splitscreen_right"
+		},
+		{
+			"codepoint": 63091,
+			"name": "splitscreen_top"
+		},
+		{
+			"codepoint": 62716,
+			"name": "splitscreen_vertical_add"
+		},
+		{
+			"codepoint": 63195,
+			"name": "spo2"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61368,
+			"name": "sports_and_outdoors"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 58010,
+			"name": "sprinkler"
+		},
+		{
+			"codepoint": 63519,
+			"name": "sprint"
+		},
+		{
+			"codepoint": 1048469,
+			"name": "sql"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 61127,
+			"name": "square_circle"
+		},
+		{
+			"codepoint": 62387,
+			"name": "square_dot"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 62985,
+			"name": "stack"
+		},
+		{
+			"codepoint": 62297,
+			"name": "stack_group"
+		},
+		{
+			"codepoint": 62492,
+			"name": "stack_hexagon"
+		},
+		{
+			"codepoint": 62984,
+			"name": "stack_off"
+		},
+		{
+			"codepoint": 62983,
+			"name": "stack_star"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 59079,
+			"name": "stacked_email"
+		},
+		{
+			"codepoint": 59081,
+			"name": "stacked_inbox"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 62720,
+			"name": "stacks"
+		},
+		{
+			"codepoint": 61749,
+			"name": "stadia_controller"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 62572,
+			"name": "stairs_2"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 60485,
+			"name": "star_rate_half"
+		},
+		{
+			"codepoint": 62237,
+			"name": "star_shine"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 62236,
+			"name": "stars_2"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 59031,
+			"name": "stat_0"
+		},
+		{
+			"codepoint": 59032,
+			"name": "stat_1"
+		},
+		{
+			"codepoint": 59033,
+			"name": "stat_2"
+		},
+		{
+			"codepoint": 59034,
+			"name": "stat_3"
+		},
+		{
+			"codepoint": 59035,
+			"name": "stat_minus_1"
+		},
+		{
+			"codepoint": 59036,
+			"name": "stat_minus_2"
+		},
+		{
+			"codepoint": 59037,
+			"name": "stat_minus_3"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 59322,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 62163,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 62251,
+			"name": "steering_wheel_heat"
+		},
+		{
+			"codepoint": 63230,
+			"name": "step"
+		},
+		{
+			"codepoint": 63233,
+			"name": "step_into"
+		},
+		{
+			"codepoint": 63232,
+			"name": "step_out"
+		},
+		{
+			"codepoint": 63231,
+			"name": "step_over"
+		},
+		{
+			"codepoint": 59879,
+			"name": "steppers"
+		},
+		{
+			"codepoint": 63194,
+			"name": "steps"
+		},
+		{
+			"codepoint": 63493,
+			"name": "stethoscope"
+		},
+		{
+			"codepoint": 63495,
+			"name": "stethoscope_arrow"
+		},
+		{
+			"codepoint": 63494,
+			"name": "stethoscope_check"
+		},
+		{
+			"codepoint": 59143,
+			"name": "sticker"
+		},
+		{
+			"codepoint": 61122,
+			"name": "sticker_add"
+		},
+		{
+			"codepoint": 59880,
+			"name": "sticky_note"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 62832,
+			"name": "stock_media"
+		},
+		{
+			"codepoint": 62789,
+			"name": "stockpot"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 62943,
+			"name": "strategy"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 63391,
+			"name": "stream_apps"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 63193,
+			"name": "stress_management"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 63305,
+			"name": "stroke_full"
+		},
+		{
+			"codepoint": 63304,
+			"name": "stroke_partial"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 57971,
+			"name": "styler"
+		},
+		{
+			"codepoint": 62980,
+			"name": "stylus"
+		},
+		{
+			"codepoint": 62310,
+			"name": "stylus_brush"
+		},
+		{
+			"codepoint": 62309,
+			"name": "stylus_fountain_pen"
+		},
+		{
+			"codepoint": 62308,
+			"name": "stylus_highlighter"
+		},
+		{
+			"codepoint": 63303,
+			"name": "stylus_laser_pointer"
+		},
+		{
+			"codepoint": 62979,
+			"name": "stylus_note"
+		},
+		{
+			"codepoint": 62307,
+			"name": "stylus_pen"
+		},
+		{
+			"codepoint": 62306,
+			"name": "stylus_pencil"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59882,
+			"name": "subheader"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 62293,
+			"name": "subtitles_gear"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 62087,
+			"name": "subway_walk"
+		},
+		{
+			"codepoint": 1048432,
+			"name": "subwoofer"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 59418,
+			"name": "sunny"
+		},
+		{
+			"codepoint": 59417,
+			"name": "sunny_snowing"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 62990,
+			"name": "supervised_user_circle_off"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57649,
+			"name": "surgical"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59038,
+			"name": "swap_driving_apps"
+		},
+		{
+			"codepoint": 59039,
+			"name": "swap_driving_apps_wheel"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59052,
+			"name": "sweep"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 1048468,
+			"name": "swipe_left_2"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 1048467,
+			"name": "swipe_right_2"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 57844,
+			"name": "switch"
+		},
+		{
+			"codepoint": 63229,
+			"name": "switch_access"
+		},
+		{
+			"codepoint": 62726,
+			"name": "switch_access_2"
+		},
+		{
+			"codepoint": 62285,
+			"name": "switch_access_3"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 1048431,
+			"name": "switch_off"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 59187,
+			"name": "switches"
+		},
+		{
+			"codepoint": 62942,
+			"name": "sword_rose"
+		},
+		{
+			"codepoint": 63625,
+			"name": "swords"
+		},
+		{
+			"codepoint": 57650,
+			"name": "symptoms"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 62332,
+			"name": "sync_arrow_down"
+		},
+		{
+			"codepoint": 62331,
+			"name": "sync_arrow_up"
+		},
+		{
+			"codepoint": 62490,
+			"name": "sync_desktop"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 63520,
+			"name": "sync_saved_locally"
+		},
+		{
+			"codepoint": 62052,
+			"name": "sync_saved_locally_off"
+		},
+		{
+			"codepoint": 57651,
+			"name": "syringe"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 63301,
+			"name": "tab_close"
+		},
+		{
+			"codepoint": 62416,
+			"name": "tab_close_inactive"
+		},
+		{
+			"codepoint": 63302,
+			"name": "tab_close_right"
+		},
+		{
+			"codepoint": 63300,
+			"name": "tab_duplicate"
+		},
+		{
+			"codepoint": 63299,
+			"name": "tab_group"
+		},
+		{
+			"codepoint": 62523,
+			"name": "tab_inactive"
+		},
+		{
+			"codepoint": 63298,
+			"name": "tab_move"
+		},
+		{
+			"codepoint": 63297,
+			"name": "tab_new_right"
+		},
+		{
+			"codepoint": 63296,
+			"name": "tab_recent"
+		},
+		{
+			"codepoint": 62194,
+			"name": "tab_search"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 61841,
+			"name": "table"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 63215,
+			"name": "table_chart_view"
+		},
+		{
+			"codepoint": 62407,
+			"name": "table_convert"
+		},
+		{
+			"codepoint": 62406,
+			"name": "table_edit"
+		},
+		{
+			"codepoint": 62566,
+			"name": "table_eye"
+		},
+		{
+			"codepoint": 57842,
+			"name": "table_lamp"
+		},
+		{
+			"codepoint": 62105,
+			"name": "table_large"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 63295,
+			"name": "table_rows_narrow"
+		},
+		{
+			"codepoint": 61228,
+			"name": "table_sign"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 62541,
+			"name": "tablet_camera"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59886,
+			"name": "tabs"
+		},
+		{
+			"codepoint": 62820,
+			"name": "tactic"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 59938,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 61236,
+			"name": "takeout_dining_2"
+		},
+		{
+			"codepoint": 59438,
+			"name": "tamper_detection_off"
+		},
+		{
+			"codepoint": 63688,
+			"name": "tamper_detection_on"
+		},
+		{
+			"codepoint": 62156,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 59161,
+			"name": "target"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61235,
+			"name": "tatami_seat"
+		},
+		{
+			"codepoint": 63135,
+			"name": "taunt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 57363,
+			"name": "team_dashboard"
+		},
+		{
+			"codepoint": 63689,
+			"name": "temp_preferences_custom"
+		},
+		{
+			"codepoint": 63690,
+			"name": "temp_preferences_eco"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 61667,
+			"name": "tenancy"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 1048462,
+			"name": "terminal_2"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 59176,
+			"name": "text_ad"
+		},
+		{
+			"codepoint": 1048466,
+			"name": "text_ad_off"
+		},
+		{
+			"codepoint": 62405,
+			"name": "text_compare"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 59889,
+			"name": "text_fields_alt"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 63294,
+			"name": "text_select_end"
+		},
+		{
+			"codepoint": 63293,
+			"name": "text_select_jump_to_beginning"
+		},
+		{
+			"codepoint": 63292,
+			"name": "text_select_jump_to_end"
+		},
+		{
+			"codepoint": 63291,
+			"name": "text_select_move_back_character"
+		},
+		{
+			"codepoint": 63290,
+			"name": "text_select_move_back_word"
+		},
+		{
+			"codepoint": 63289,
+			"name": "text_select_move_down"
+		},
+		{
+			"codepoint": 63288,
+			"name": "text_select_move_forward_character"
+		},
+		{
+			"codepoint": 63287,
+			"name": "text_select_move_forward_word"
+		},
+		{
+			"codepoint": 63286,
+			"name": "text_select_move_up"
+		},
+		{
+			"codepoint": 63285,
+			"name": "text_select_start"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 61884,
+			"name": "text_to_speech"
+		},
+		{
+			"codepoint": 62622,
+			"name": "text_up"
+		},
+		{
+			"codepoint": 58917,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 62844,
+			"name": "texture_add"
+		},
+		{
+			"codepoint": 62843,
+			"name": "texture_minus"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 59462,
+			"name": "thermometer"
+		},
+		{
+			"codepoint": 62850,
+			"name": "thermometer_add"
+		},
+		{
+			"codepoint": 1048571,
+			"name": "thermometer_alert"
+		},
+		{
+			"codepoint": 63192,
+			"name": "thermometer_gain"
+		},
+		{
+			"codepoint": 63191,
+			"name": "thermometer_loss"
+		},
+		{
+			"codepoint": 62849,
+			"name": "thermometer_minus"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 62330,
+			"name": "thermostat_arrow_down"
+		},
+		{
+			"codepoint": 62329,
+			"name": "thermostat_arrow_up"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 61816,
+			"name": "thermostat_carbon"
+		},
+		{
+			"codepoint": 60202,
+			"name": "things_to_do"
+		},
+		{
+			"codepoint": 62713,
+			"name": "thread_unread"
+		},
+		{
+			"codepoint": 60141,
+			"name": "threat_intelligence"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_filled"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_filled"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 63284,
+			"name": "thumbnail_bar"
+		},
+		{
+			"codepoint": 61180,
+			"name": "thumbs_up_double"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 63643,
+			"name": "tibia"
+		},
+		{
+			"codepoint": 63644,
+			"name": "tibia_alt"
+		},
+		{
+			"codepoint": 62403,
+			"name": "tile_large"
+		},
+		{
+			"codepoint": 62402,
+			"name": "tile_medium"
+		},
+		{
+			"codepoint": 62401,
+			"name": "tile_small"
+		},
+		{
+			"codepoint": 1048358,
+			"name": "tilt_arrow_down"
+		},
+		{
+			"codepoint": 1048357,
+			"name": "tilt_arrow_up"
+		},
+		{
+			"codepoint": 61668,
+			"name": "time_auto"
+		},
+		{
+			"codepoint": 61431,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 62127,
+			"name": "timer_1"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61375,
+			"name": "timer_10_alt_1"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 62126,
+			"name": "timer_2"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61376,
+			"name": "timer_3_alt_1"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 62641,
+			"name": "timer_5"
+		},
+		{
+			"codepoint": 62642,
+			"name": "timer_5_shutter"
+		},
+		{
+			"codepoint": 62328,
+			"name": "timer_arrow_down"
+		},
+		{
+			"codepoint": 62327,
+			"name": "timer_arrow_up"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 62651,
+			"name": "timer_pause"
+		},
+		{
+			"codepoint": 62650,
+			"name": "timer_play"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 62601,
+			"name": "titlecase"
+		},
+		{
+			"codepoint": 61377,
+			"name": "toast"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 62132,
+			"name": "tonality_2"
+		},
+		{
+			"codepoint": 59895,
+			"name": "toolbar"
+		},
+		{
+			"codepoint": 63691,
+			"name": "tools_flat_head"
+		},
+		{
+			"codepoint": 58027,
+			"name": "tools_installation_kit"
+		},
+		{
+			"codepoint": 58059,
+			"name": "tools_ladder"
+		},
+		{
+			"codepoint": 59259,
+			"name": "tools_level"
+		},
+		{
+			"codepoint": 63692,
+			"name": "tools_phillips"
+		},
+		{
+			"codepoint": 58026,
+			"name": "tools_pliers_wire_stripper"
+		},
+		{
+			"codepoint": 57833,
+			"name": "tools_power_drill"
+		},
+		{
+			"codepoint": 63693,
+			"name": "tools_wrench"
+		},
+		{
+			"codepoint": 59896,
+			"name": "tooltip"
+		},
+		{
+			"codepoint": 62445,
+			"name": "tooltip_2"
+		},
+		{
+			"codepoint": 63283,
+			"name": "top_panel_close"
+		},
+		{
+			"codepoint": 63282,
+			"name": "top_panel_open"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 63607,
+			"name": "total_dissolved_solids"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 62347,
+			"name": "touch_double"
+		},
+		{
+			"codepoint": 1048373,
+			"name": "touch_double_2"
+		},
+		{
+			"codepoint": 62346,
+			"name": "touch_long"
+		},
+		{
+			"codepoint": 62345,
+			"name": "touch_triple"
+		},
+		{
+			"codepoint": 63111,
+			"name": "touchpad_mouse"
+		},
+		{
+			"codepoint": 62694,
+			"name": "touchpad_mouse_off"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 61378,
+			"name": "toys_and_games"
+		},
+		{
+			"codepoint": 63623,
+			"name": "toys_fan"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 62663,
+			"name": "trackpad_input"
+		},
+		{
+			"codepoint": 62473,
+			"name": "trackpad_input_2"
+		},
+		{
+			"codepoint": 62472,
+			"name": "trackpad_input_3"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 62575,
+			"name": "traffic_jam"
+		},
+		{
+			"codepoint": 60254,
+			"name": "trail_length"
+		},
+		{
+			"codepoint": 60259,
+			"name": "trail_length_medium"
+		},
+		{
+			"codepoint": 60269,
+			"name": "trail_length_short"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 62449,
+			"name": "transit_ticket"
+		},
+		{
+			"codepoint": 62734,
+			"name": "transition_chop"
+		},
+		{
+			"codepoint": 62733,
+			"name": "transition_dissolve"
+		},
+		{
+			"codepoint": 62732,
+			"name": "transition_fade"
+		},
+		{
+			"codepoint": 62731,
+			"name": "transition_push"
+		},
+		{
+			"codepoint": 62730,
+			"name": "transition_slide"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 62051,
+			"name": "translate_indic"
+		},
+		{
+			"codepoint": 57885,
+			"name": "transportation"
+		},
+		{
+			"codepoint": 61331,
+			"name": "travel"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 61379,
+			"name": "travel_luggage_and_bags"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 61126,
+			"name": "triangle_circle"
+		},
+		{
+			"codepoint": 59131,
+			"name": "trip"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 63595,
+			"name": "trolley"
+		},
+		{
+			"codepoint": 62574,
+			"name": "trolley_cable_car"
+		},
+		{
+			"codepoint": 59939,
+			"name": "trophy"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 59094,
+			"name": "tsv"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58939,
+			"name": "tv"
+		},
+		{
+			"codepoint": 62444,
+			"name": "tv_displays"
+		},
+		{
+			"codepoint": 59440,
+			"name": "tv_gen"
+		},
+		{
+			"codepoint": 57820,
+			"name": "tv_guide"
+		},
+		{
+			"codepoint": 62443,
+			"name": "tv_next"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 57821,
+			"name": "tv_options_edit_channels"
+		},
+		{
+			"codepoint": 57822,
+			"name": "tv_options_input_settings"
+		},
+		{
+			"codepoint": 62937,
+			"name": "tv_remote"
+		},
+		{
+			"codepoint": 59163,
+			"name": "tv_signin"
+		},
+		{
+			"codepoint": 59269,
+			"name": "tv_with_assistant"
+		},
+		{
+			"codepoint": 62751,
+			"name": "two_pager"
+		},
+		{
+			"codepoint": 62404,
+			"name": "two_pager_store"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61234,
+			"name": "udon"
+		},
+		{
+			"codepoint": 63645,
+			"name": "ulna_radius"
+		},
+		{
+			"codepoint": 63646,
+			"name": "ulna_radius_alt"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 61105,
+			"name": "undereye"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 63281,
+			"name": "ungroup"
+		},
+		{
+			"codepoint": 59898,
+			"name": "universal_currency"
+		},
+		{
+			"codepoint": 59188,
+			"name": "universal_currency_alt"
+		},
+		{
+			"codepoint": 59899,
+			"name": "universal_local"
+		},
+		{
+			"codepoint": 62623,
+			"name": "unknown_2"
+		},
+		{
+			"codepoint": 59045,
+			"name": "unknown_5"
+		},
+		{
+			"codepoint": 62622,
+			"name": "unknown_7"
+		},
+		{
+			"codepoint": 63492,
+			"name": "unknown_document"
+		},
+		{
+			"codepoint": 60093,
+			"name": "unknown_med"
+		},
+		{
+			"codepoint": 60165,
+			"name": "unlicense"
+		},
+		{
+			"codepoint": 62573,
+			"name": "unpaved_road"
+		},
+		{
+			"codepoint": 59129,
+			"name": "unpin"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 62415,
+			"name": "upi_pay"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 62753,
+			"name": "upload_2"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 62600,
+			"name": "uppercase"
+		},
+		{
+			"codepoint": 57655,
+			"name": "urology"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 59144,
+			"name": "user_attributes"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 61381,
+			"name": "vacuum"
+		},
+		{
+			"codepoint": 1048429,
+			"name": "vacuum_2"
+		},
+		{
+			"codepoint": 1048430,
+			"name": "vacuum_2_on"
+		},
+		{
+			"codepoint": 57892,
+			"name": "valve"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 62750,
+			"name": "variable_add"
+		},
+		{
+			"codepoint": 62749,
+			"name": "variable_insert"
+		},
+		{
+			"codepoint": 62748,
+			"name": "variable_remove"
+		},
+		{
+			"codepoint": 63569,
+			"name": "variables"
+		},
+		{
+			"codepoint": 57657,
+			"name": "ventilator"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 62222,
+			"name": "verified_off"
+		},
+		{
+			"codepoint": 61459,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 62155,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 62476,
+			"name": "video_camera_back_add"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63547,
+			"name": "video_camera_front_off"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 1048333,
+			"name": "video_frame_copy"
+		},
+		{
+			"codepoint": 1048332,
+			"name": "video_frame_save"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 61382,
+			"name": "video_search"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 1048531,
+			"name": "video_template"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 62352,
+			"name": "videocam_alert"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 62326,
+			"name": "view_apps"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 63559,
+			"name": "view_column_2"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar_new"
+		},
+		{
+			"codepoint": 63003,
+			"name": "view_in_ar_off"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 62514,
+			"name": "view_object_track"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 62658,
+			"name": "view_real_size"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 62131,
+			"name": "vignette_2"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 63059,
+			"name": "visibility_lock"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58960,
+			"name": "vital_signs"
+		},
+		{
+			"codepoint": 57659,
+			"name": "vitals"
+		},
+		{
+			"codepoint": 62634,
+			"name": "vo2_max"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 61118,
+			"name": "voice_chat_off"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 62858,
+			"name": "voice_selection"
+		},
+		{
+			"codepoint": 62508,
+			"name": "voice_selection_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 62290,
+			"name": "voicemail_2"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 59292,
+			"name": "volume_down_alt"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 63570,
+			"name": "voting_chip"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 63180,
+			"name": "vpn_key_alert"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 62288,
+			"name": "vpn_lock_2"
+		},
+		{
+			"codepoint": 61386,
+			"name": "vr180_create2d"
+		},
+		{
+			"codepoint": 62833,
+			"name": "vr180_create2d_off"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 1048321,
+			"name": "walk_bike"
+		},
+		{
+			"codepoint": 61387,
+			"name": "wall_art"
+		},
+		{
+			"codepoint": 58036,
+			"name": "wall_lamp"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 57788,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 63090,
+			"name": "wallpaper_slideshow"
+		},
+		{
+			"codepoint": 62239,
+			"name": "wand_shine"
+		},
+		{
+			"codepoint": 62238,
+			"name": "wand_stars"
+		},
+		{
+			"codepoint": 57660,
+			"name": "ward"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 63405,
+			"name": "warning_off"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 62080,
+			"name": "washoku"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 1048529,
+			"name": "watch_alert"
+		},
+		{
+			"codepoint": 62154,
+			"name": "watch_arrow"
+		},
+		{
+			"codepoint": 1048527,
+			"name": "watch_arrow_down"
+		},
+		{
+			"codepoint": 1048352,
+			"name": "watch_button"
+		},
+		{
+			"codepoint": 63146,
+			"name": "watch_button_press"
+		},
+		{
+			"codepoint": 62568,
+			"name": "watch_check"
+		},
+		{
+			"codepoint": 61398,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 61161,
+			"name": "watch_lock"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 63150,
+			"name": "watch_screentime"
+		},
+		{
+			"codepoint": 62567,
+			"name": "watch_vibration"
+		},
+		{
+			"codepoint": 63145,
+			"name": "watch_wake"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 63133,
+			"name": "water_bottle"
+		},
+		{
+			"codepoint": 63134,
+			"name": "water_bottle_large"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 63600,
+			"name": "water_do"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 1048485,
+			"name": "water_drops"
+		},
+		{
+			"codepoint": 63605,
+			"name": "water_ec"
+		},
+		{
+			"codepoint": 63190,
+			"name": "water_full"
+		},
+		{
+			"codepoint": 57988,
+			"name": "water_heater"
+		},
+		{
+			"codepoint": 63149,
+			"name": "water_lock"
+		},
+		{
+			"codepoint": 63189,
+			"name": "water_loss"
+		},
+		{
+			"codepoint": 63604,
+			"name": "water_lux"
+		},
+		{
+			"codepoint": 63188,
+			"name": "water_medium"
+		},
+		{
+			"codepoint": 63608,
+			"name": "water_orp"
+		},
+		{
+			"codepoint": 63610,
+			"name": "water_ph"
+		},
+		{
+			"codepoint": 62936,
+			"name": "water_pump"
+		},
+		{
+			"codepoint": 63611,
+			"name": "water_voc"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 61788,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 61565,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 1048351,
+			"name": "wb_twilight_2"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 63103,
+			"name": "weather_hail"
+		},
+		{
+			"codepoint": 62987,
+			"name": "weather_mix"
+		},
+		{
+			"codepoint": 58061,
+			"name": "weather_snowy"
+		},
+		{
+			"codepoint": 59009,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 61255,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 59907,
+			"name": "web_traffic"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 57661,
+			"name": "weight"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 1048484,
+			"name": "wheat"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 62394,
+			"name": "widget_medium"
+		},
+		{
+			"codepoint": 61111,
+			"name": "widget_menu"
+		},
+		{
+			"codepoint": 62393,
+			"name": "widget_small"
+		},
+		{
+			"codepoint": 62392,
+			"name": "widget_width"
+		},
+		{
+			"codepoint": 57789,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63280,
+			"name": "width"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 63400,
+			"name": "wifi_add"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_1"
+		},
+		{
+			"codepoint": 61686,
+			"name": "wifi_calling_2"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 62540,
+			"name": "wifi_calling_bar_1"
+		},
+		{
+			"codepoint": 62539,
+			"name": "wifi_calling_bar_2"
+		},
+		{
+			"codepoint": 62538,
+			"name": "wifi_calling_bar_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 1048372,
+			"name": "wifi_device"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 63089,
+			"name": "wifi_home"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 63088,
+			"name": "wifi_notification"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 63399,
+			"name": "wifi_proxy"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 60121,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 59262,
+			"name": "window_closed"
+		},
+		{
+			"codepoint": 59276,
+			"name": "window_open"
+		},
+		{
+			"codepoint": 58043,
+			"name": "window_sensor"
+		},
+		{
+			"codepoint": 62024,
+			"name": "windshield_defrost_auto"
+		},
+		{
+			"codepoint": 62250,
+			"name": "windshield_defrost_front"
+		},
+		{
+			"codepoint": 62249,
+			"name": "windshield_defrost_rear"
+		},
+		{
+			"codepoint": 62248,
+			"name": "windshield_heat_front"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work"
+		},
+		{
+			"codepoint": 62967,
+			"name": "work_alert"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 62968,
+			"name": "work_update"
+		},
+		{
+			"codepoint": 59908,
+			"name": "workflow"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces_outline"
+		},
+		{
+			"codepoint": 57663,
+			"name": "wounds_injuries"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 63132,
+			"name": "wrist"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 58185,
+			"name": "x_circle"
+		},
+		{
+			"codepoint": 61125,
+			"name": "y_circle"
+		},
+		{
+			"codepoint": 61233,
+			"name": "yakitori"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 62079,
+			"name": "yoshoku"
+		},
+		{
+			"codepoint": 60203,
+			"name": "your_trips"
+		},
+		{
+			"codepoint": 63578,
+			"name": "youtube_activity"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59265,
+			"name": "zone_person_alert"
+		},
+		{
+			"codepoint": 59258,
+			"name": "zone_person_idle"
+		},
+		{
+			"codepoint": 59272,
+			"name": "zone_person_urgent"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "variablefont/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"sha256": "8567a3d0512ce8a735a739d325e83ee7010d9bf7f6f8ed6a699c07c817ea907d"
+	}
+}

--- a/registry/data/families/google-icons/material-symbols-outlined/inspection.json
+++ b/registry/data/families/google-icons/material-symbols-outlined/inspection.json
@@ -1,0 +1,46 @@
+{
+	"files": [
+		{
+			"axes": [
+				{
+					"default": 0,
+					"max": 1,
+					"min": 0,
+					"tag": "FILL"
+				},
+				{
+					"default": 0,
+					"max": 200,
+					"min": -50,
+					"tag": "GRAD"
+				},
+				{
+					"default": 24,
+					"max": 48,
+					"min": 20,
+					"tag": "opsz"
+				},
+				{
+					"default": 400,
+					"max": 700,
+					"min": 100,
+					"tag": "wght"
+				}
+			],
+			"cmap": {
+				"codepointCount": 4382,
+				"sha256": "c7e2330b037a77ee633c96bab75b961eb0376d69ff3e00ecce87a89de557b18d"
+			},
+			"colorTables": [],
+			"fontVersion": "Version 2.961",
+			"outline": "glyf",
+			"path": "variablefont/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf",
+			"style": "normal",
+			"weight": {
+				"default": 400,
+				"max": 700,
+				"min": 100
+			}
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-outlined/license.txt
+++ b/registry/data/families/google-icons/material-symbols-outlined/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-symbols-outlined/metadata.json
+++ b/registry/data/families/google-icons/material-symbols-outlined/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Symbols Outlined",
+	"id": "material-symbols-outlined",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "variablefont",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "variablefont/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf",
+			"sha256": "b5126c4655e0756f334d684104156b98b82ef7d61212a81c041b9e6cfa8ba925",
+			"size": 10643720,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2026-07-24",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-rounded/description.en-US.md
+++ b/registry/data/families/google-icons/material-symbols-rounded/description.en-US.md
@@ -1,0 +1,1 @@
+Material Symbols Rounded is part of Google's current Material Symbols collection. It is a variable icon font with fill, weight, grade, and optical size axes.

--- a/registry/data/families/google-icons/material-symbols-rounded/icons.json
+++ b/registry/data/families/google-icons/material-symbols-rounded/icons.json
@@ -1,0 +1,17078 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 63473,
+			"name": "1x_mobiledata_badge"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 62450,
+			"name": "24fps_select"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 61239,
+			"name": "2d"
+		},
+		{
+			"codepoint": 1048334,
+			"name": "2d_2"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 60728,
+			"name": "3d"
+		},
+		{
+			"codepoint": 1048335,
+			"name": "3d_2"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 63472,
+			"name": "3g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 63471,
+			"name": "4g_mobiledata_badge"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 63219,
+			"name": "50mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 63470,
+			"name": "5g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 62286,
+			"name": "accessible_menu"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59474,
+			"name": "account_child"
+		},
+		{
+			"codepoint": 58969,
+			"name": "account_child_invert"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle_filled"
+		},
+		{
+			"codepoint": 63411,
+			"name": "account_circle_off"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 62722,
+			"name": "action_key"
+		},
+		{
+			"codepoint": 57830,
+			"name": "activity_zone"
+		},
+		{
+			"codepoint": 62148,
+			"name": "acupuncture"
+		},
+		{
+			"codepoint": 58571,
+			"name": "acute"
+		},
+		{
+			"codepoint": 58970,
+			"name": "ad"
+		},
+		{
+			"codepoint": 58971,
+			"name": "ad_group"
+		},
+		{
+			"codepoint": 60133,
+			"name": "ad_group_off"
+		},
+		{
+			"codepoint": 63410,
+			"name": "ad_off"
+		},
+		{
+			"codepoint": 62187,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 62668,
+			"name": "adaptive_audio_mic"
+		},
+		{
+			"codepoint": 62667,
+			"name": "adaptive_audio_mic_off"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 62429,
+			"name": "add_2"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 59178,
+			"name": "add_ad"
+		},
+		{
+			"codepoint": 59478,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_call"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 61244,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 62501,
+			"name": "add_column_left"
+		},
+		{
+			"codepoint": 62500,
+			"name": "add_column_right"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 62620,
+			"name": "add_diamond"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 57489,
+			"name": "add_notes"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 62499,
+			"name": "add_row_above"
+		},
+		{
+			"codepoint": 62498,
+			"name": "add_row_below"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 62137,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 62606,
+			"name": "add_triangle"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 58509,
+			"name": "admin_meds"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 63624,
+			"name": "agender"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58058,
+			"name": "air_freshener"
+		},
+		{
+			"codepoint": 59774,
+			"name": "air_purifier"
+		},
+		{
+			"codepoint": 59433,
+			"name": "air_purifier_gen"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 58685,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airware"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airwave"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 62299,
+			"name": "alarm_pause"
+		},
+		{
+			"codepoint": 63152,
+			"name": "alarm_smart_wake"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 58198,
+			"name": "align_center"
+		},
+		{
+			"codepoint": 63383,
+			"name": "align_end"
+		},
+		{
+			"codepoint": 63382,
+			"name": "align_flex_center"
+		},
+		{
+			"codepoint": 63381,
+			"name": "align_flex_end"
+		},
+		{
+			"codepoint": 63380,
+			"name": "align_flex_start"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 63379,
+			"name": "align_items_stretch"
+		},
+		{
+			"codepoint": 63378,
+			"name": "align_justify_center"
+		},
+		{
+			"codepoint": 63377,
+			"name": "align_justify_flex_end"
+		},
+		{
+			"codepoint": 63376,
+			"name": "align_justify_flex_start"
+		},
+		{
+			"codepoint": 63375,
+			"name": "align_justify_space_around"
+		},
+		{
+			"codepoint": 63374,
+			"name": "align_justify_space_between"
+		},
+		{
+			"codepoint": 63373,
+			"name": "align_justify_space_even"
+		},
+		{
+			"codepoint": 63372,
+			"name": "align_justify_stretch"
+		},
+		{
+			"codepoint": 63371,
+			"name": "align_self_stretch"
+		},
+		{
+			"codepoint": 63370,
+			"name": "align_space_around"
+		},
+		{
+			"codepoint": 63369,
+			"name": "align_space_between"
+		},
+		{
+			"codepoint": 63368,
+			"name": "align_space_even"
+		},
+		{
+			"codepoint": 63367,
+			"name": "align_start"
+		},
+		{
+			"codepoint": 63366,
+			"name": "align_stretch"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 57491,
+			"name": "all_match"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 57492,
+			"name": "allergies"
+		},
+		{
+			"codepoint": 58958,
+			"name": "allergy"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 63603,
+			"name": "altitude"
+		},
+		{
+			"codepoint": 63172,
+			"name": "ambient_screen"
+		},
+		{
+			"codepoint": 63491,
+			"name": "ambulance"
+		},
+		{
+			"codepoint": 63490,
+			"name": "amend"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 61190,
+			"name": "android_cell_4_bar"
+		},
+		{
+			"codepoint": 61193,
+			"name": "android_cell_4_bar_alert"
+		},
+		{
+			"codepoint": 61192,
+			"name": "android_cell_4_bar_off"
+		},
+		{
+			"codepoint": 61191,
+			"name": "android_cell_4_bar_plus"
+		},
+		{
+			"codepoint": 61186,
+			"name": "android_cell_5_bar"
+		},
+		{
+			"codepoint": 61189,
+			"name": "android_cell_5_bar_alert"
+		},
+		{
+			"codepoint": 61188,
+			"name": "android_cell_5_bar_off"
+		},
+		{
+			"codepoint": 61187,
+			"name": "android_cell_5_bar_plus"
+		},
+		{
+			"codepoint": 61197,
+			"name": "android_cell_dual_4_bar"
+		},
+		{
+			"codepoint": 61199,
+			"name": "android_cell_dual_4_bar_alert"
+		},
+		{
+			"codepoint": 61198,
+			"name": "android_cell_dual_4_bar_plus"
+		},
+		{
+			"codepoint": 61194,
+			"name": "android_cell_dual_5_bar"
+		},
+		{
+			"codepoint": 61196,
+			"name": "android_cell_dual_5_bar_alert"
+		},
+		{
+			"codepoint": 61195,
+			"name": "android_cell_dual_5_bar_plus"
+		},
+		{
+			"codepoint": 61206,
+			"name": "android_wifi_3_bar"
+		},
+		{
+			"codepoint": 61211,
+			"name": "android_wifi_3_bar_alert"
+		},
+		{
+			"codepoint": 61210,
+			"name": "android_wifi_3_bar_lock"
+		},
+		{
+			"codepoint": 61209,
+			"name": "android_wifi_3_bar_off"
+		},
+		{
+			"codepoint": 61208,
+			"name": "android_wifi_3_bar_plus"
+		},
+		{
+			"codepoint": 61207,
+			"name": "android_wifi_3_bar_question"
+		},
+		{
+			"codepoint": 61200,
+			"name": "android_wifi_4_bar"
+		},
+		{
+			"codepoint": 61205,
+			"name": "android_wifi_4_bar_alert"
+		},
+		{
+			"codepoint": 61204,
+			"name": "android_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61203,
+			"name": "android_wifi_4_bar_off"
+		},
+		{
+			"codepoint": 61202,
+			"name": "android_wifi_4_bar_plus"
+		},
+		{
+			"codepoint": 61201,
+			"name": "android_wifi_4_bar_question"
+		},
+		{
+			"codepoint": 62618,
+			"name": "animated_images"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59519,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 1048530,
+			"name": "antigravity"
+		},
+		{
+			"codepoint": 62182,
+			"name": "aod"
+		},
+		{
+			"codepoint": 63647,
+			"name": "aod_tablet"
+		},
+		{
+			"codepoint": 63148,
+			"name": "aod_watch"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 63630,
+			"name": "apk_document"
+		},
+		{
+			"codepoint": 63631,
+			"name": "apk_install"
+		},
+		{
+			"codepoint": 63279,
+			"name": "app_badging"
+		},
+		{
+			"codepoint": 62181,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 62157,
+			"name": "app_promo"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 62169,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 62175,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 61307,
+			"name": "apparel"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 63562,
+			"name": "approval_delegation"
+		},
+		{
+			"codepoint": 62149,
+			"name": "approval_delegation_off"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 62810,
+			"name": "aq"
+		},
+		{
+			"codepoint": 62811,
+			"name": "aq_indoor"
+		},
+		{
+			"codepoint": 61308,
+			"name": "ar_on_you"
+		},
+		{
+			"codepoint": 59779,
+			"name": "ar_stickers"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 59274,
+			"name": "arming_countdown"
+		},
+		{
+			"codepoint": 62935,
+			"name": "arrow_and_edge"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 62522,
+			"name": "arrow_back_2"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 62646,
+			"name": "arrow_cool_down"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 59780,
+			"name": "arrow_downward_alt"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 63543,
+			"name": "arrow_insert"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 61309,
+			"name": "arrow_left_alt"
+		},
+		{
+			"codepoint": 62419,
+			"name": "arrow_menu_close"
+		},
+		{
+			"codepoint": 62418,
+			"name": "arrow_menu_open"
+		},
+		{
+			"codepoint": 62934,
+			"name": "arrow_or_edge"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 63131,
+			"name": "arrow_range"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 63535,
+			"name": "arrow_selector_tool"
+		},
+		{
+			"codepoint": 61174,
+			"name": "arrow_shape_up"
+		},
+		{
+			"codepoint": 61175,
+			"name": "arrow_shape_up_stack"
+		},
+		{
+			"codepoint": 61176,
+			"name": "arrow_shape_up_stack_2"
+		},
+		{
+			"codepoint": 59908,
+			"name": "arrow_split"
+		},
+		{
+			"codepoint": 63278,
+			"name": "arrow_top_left"
+		},
+		{
+			"codepoint": 63277,
+			"name": "arrow_top_right"
+		},
+		{
+			"codepoint": 62452,
+			"name": "arrow_upload_progress"
+		},
+		{
+			"codepoint": 62453,
+			"name": "arrow_upload_ready"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 59782,
+			"name": "arrow_upward_alt"
+		},
+		{
+			"codepoint": 62645,
+			"name": "arrow_warm_up"
+		},
+		{
+			"codepoint": 62356,
+			"name": "arrows_input"
+		},
+		{
+			"codepoint": 61156,
+			"name": "arrows_left_right_circle"
+		},
+		{
+			"codepoint": 63659,
+			"name": "arrows_more_down"
+		},
+		{
+			"codepoint": 63660,
+			"name": "arrows_more_up"
+		},
+		{
+			"codepoint": 62355,
+			"name": "arrows_output"
+		},
+		{
+			"codepoint": 63276,
+			"name": "arrows_outward"
+		},
+		{
+			"codepoint": 61155,
+			"name": "arrows_up_down_circle"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61319,
+			"name": "article"
+		},
+		{
+			"codepoint": 62312,
+			"name": "article_person"
+		},
+		{
+			"codepoint": 62855,
+			"name": "article_shortcut"
+		},
+		{
+			"codepoint": 57370,
+			"name": "artist"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 61644,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 63560,
+			"name": "assignment_add"
+		},
+		{
+			"codepoint": 61164,
+			"name": "assignment_globe"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59783,
+			"name": "assistant_device"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 59785,
+			"name": "assistant_navigation"
+		},
+		{
+			"codepoint": 63169,
+			"name": "assistant_on_hub"
+		},
+		{
+			"codepoint": 61638,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 62757,
+			"name": "asterisk"
+		},
+		{
+			"codepoint": 61913,
+			"name": "astrophotography_auto"
+		},
+		{
+			"codepoint": 61914,
+			"name": "astrophotography_off"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 60359,
+			"name": "atr"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 63553,
+			"name": "attach_file_add"
+		},
+		{
+			"codepoint": 62681,
+			"name": "attach_file_off"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 1048323,
+			"name": "audio_capture"
+		},
+		{
+			"codepoint": 62860,
+			"name": "audio_description"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 62931,
+			"name": "audio_video_receiver"
+		},
+		{
+			"codepoint": 58373,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 63661,
+			"name": "auto_activity_zone"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 63550,
+			"name": "auto_detect_voice"
+		},
+		{
+			"codepoint": 59786,
+			"name": "auto_draw_solid"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 63166,
+			"name": "auto_label"
+		},
+		{
+			"codepoint": 63167,
+			"name": "auto_meeting_room"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 61977,
+			"name": "auto_read_pause"
+		},
+		{
+			"codepoint": 61974,
+			"name": "auto_read_play"
+		},
+		{
+			"codepoint": 57876,
+			"name": "auto_schedule"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 62055,
+			"name": "auto_stories_off"
+		},
+		{
+			"codepoint": 61311,
+			"name": "auto_timer"
+		},
+		{
+			"codepoint": 59166,
+			"name": "auto_towing"
+		},
+		{
+			"codepoint": 62783,
+			"name": "auto_transmission"
+		},
+		{
+			"codepoint": 63168,
+			"name": "auto_videocam"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 62497,
+			"name": "automation"
+		},
+		{
+			"codepoint": 63158,
+			"name": "autopause"
+		},
+		{
+			"codepoint": 63563,
+			"name": "autopay"
+		},
+		{
+			"codepoint": 63157,
+			"name": "autoplay"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 63106,
+			"name": "autostop"
+		},
+		{
+			"codepoint": 62640,
+			"name": "av1"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 62639,
+			"name": "avc"
+		},
+		{
+			"codepoint": 63163,
+			"name": "avg_pace"
+		},
+		{
+			"codepoint": 63507,
+			"name": "avg_time"
+		},
+		{
+			"codepoint": 1048487,
+			"name": "avocado_bean"
+		},
+		{
+			"codepoint": 62017,
+			"name": "award_meal"
+		},
+		{
+			"codepoint": 62994,
+			"name": "award_star"
+		},
+		{
+			"codepoint": 63212,
+			"name": "azm"
+		},
+		{
+			"codepoint": 61154,
+			"name": "b_circle"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 63275,
+			"name": "back_to_tab"
+		},
+		{
+			"codepoint": 63390,
+			"name": "background_dot_large"
+		},
+		{
+			"codepoint": 62740,
+			"name": "background_dot_small"
+		},
+		{
+			"codepoint": 63389,
+			"name": "background_grid_small"
+		},
+		{
+			"codepoint": 61962,
+			"name": "background_replace"
+		},
+		{
+			"codepoint": 63469,
+			"name": "backlight_high"
+		},
+		{
+			"codepoint": 62703,
+			"name": "backlight_high_off"
+		},
+		{
+			"codepoint": 63468,
+			"name": "backlight_low"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 61782,
+			"name": "badge_critical_battery"
+		},
+		{
+			"codepoint": 62120,
+			"name": "badminton"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 63105,
+			"name": "bar_chart_4_bars"
+		},
+		{
+			"codepoint": 62481,
+			"name": "bar_chart_off"
+		},
+		{
+			"codepoint": 59147,
+			"name": "barcode"
+		},
+		{
+			"codepoint": 63580,
+			"name": "barcode_reader"
+		},
+		{
+			"codepoint": 59148,
+			"name": "barcode_scanner"
+		},
+		{
+			"codepoint": 63601,
+			"name": "barefoot"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 62086,
+			"name": "bath_bedrock"
+		},
+		{
+			"codepoint": 63227,
+			"name": "bath_outdoor"
+		},
+		{
+			"codepoint": 63226,
+			"name": "bath_private"
+		},
+		{
+			"codepoint": 63225,
+			"name": "bath_public_large"
+		},
+		{
+			"codepoint": 62112,
+			"name": "bath_soak"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_20"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_30"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_50"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_60"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_80"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_90"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 62221,
+			"name": "battery_android_0"
+		},
+		{
+			"codepoint": 62220,
+			"name": "battery_android_1"
+		},
+		{
+			"codepoint": 62219,
+			"name": "battery_android_2"
+		},
+		{
+			"codepoint": 62218,
+			"name": "battery_android_3"
+		},
+		{
+			"codepoint": 62217,
+			"name": "battery_android_4"
+		},
+		{
+			"codepoint": 62216,
+			"name": "battery_android_5"
+		},
+		{
+			"codepoint": 62215,
+			"name": "battery_android_6"
+		},
+		{
+			"codepoint": 62214,
+			"name": "battery_android_alert"
+		},
+		{
+			"codepoint": 62213,
+			"name": "battery_android_bolt"
+		},
+		{
+			"codepoint": 62039,
+			"name": "battery_android_frame_1"
+		},
+		{
+			"codepoint": 62038,
+			"name": "battery_android_frame_2"
+		},
+		{
+			"codepoint": 62037,
+			"name": "battery_android_frame_3"
+		},
+		{
+			"codepoint": 62036,
+			"name": "battery_android_frame_4"
+		},
+		{
+			"codepoint": 62035,
+			"name": "battery_android_frame_5"
+		},
+		{
+			"codepoint": 62034,
+			"name": "battery_android_frame_6"
+		},
+		{
+			"codepoint": 62033,
+			"name": "battery_android_frame_alert"
+		},
+		{
+			"codepoint": 62032,
+			"name": "battery_android_frame_bolt"
+		},
+		{
+			"codepoint": 62031,
+			"name": "battery_android_frame_full"
+		},
+		{
+			"codepoint": 62030,
+			"name": "battery_android_frame_plus"
+		},
+		{
+			"codepoint": 62029,
+			"name": "battery_android_frame_question"
+		},
+		{
+			"codepoint": 62028,
+			"name": "battery_android_frame_share"
+		},
+		{
+			"codepoint": 62027,
+			"name": "battery_android_frame_shield"
+		},
+		{
+			"codepoint": 62212,
+			"name": "battery_android_full"
+		},
+		{
+			"codepoint": 62211,
+			"name": "battery_android_plus"
+		},
+		{
+			"codepoint": 62210,
+			"name": "battery_android_question"
+		},
+		{
+			"codepoint": 62209,
+			"name": "battery_android_share"
+		},
+		{
+			"codepoint": 62208,
+			"name": "battery_android_shield"
+		},
+		{
+			"codepoint": 63467,
+			"name": "battery_change"
+		},
+		{
+			"codepoint": 61602,
+			"name": "battery_charging_20"
+		},
+		{
+			"codepoint": 1048382,
+			"name": "battery_charging_20_2"
+		},
+		{
+			"codepoint": 61603,
+			"name": "battery_charging_30"
+		},
+		{
+			"codepoint": 1048381,
+			"name": "battery_charging_30_2"
+		},
+		{
+			"codepoint": 61604,
+			"name": "battery_charging_50"
+		},
+		{
+			"codepoint": 1048380,
+			"name": "battery_charging_50_2"
+		},
+		{
+			"codepoint": 61605,
+			"name": "battery_charging_60"
+		},
+		{
+			"codepoint": 1048379,
+			"name": "battery_charging_60_2"
+		},
+		{
+			"codepoint": 61606,
+			"name": "battery_charging_80"
+		},
+		{
+			"codepoint": 1048378,
+			"name": "battery_charging_80_2"
+		},
+		{
+			"codepoint": 61607,
+			"name": "battery_charging_90"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 1048377,
+			"name": "battery_charging_full_2"
+		},
+		{
+			"codepoint": 63466,
+			"name": "battery_error"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61755,
+			"name": "battery_full_alt"
+		},
+		{
+			"codepoint": 63662,
+			"name": "battery_horiz_000"
+		},
+		{
+			"codepoint": 63663,
+			"name": "battery_horiz_050"
+		},
+		{
+			"codepoint": 63664,
+			"name": "battery_horiz_075"
+		},
+		{
+			"codepoint": 61781,
+			"name": "battery_low"
+		},
+		{
+			"codepoint": 63465,
+			"name": "battery_plus"
+		},
+		{
+			"codepoint": 57862,
+			"name": "battery_profile"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 63102,
+			"name": "battery_share"
+		},
+		{
+			"codepoint": 63101,
+			"name": "battery_status_good"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 63665,
+			"name": "battery_vert_005"
+		},
+		{
+			"codepoint": 63666,
+			"name": "battery_vert_020"
+		},
+		{
+			"codepoint": 63667,
+			"name": "battery_vert_050"
+		},
+		{
+			"codepoint": 61782,
+			"name": "battery_very_low"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61785,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 62085,
+			"name": "beer_meal"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 63211,
+			"name": "bia"
+		},
+		{
+			"codepoint": 59000,
+			"name": "bid_landscape"
+		},
+		{
+			"codepoint": 61313,
+			"name": "bid_landscape_disabled"
+		},
+		{
+			"codepoint": 58985,
+			"name": "bigtop_updates"
+		},
+		{
+			"codepoint": 62587,
+			"name": "bike_dock"
+		},
+		{
+			"codepoint": 62586,
+			"name": "bike_lane"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 59432,
+			"name": "blanket"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 1048440,
+			"name": "blinds_2"
+		},
+		{
+			"codepoint": 1048441,
+			"name": "blinds_2_closed"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 61580,
+			"name": "block"
+		},
+		{
+			"codepoint": 57495,
+			"name": "blood_pressure"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 59468,
+			"name": "blur_medium"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59599,
+			"name": "blur_short"
+		},
+		{
+			"codepoint": 62317,
+			"name": "boat_bus"
+		},
+		{
+			"codepoint": 62316,
+			"name": "boat_railway"
+		},
+		{
+			"codepoint": 57496,
+			"name": "body_fat"
+		},
+		{
+			"codepoint": 57497,
+			"name": "body_system"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 1048426,
+			"name": "bolt_boost"
+		},
+		{
+			"codepoint": 62824,
+			"name": "bomb"
+		},
+		{
+			"codepoint": 59502,
+			"name": "book"
+		},
+		{
+			"codepoint": 62782,
+			"name": "book_2"
+		},
+		{
+			"codepoint": 62781,
+			"name": "book_3"
+		},
+		{
+			"codepoint": 62780,
+			"name": "book_4"
+		},
+		{
+			"codepoint": 62779,
+			"name": "book_5"
+		},
+		{
+			"codepoint": 62431,
+			"name": "book_6"
+		},
+		{
+			"codepoint": 62180,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 62439,
+			"name": "book_ribbon"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 62480,
+			"name": "bookmark_bag"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 62551,
+			"name": "bookmark_check"
+		},
+		{
+			"codepoint": 62550,
+			"name": "bookmark_flag"
+		},
+		{
+			"codepoint": 62549,
+			"name": "bookmark_heart"
+		},
+		{
+			"codepoint": 63409,
+			"name": "bookmark_manager"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 61160,
+			"name": "bookmark_stacks"
+		},
+		{
+			"codepoint": 62548,
+			"name": "bookmark_star"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 61314,
+			"name": "books_movies_and_music"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 62477,
+			"name": "borg"
+		},
+		{
+			"codepoint": 59184,
+			"name": "bottom_app_bar"
+		},
+		{
+			"codepoint": 59181,
+			"name": "bottom_drawer"
+		},
+		{
+			"codepoint": 59788,
+			"name": "bottom_navigation"
+		},
+		{
+			"codepoint": 63274,
+			"name": "bottom_panel_close"
+		},
+		{
+			"codepoint": 63273,
+			"name": "bottom_panel_open"
+		},
+		{
+			"codepoint": 63108,
+			"name": "bottom_right_click"
+		},
+		{
+			"codepoint": 59789,
+			"name": "bottom_sheets"
+		},
+		{
+			"codepoint": 62884,
+			"name": "box"
+		},
+		{
+			"codepoint": 62885,
+			"name": "box_add"
+		},
+		{
+			"codepoint": 62886,
+			"name": "box_edit"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 59790,
+			"name": "brand_awareness"
+		},
+		{
+			"codepoint": 62705,
+			"name": "brand_family"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 59912,
+			"name": "breaking_news"
+		},
+		{
+			"codepoint": 61626,
+			"name": "breaking_news_alt_1"
+		},
+		{
+			"codepoint": 63574,
+			"name": "breastfeeding"
+		},
+		{
+			"codepoint": 62344,
+			"name": "brick"
+		},
+		{
+			"codepoint": 62022,
+			"name": "briefcase_meal"
+		},
+		{
+			"codepoint": 58362,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 61494,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 62927,
+			"name": "brightness_alert"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 63464,
+			"name": "brightness_empty"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 57366,
+			"name": "bring_your_own_ip"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60179,
+			"name": "browse"
+		},
+		{
+			"codepoint": 63653,
+			"name": "browse_activity"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 61315,
+			"name": "bubble"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 63054,
+			"name": "bubbles"
+		},
+		{
+			"codepoint": 61226,
+			"name": "bucket_check"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 63693,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 1048482,
+			"name": "bus_map_pin"
+		},
+		{
+			"codepoint": 62315,
+			"name": "bus_railway"
+		},
+		{
+			"codepoint": 59374,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 63564,
+			"name": "business_chip"
+		},
+		{
+			"codepoint": 61316,
+			"name": "business_messages"
+		},
+		{
+			"codepoint": 59183,
+			"name": "buttons_alt"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 62585,
+			"name": "cable_car"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 62644,
+			"name": "cadence"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 63579,
+			"name": "cake_add"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 61317,
+			"name": "calendar_add_on"
+		},
+		{
+			"codepoint": 61627,
+			"name": "calendar_apps_script"
+		},
+		{
+			"codepoint": 62019,
+			"name": "calendar_check"
+		},
+		{
+			"codepoint": 62784,
+			"name": "calendar_clock"
+		},
+		{
+			"codepoint": 62018,
+			"name": "calendar_lock"
+		},
+		{
+			"codepoint": 62102,
+			"name": "calendar_meal"
+		},
+		{
+			"codepoint": 62016,
+			"name": "calendar_meal_2"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 61652,
+			"name": "call"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end_alt"
+		},
+		{
+			"codepoint": 57486,
+			"name": "call_log"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 63058,
+			"name": "call_quality"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58386,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 62153,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 62152,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 63398,
+			"name": "camera_video"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 63650,
+			"name": "camping"
+		},
+		{
+			"codepoint": 59528,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 62856,
+			"name": "candle"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 62195,
+			"name": "cannabis"
+		},
+		{
+			"codepoint": 63272,
+			"name": "captive_portal"
+		},
+		{
+			"codepoint": 63271,
+			"name": "capture"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 62276,
+			"name": "car_defrost_left"
+		},
+		{
+			"codepoint": 62275,
+			"name": "car_defrost_low_left"
+		},
+		{
+			"codepoint": 62274,
+			"name": "car_defrost_low_right"
+		},
+		{
+			"codepoint": 62072,
+			"name": "car_defrost_mid_left"
+		},
+		{
+			"codepoint": 62273,
+			"name": "car_defrost_mid_low_left"
+		},
+		{
+			"codepoint": 62071,
+			"name": "car_defrost_mid_low_right"
+		},
+		{
+			"codepoint": 62272,
+			"name": "car_defrost_mid_right"
+		},
+		{
+			"codepoint": 62271,
+			"name": "car_defrost_right"
+		},
+		{
+			"codepoint": 62270,
+			"name": "car_fan_low_left"
+		},
+		{
+			"codepoint": 62269,
+			"name": "car_fan_low_mid_left"
+		},
+		{
+			"codepoint": 62268,
+			"name": "car_fan_low_right"
+		},
+		{
+			"codepoint": 62267,
+			"name": "car_fan_mid_left"
+		},
+		{
+			"codepoint": 62266,
+			"name": "car_fan_mid_low_right"
+		},
+		{
+			"codepoint": 62265,
+			"name": "car_fan_mid_right"
+		},
+		{
+			"codepoint": 62264,
+			"name": "car_fan_recirculate"
+		},
+		{
+			"codepoint": 1048384,
+			"name": "car_fan_recirculate_2"
+		},
+		{
+			"codepoint": 62263,
+			"name": "car_gear"
+		},
+		{
+			"codepoint": 62262,
+			"name": "car_lock"
+		},
+		{
+			"codepoint": 62261,
+			"name": "car_mirror_heat"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 62691,
+			"name": "car_tag"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 62649,
+			"name": "cardio_load"
+		},
+		{
+			"codepoint": 57500,
+			"name": "cardiology"
+		},
+		{
+			"codepoint": 59793,
+			"name": "cards"
+		},
+		{
+			"codepoint": 62351,
+			"name": "cards_stack"
+		},
+		{
+			"codepoint": 62325,
+			"name": "cards_star"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 60168,
+			"name": "carry_on_bag"
+		},
+		{
+			"codepoint": 60171,
+			"name": "carry_on_bag_checked"
+		},
+		{
+			"codepoint": 60170,
+			"name": "carry_on_bag_inactive"
+		},
+		{
+			"codepoint": 60169,
+			"name": "carry_on_bag_question"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 62960,
+			"name": "cast_pause"
+		},
+		{
+			"codepoint": 62959,
+			"name": "cast_warning"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 59180,
+			"name": "category"
+		},
+		{
+			"codepoint": 62519,
+			"name": "category_search"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 63534,
+			"name": "cell_merge"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 62111,
+			"name": "chair_counter"
+		},
+		{
+			"codepoint": 62110,
+			"name": "chair_fireplace"
+		},
+		{
+			"codepoint": 62109,
+			"name": "chair_umbrella"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 58030,
+			"name": "charger"
+		},
+		{
+			"codepoint": 62179,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 58483,
+			"name": "chart_data"
+		},
+		{
+			"codepoint": 57545,
+			"name": "chat"
+		},
+		{
+			"codepoint": 61683,
+			"name": "chat_add_on"
+		},
+		{
+			"codepoint": 61629,
+			"name": "chat_apps_script"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 1048507,
+			"name": "chat_bubble_off"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 61165,
+			"name": "chat_dashed"
+		},
+		{
+			"codepoint": 63404,
+			"name": "chat_error"
+		},
+		{
+			"codepoint": 62763,
+			"name": "chat_info"
+		},
+		{
+			"codepoint": 63165,
+			"name": "chat_paste_go"
+		},
+		{
+			"codepoint": 62411,
+			"name": "chat_paste_go_2"
+		},
+		{
+			"codepoint": 58984,
+			"name": "check"
+		},
+		{
+			"codepoint": 1048453,
+			"name": "check_alert"
+		},
+		{
+			"codepoint": 59870,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_filled"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 62078,
+			"name": "check_circle_unread"
+		},
+		{
+			"codepoint": 63222,
+			"name": "check_in_out"
+		},
+		{
+			"codepoint": 63626,
+			"name": "check_indeterminate_small"
+		},
+		{
+			"codepoint": 63627,
+			"name": "check_small"
+		},
+		{
+			"codepoint": 59149,
+			"name": "checkbook"
+		},
+		{
+			"codepoint": 60172,
+			"name": "checked_bag"
+		},
+		{
+			"codepoint": 60173,
+			"name": "checked_bag_question"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 63144,
+			"name": "cheer"
+		},
+		{
+			"codepoint": 62295,
+			"name": "chef_hat"
+		},
+		{
+			"codepoint": 62951,
+			"name": "chess"
+		},
+		{
+			"codepoint": 62049,
+			"name": "chess_bishop"
+		},
+		{
+			"codepoint": 62050,
+			"name": "chess_bishop_2"
+		},
+		{
+			"codepoint": 62047,
+			"name": "chess_king"
+		},
+		{
+			"codepoint": 62048,
+			"name": "chess_king_2"
+		},
+		{
+			"codepoint": 62046,
+			"name": "chess_knight"
+		},
+		{
+			"codepoint": 62390,
+			"name": "chess_pawn"
+		},
+		{
+			"codepoint": 62045,
+			"name": "chess_pawn_2"
+		},
+		{
+			"codepoint": 62044,
+			"name": "chess_queen"
+		},
+		{
+			"codepoint": 62043,
+			"name": "chess_rook"
+		},
+		{
+			"codepoint": 62571,
+			"name": "chevron_backward"
+		},
+		{
+			"codepoint": 62570,
+			"name": "chevron_forward"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 61123,
+			"name": "chevron_line_up"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 61312,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 61232,
+			"name": "child_hat"
+		},
+		{
+			"codepoint": 63521,
+			"name": "chip_extraction"
+		},
+		{
+			"codepoint": 59795,
+			"name": "chips"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 61819,
+			"name": "chromecast_2"
+		},
+		{
+			"codepoint": 59452,
+			"name": "chromecast_device"
+		},
+		{
+			"codepoint": 60338,
+			"name": "chronic"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 63571,
+			"name": "cinematic_blur"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 61153,
+			"name": "circle_circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59370,
+			"name": "circles"
+		},
+		{
+			"codepoint": 59372,
+			"name": "circles_ext"
+		},
+		{
+			"codepoint": 61631,
+			"name": "clarify"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 59797,
+			"name": "cleaning"
+		},
+		{
+			"codepoint": 63668,
+			"name": "cleaning_bucket"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 58829,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 61783,
+			"name": "clear_day"
+		},
+		{
+			"codepoint": 61785,
+			"name": "clear_night"
+		},
+		{
+			"codepoint": 63669,
+			"name": "climate_mini_split"
+		},
+		{
+			"codepoint": 57502,
+			"name": "clinical_notes"
+		},
+		{
+			"codepoint": 62338,
+			"name": "clock_arrow_down"
+		},
+		{
+			"codepoint": 62337,
+			"name": "clock_arrow_up"
+		},
+		{
+			"codepoint": 63270,
+			"name": "clock_loader_10"
+		},
+		{
+			"codepoint": 63269,
+			"name": "clock_loader_20"
+		},
+		{
+			"codepoint": 63268,
+			"name": "clock_loader_40"
+		},
+		{
+			"codepoint": 63267,
+			"name": "clock_loader_60"
+		},
+		{
+			"codepoint": 63266,
+			"name": "clock_loader_80"
+		},
+		{
+			"codepoint": 63265,
+			"name": "clock_loader_90"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 62728,
+			"name": "close_small"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 62638,
+			"name": "closed_caption_add"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 62412,
+			"name": "cloud_alert"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 62342,
+			"name": "cloud_lock"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy_filled"
+		},
+		{
+			"codepoint": 59408,
+			"name": "cloudy_snowing"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 63565,
+			"name": "code_blocks"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 1048459,
+			"name": "code_xml"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 57503,
+			"name": "cognition"
+		},
+		{
+			"codepoint": 62389,
+			"name": "cognition_2"
+		},
+		{
+			"codepoint": 59716,
+			"name": "collapse_all"
+		},
+		{
+			"codepoint": 62727,
+			"name": "collapse_content"
+		},
+		{
+			"codepoint": 58323,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58378,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 59799,
+			"name": "colors"
+		},
+		{
+			"codepoint": 62496,
+			"name": "combine_columns"
+		},
+		{
+			"codepoint": 62678,
+			"name": "comedy_mask"
+		},
+		{
+			"codepoint": 62941,
+			"name": "comic_bubble"
+		},
+		{
+			"codepoint": 57932,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 57980,
+			"name": "communication"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities_filled"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 61927,
+			"name": "component_exchange"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58142,
+			"name": "computer"
+		},
+		{
+			"codepoint": 62199,
+			"name": "computer_arrow_up"
+		},
+		{
+			"codepoint": 62198,
+			"name": "computer_cancel"
+		},
+		{
+			"codepoint": 61108,
+			"name": "computer_sound"
+		},
+		{
+			"codepoint": 62817,
+			"name": "concierge"
+		},
+		{
+			"codepoint": 57504,
+			"name": "conditions"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 57505,
+			"name": "congenital"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone_filled"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 63576,
+			"name": "contactless_off"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 59801,
+			"name": "contacts_product"
+		},
+		{
+			"codepoint": 57677,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 57678,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 57679,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 62598,
+			"name": "contextual_token"
+		},
+		{
+			"codepoint": 62597,
+			"name": "contextual_token_add"
+		},
+		{
+			"codepoint": 62880,
+			"name": "contract"
+		},
+		{
+			"codepoint": 62882,
+			"name": "contract_delete"
+		},
+		{
+			"codepoint": 62881,
+			"name": "contract_edit"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 62623,
+			"name": "contrast_circle"
+		},
+		{
+			"codepoint": 60530,
+			"name": "contrast_rtl_off"
+		},
+		{
+			"codepoint": 62624,
+			"name": "contrast_square"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 59792,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 59453,
+			"name": "controller_gen"
+		},
+		{
+			"codepoint": 61231,
+			"name": "conversation"
+		},
+		{
+			"codepoint": 61633,
+			"name": "conversion_path"
+		},
+		{
+			"codepoint": 63412,
+			"name": "conversion_path_off"
+		},
+		{
+			"codepoint": 62495,
+			"name": "convert_to_text"
+		},
+		{
+			"codepoint": 63591,
+			"name": "conveyor_belt"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 63386,
+			"name": "cookie_off"
+		},
+		{
+			"codepoint": 58038,
+			"name": "cooking"
+		},
+		{
+			"codepoint": 57974,
+			"name": "cool_to_dry"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 63365,
+			"name": "counter_0"
+		},
+		{
+			"codepoint": 63364,
+			"name": "counter_1"
+		},
+		{
+			"codepoint": 63363,
+			"name": "counter_2"
+		},
+		{
+			"codepoint": 63362,
+			"name": "counter_3"
+		},
+		{
+			"codepoint": 63361,
+			"name": "counter_4"
+		},
+		{
+			"codepoint": 63360,
+			"name": "counter_5"
+		},
+		{
+			"codepoint": 63359,
+			"name": "counter_6"
+		},
+		{
+			"codepoint": 63358,
+			"name": "counter_7"
+		},
+		{
+			"codepoint": 63357,
+			"name": "counter_8"
+		},
+		{
+			"codepoint": 63356,
+			"name": "counter_9"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 61591,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59553,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 62520,
+			"name": "credit_card_clock"
+		},
+		{
+			"codepoint": 62765,
+			"name": "credit_card_gear"
+		},
+		{
+			"codepoint": 62764,
+			"name": "credit_card_heart"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 1048330,
+			"name": "crop_21_9"
+		},
+		{
+			"codepoint": 1048331,
+			"name": "crop_2_3"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 62793,
+			"name": "crop_9_16"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58356,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 62949,
+			"name": "crossword"
+		},
+		{
+			"codepoint": 60184,
+			"name": "crowdsource"
+		},
+		{
+			"codepoint": 60595,
+			"name": "crown"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 59087,
+			"name": "csv"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 62560,
+			"name": "currency_rupee_circle"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 59186,
+			"name": "custom_typography"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 63572,
+			"name": "cycle"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 62442,
+			"name": "dashboard_2"
+		},
+		{
+			"codepoint": 1048297,
+			"name": "dashboard_2_add"
+		},
+		{
+			"codepoint": 1048535,
+			"name": "dashboard_2_edit"
+		},
+		{
+			"codepoint": 1048534,
+			"name": "dashboard_2_gear"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 63478,
+			"name": "data_alert"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 63474,
+			"name": "data_check"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 63477,
+			"name": "data_info_alert"
+		},
+		{
+			"codepoint": 58076,
+			"name": "data_loss_prevention"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 59804,
+			"name": "data_table"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 61966,
+			"name": "database"
+		},
+		{
+			"codepoint": 62484,
+			"name": "database_off"
+		},
+		{
+			"codepoint": 62350,
+			"name": "database_search"
+		},
+		{
+			"codepoint": 62428,
+			"name": "database_upload"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 57509,
+			"name": "deceased"
+		},
+		{
+			"codepoint": 63533,
+			"name": "decimal_decrease"
+		},
+		{
+			"codepoint": 63532,
+			"name": "decimal_increase"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 62744,
+			"name": "delete_history"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60200,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 62370,
+			"name": "delivery_truck_bolt"
+		},
+		{
+			"codepoint": 62369,
+			"name": "delivery_truck_speed"
+		},
+		{
+			"codepoint": 58505,
+			"name": "demography"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 57510,
+			"name": "dentistry"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 63264,
+			"name": "deployed_code"
+		},
+		{
+			"codepoint": 62747,
+			"name": "deployed_code_account"
+		},
+		{
+			"codepoint": 62962,
+			"name": "deployed_code_alert"
+		},
+		{
+			"codepoint": 62963,
+			"name": "deployed_code_history"
+		},
+		{
+			"codepoint": 62964,
+			"name": "deployed_code_update"
+		},
+		{
+			"codepoint": 57511,
+			"name": "dermatology"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 63482,
+			"name": "deskphone"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 62427,
+			"name": "desktop_cloud"
+		},
+		{
+			"codepoint": 62398,
+			"name": "desktop_cloud_stack"
+		},
+		{
+			"codepoint": 62558,
+			"name": "desktop_landscape"
+		},
+		{
+			"codepoint": 62521,
+			"name": "desktop_landscape_add"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 62557,
+			"name": "desktop_portrait"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 62853,
+			"name": "destruction"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58015,
+			"name": "detection_and_zone"
+		},
+		{
+			"codepoint": 61119,
+			"name": "detection_and_zone_off"
+		},
+		{
+			"codepoint": 57986,
+			"name": "detector"
+		},
+		{
+			"codepoint": 57847,
+			"name": "detector_alarm"
+		},
+		{
+			"codepoint": 57860,
+			"name": "detector_battery"
+		},
+		{
+			"codepoint": 58031,
+			"name": "detector_co"
+		},
+		{
+			"codepoint": 57891,
+			"name": "detector_offline"
+		},
+		{
+			"codepoint": 57989,
+			"name": "detector_smoke"
+		},
+		{
+			"codepoint": 57832,
+			"name": "detector_status"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 59806,
+			"name": "developer_guide"
+		},
+		{
+			"codepoint": 62178,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 59508,
+			"name": "developer_mode_tv"
+		},
+		{
+			"codepoint": 62197,
+			"name": "device_band"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 59571,
+			"name": "device_reset"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 62177,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 58150,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 62470,
+			"name": "devices_fold_2"
+		},
+		{
+			"codepoint": 63397,
+			"name": "devices_off"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 63147,
+			"name": "devices_wearables"
+		},
+		{
+			"codepoint": 63609,
+			"name": "dew_point"
+		},
+		{
+			"codepoint": 57512,
+			"name": "diagnosis"
+		},
+		{
+			"codepoint": 62494,
+			"name": "diagonal_line"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 59807,
+			"name": "dialogs"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 62130,
+			"name": "diamond_shine"
+		},
+		{
+			"codepoint": 62777,
+			"name": "dictionary"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61918,
+			"name": "digital_out_of_home"
+		},
+		{
+			"codepoint": 61318,
+			"name": "digital_wellbeing"
+		},
+		{
+			"codepoint": 62108,
+			"name": "dine_heart"
+		},
+		{
+			"codepoint": 62101,
+			"name": "dine_in"
+		},
+		{
+			"codepoint": 62107,
+			"name": "dine_lamp"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 63616,
+			"name": "directions_alt"
+		},
+		{
+			"codepoint": 63617,
+			"name": "directions_alt_off"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 62562,
+			"name": "directions_railway_2"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 58260,
+			"name": "directory_sync"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 57368,
+			"name": "discover_tune"
+		},
+		{
+			"codepoint": 59808,
+			"name": "dishwasher"
+		},
+		{
+			"codepoint": 59442,
+			"name": "dishwasher_gen"
+		},
+		{
+			"codepoint": 63463,
+			"name": "display_external_input"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63210,
+			"name": "distance"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 63575,
+			"name": "diversity_4"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 62176,
+			"name": "dock"
+		},
+		{
+			"codepoint": 63462,
+			"name": "dock_to_bottom"
+		},
+		{
+			"codepoint": 63461,
+			"name": "dock_to_left"
+		},
+		{
+			"codepoint": 63460,
+			"name": "dock_to_right"
+		},
+		{
+			"codepoint": 60029,
+			"name": "docs"
+		},
+		{
+			"codepoint": 61634,
+			"name": "docs_add_on"
+		},
+		{
+			"codepoint": 61635,
+			"name": "docs_apps_script"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 62341,
+			"name": "document_search"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 63408,
+			"name": "domain_verification_off"
+		},
+		{
+			"codepoint": 62948,
+			"name": "domino_mask"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 59260,
+			"name": "door_open"
+		},
+		{
+			"codepoint": 57994,
+			"name": "door_sensor"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 57831,
+			"name": "doorbell_3p"
+		},
+		{
+			"codepoint": 57843,
+			"name": "doorbell_chime"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 62755,
+			"name": "download_2"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 58996,
+			"name": "draft"
+		},
+		{
+			"codepoint": 59315,
+			"name": "draft_orders"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 63263,
+			"name": "drag_click"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 63262,
+			"name": "drag_pan"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 63480,
+			"name": "draw_abstract"
+		},
+		{
+			"codepoint": 63479,
+			"name": "draw_collage"
+		},
+		{
+			"codepoint": 60160,
+			"name": "drawing_recognition"
+		},
+		{
+			"codepoint": 57872,
+			"name": "dresser"
+		},
+		{
+			"codepoint": 61431,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 62493,
+			"name": "drive_export"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_outline"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 58998,
+			"name": "drive_file_rename"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 59000,
+			"name": "drive_fusiontable"
+		},
+		{
+			"codepoint": 62042,
+			"name": "drone"
+		},
+		{
+			"codepoint": 62041,
+			"name": "drone_2"
+		},
+		{
+			"codepoint": 59812,
+			"name": "dropdown"
+		},
+		{
+			"codepoint": 1048304,
+			"name": "dropdown_menu"
+		},
+		{
+			"codepoint": 62289,
+			"name": "dropper_eye"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 63183,
+			"name": "dual_screen"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61722,
+			"name": "e911_avatar"
+		},
+		{
+			"codepoint": 61721,
+			"name": "e911_emergency"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 63459,
+			"name": "e_mobiledata_badge"
+		},
+		{
+			"codepoint": 62294,
+			"name": "ear_sound"
+		},
+		{
+			"codepoint": 62247,
+			"name": "earbud_case"
+		},
+		{
+			"codepoint": 62246,
+			"name": "earbud_left"
+		},
+		{
+			"codepoint": 62245,
+			"name": "earbud_right"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 62244,
+			"name": "earbuds_2"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 58042,
+			"name": "early_on"
+		},
+		{
+			"codepoint": 63055,
+			"name": "earthquake"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 63503,
+			"name": "ecg"
+		},
+		{
+			"codepoint": 63209,
+			"name": "ecg_heart"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 63208,
+			"name": "eda"
+		},
+		{
+			"codepoint": 62191,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 62190,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 61591,
+			"name": "edit"
+		},
+		{
+			"codepoint": 62336,
+			"name": "edit_arrow_down"
+		},
+		{
+			"codepoint": 62335,
+			"name": "edit_arrow_up"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 62509,
+			"name": "edit_audio"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 63628,
+			"name": "edit_document"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 63629,
+			"name": "edit_square"
+		},
+		{
+			"codepoint": 62760,
+			"name": "editor_choice"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 63207,
+			"name": "elevation"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57689,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 61789,
+			"name": "emergency_heat"
+		},
+		{
+			"codepoint": 62693,
+			"name": "emergency_heat_2"
+		},
+		{
+			"codepoint": 59434,
+			"name": "emergency_home"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 62878,
+			"name": "emergency_share_off"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 61638,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 62669,
+			"name": "emoji_language"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 58867,
+			"name": "emoticon"
+		},
+		{
+			"codepoint": 63556,
+			"name": "empty_dashboard"
+		},
+		{
+			"codepoint": 61832,
+			"name": "enable"
+		},
+		{
+			"codepoint": 58771,
+			"name": "encrypted"
+		},
+		{
+			"codepoint": 62505,
+			"name": "encrypted_add"
+		},
+		{
+			"codepoint": 62506,
+			"name": "encrypted_add_circle"
+		},
+		{
+			"codepoint": 62504,
+			"name": "encrypted_minus_circle"
+		},
+		{
+			"codepoint": 62503,
+			"name": "encrypted_off"
+		},
+		{
+			"codepoint": 57513,
+			"name": "endocrinology"
+		},
+		{
+			"codepoint": 59814,
+			"name": "energy"
+		},
+		{
+			"codepoint": 61791,
+			"name": "energy_program_saving"
+		},
+		{
+			"codepoint": 61793,
+			"name": "energy_program_time_used"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57514,
+			"name": "ent"
+		},
+		{
+			"codepoint": 59150,
+			"name": "enterprise"
+		},
+		{
+			"codepoint": 60237,
+			"name": "enterprise_off"
+		},
+		{
+			"codepoint": 63355,
+			"name": "equal"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 62460,
+			"name": "eraser_size_1"
+		},
+		{
+			"codepoint": 62459,
+			"name": "eraser_size_2"
+		},
+		{
+			"codepoint": 62458,
+			"name": "eraser_size_3"
+		},
+		{
+			"codepoint": 62457,
+			"name": "eraser_size_4"
+		},
+		{
+			"codepoint": 62456,
+			"name": "eraser_size_5"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_circle_rounded"
+		},
+		{
+			"codepoint": 58523,
+			"name": "error_med"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_charger"
+		},
+		{
+			"codepoint": 63458,
+			"name": "ev_mobiledata_badge"
+		},
+		{
+			"codepoint": 61327,
+			"name": "ev_shadow"
+		},
+		{
+			"codepoint": 62848,
+			"name": "ev_shadow_add"
+		},
+		{
+			"codepoint": 62847,
+			"name": "ev_shadow_minus"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 63107,
+			"name": "event_list"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 62008,
+			"name": "event_upcoming"
+		},
+		{
+			"codepoint": 61999,
+			"name": "exclamation"
+		},
+		{
+			"codepoint": 63206,
+			"name": "exercise"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59718,
+			"name": "expand_all"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 62865,
+			"name": "expand_circle_right"
+		},
+		{
+			"codepoint": 62930,
+			"name": "expand_circle_up"
+		},
+		{
+			"codepoint": 63536,
+			"name": "expand_content"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expansion_panels"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expension_panels"
+		},
+		{
+			"codepoint": 59014,
+			"name": "experiment"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 58680,
+			"name": "explore_nearby"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 63109,
+			"name": "explosion"
+		},
+		{
+			"codepoint": 57516,
+			"name": "export_notes"
+		},
+		{
+			"codepoint": 58358,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 59392,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 62665,
+			"name": "eye_tracking"
+		},
+		{
+			"codepoint": 61107,
+			"name": "eyebrow"
+		},
+		{
+			"codepoint": 63214,
+			"name": "eyeglasses"
+		},
+		{
+			"codepoint": 62151,
+			"name": "eyeglasses_2"
+		},
+		{
+			"codepoint": 62053,
+			"name": "eyeglasses_2_sound"
+		},
+		{
+			"codepoint": 1048305,
+			"name": "eyeglasses_3"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 62466,
+			"name": "face_down"
+		},
+		{
+			"codepoint": 62465,
+			"name": "face_left"
+		},
+		{
+			"codepoint": 62464,
+			"name": "face_nod"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 62463,
+			"name": "face_right"
+		},
+		{
+			"codepoint": 62462,
+			"name": "face_shake"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62461,
+			"name": "face_up"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 62989,
+			"name": "falling"
+		},
+		{
+			"codepoint": 57884,
+			"name": "familiar_face_and_zone"
+		},
+		{
+			"codepoint": 61170,
+			"name": "family_group"
+		},
+		{
+			"codepoint": 57517,
+			"name": "family_history"
+		},
+		{
+			"codepoint": 60198,
+			"name": "family_home"
+		},
+		{
+			"codepoint": 60185,
+			"name": "family_link"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 62759,
+			"name": "family_star"
+		},
+		{
+			"codepoint": 62260,
+			"name": "fan_focus"
+		},
+		{
+			"codepoint": 62259,
+			"name": "fan_indirect"
+		},
+		{
+			"codepoint": 62809,
+			"name": "farsight_digital"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 57976,
+			"name": "faucet"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 59817,
+			"name": "feature_search"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 61329,
+			"name": "featured_seasonal_and_gifts"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 63633,
+			"name": "femur"
+		},
+		{
+			"codepoint": 63634,
+			"name": "femur_alt"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 63205,
+			"name": "fertile"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 62680,
+			"name": "file_copy_off"
+		},
+		{
+			"codepoint": 61584,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 62386,
+			"name": "file_export"
+		},
+		{
+			"codepoint": 62395,
+			"name": "file_json"
+		},
+		{
+			"codepoint": 58053,
+			"name": "file_map"
+		},
+		{
+			"codepoint": 62434,
+			"name": "file_map_stack"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 62396,
+			"name": "file_png"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 61823,
+			"name": "file_save"
+		},
+		{
+			"codepoint": 58629,
+			"name": "file_save_off"
+		},
+		{
+			"codepoint": 61595,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 63622,
+			"name": "file_upload_off"
+		},
+		{
+			"codepoint": 60037,
+			"name": "files"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 62417,
+			"name": "filter_arrow_right"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 59726,
+			"name": "filter_list_alt"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58337,
+			"name": "filter_retrolux"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59071,
+			"name": "finance"
+		},
+		{
+			"codepoint": 63566,
+			"name": "finance_chip"
+		},
+		{
+			"codepoint": 61330,
+			"name": "finance_mode"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 62621,
+			"name": "fingerprint_off"
+		},
+		{
+			"codepoint": 1048488,
+			"name": "fire_check"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 61859,
+			"name": "fire_hydrant"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 63354,
+			"name": "fit_page"
+		},
+		{
+			"codepoint": 62359,
+			"name": "fit_page_height"
+		},
+		{
+			"codepoint": 62358,
+			"name": "fit_page_width"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 63353,
+			"name": "fit_width"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 62563,
+			"name": "fitness_tracker"
+		},
+		{
+			"codepoint": 61169,
+			"name": "fitness_trackers"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag"
+		},
+		{
+			"codepoint": 62479,
+			"name": "flag_2"
+		},
+		{
+			"codepoint": 62424,
+			"name": "flag_check"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag_filled"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 63352,
+			"name": "flex_direction"
+		},
+		{
+			"codepoint": 63351,
+			"name": "flex_no_wrap"
+		},
+		{
+			"codepoint": 63350,
+			"name": "flex_wrap"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 59819,
+			"name": "flights_and_hotels"
+		},
+		{
+			"codepoint": 61331,
+			"name": "flightsmode"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 62556,
+			"name": "float_landscape_2"
+		},
+		{
+			"codepoint": 62555,
+			"name": "float_portrait_2"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 63204,
+			"name": "floor"
+		},
+		{
+			"codepoint": 57886,
+			"name": "floor_lamp"
+		},
+		{
+			"codepoint": 61565,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 62349,
+			"name": "flowchart"
+		},
+		{
+			"codepoint": 57518,
+			"name": "flowsheet"
+		},
+		{
+			"codepoint": 58499,
+			"name": "fluid"
+		},
+		{
+			"codepoint": 63501,
+			"name": "fluid_balance"
+		},
+		{
+			"codepoint": 63500,
+			"name": "fluid_med"
+		},
+		{
+			"codepoint": 61565,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 61917,
+			"name": "flutter"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 62584,
+			"name": "flyover"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61915,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 59416,
+			"name": "foggy"
+		},
+		{
+			"codepoint": 62957,
+			"name": "folded_hands"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 62423,
+			"name": "folder_check"
+		},
+		{
+			"codepoint": 62422,
+			"name": "folder_check_2"
+		},
+		{
+			"codepoint": 62408,
+			"name": "folder_code"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 62854,
+			"name": "folder_data"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 62421,
+			"name": "folder_eye"
+		},
+		{
+			"codepoint": 62357,
+			"name": "folder_info"
+		},
+		{
+			"codepoint": 62692,
+			"name": "folder_limited"
+		},
+		{
+			"codepoint": 63349,
+			"name": "folder_managed"
+		},
+		{
+			"codepoint": 62420,
+			"name": "folder_match"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 63348,
+			"name": "folder_supervised"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 63635,
+			"name": "foot_bones"
+		},
+		{
+			"codepoint": 63613,
+			"name": "footprint"
+		},
+		{
+			"codepoint": 59820,
+			"name": "for_you"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 1048486,
+			"name": "fork_chart"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 62436,
+			"name": "fork_spoon"
+		},
+		{
+			"codepoint": 63592,
+			"name": "forklift"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 63581,
+			"name": "format_h1"
+		},
+		{
+			"codepoint": 63582,
+			"name": "format_h2"
+		},
+		{
+			"codepoint": 63583,
+			"name": "format_h3"
+		},
+		{
+			"codepoint": 63584,
+			"name": "format_h4"
+		},
+		{
+			"codepoint": 63585,
+			"name": "format_h5"
+		},
+		{
+			"codepoint": 63586,
+			"name": "format_h6"
+		},
+		{
+			"codepoint": 61104,
+			"name": "format_image_back"
+		},
+		{
+			"codepoint": 61103,
+			"name": "format_image_break_left"
+		},
+		{
+			"codepoint": 61102,
+			"name": "format_image_break_right"
+		},
+		{
+			"codepoint": 61101,
+			"name": "format_image_front"
+		},
+		{
+			"codepoint": 61100,
+			"name": "format_image_inline_left"
+		},
+		{
+			"codepoint": 1048573,
+			"name": "format_image_inline_right"
+		},
+		{
+			"codepoint": 63587,
+			"name": "format_image_left"
+		},
+		{
+			"codepoint": 63588,
+			"name": "format_image_right"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 63531,
+			"name": "format_ink_highlighter"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 63347,
+			"name": "format_letter_spacing"
+		},
+		{
+			"codepoint": 63000,
+			"name": "format_letter_spacing_2"
+		},
+		{
+			"codepoint": 62999,
+			"name": "format_letter_spacing_standard"
+		},
+		{
+			"codepoint": 62998,
+			"name": "format_letter_spacing_wide"
+		},
+		{
+			"codepoint": 62997,
+			"name": "format_letter_spacing_wider"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 63561,
+			"name": "format_list_bulleted_add"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 1048471,
+			"name": "format_paint_off"
+		},
+		{
+			"codepoint": 63589,
+			"name": "format_paragraph"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 62483,
+			"name": "format_quote_off"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 63530,
+			"name": "format_text_clip"
+		},
+		{
+			"codepoint": 63529,
+			"name": "format_text_overflow"
+		},
+		{
+			"codepoint": 63528,
+			"name": "format_text_wrap"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 62648,
+			"name": "format_textdirection_vertical"
+		},
+		{
+			"codepoint": 57929,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 63621,
+			"name": "format_underlined_squiggle"
+		},
+		{
+			"codepoint": 61639,
+			"name": "forms_add_on"
+		},
+		{
+			"codepoint": 61640,
+			"name": "forms_apps_script"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 59567,
+			"name": "forum"
+		},
+		{
+			"codepoint": 62842,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 63221,
+			"name": "forward_circle"
+		},
+		{
+			"codepoint": 63220,
+			"name": "forward_media"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 62277,
+			"name": "fragrance"
+		},
+		{
+			"codepoint": 61167,
+			"name": "frame_bug"
+		},
+		{
+			"codepoint": 61166,
+			"name": "frame_exclamation"
+		},
+		{
+			"codepoint": 63346,
+			"name": "frame_inspect"
+		},
+		{
+			"codepoint": 63654,
+			"name": "frame_person"
+		},
+		{
+			"codepoint": 62677,
+			"name": "frame_person_mic"
+		},
+		{
+			"codepoint": 63441,
+			"name": "frame_person_off"
+		},
+		{
+			"codepoint": 63345,
+			"name": "frame_reload"
+		},
+		{
+			"codepoint": 63344,
+			"name": "frame_source"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 63593,
+			"name": "front_loader"
+		},
+		{
+			"codepoint": 60178,
+			"name": "full_coverage"
+		},
+		{
+			"codepoint": 62859,
+			"name": "full_hd"
+		},
+		{
+			"codepoint": 61970,
+			"name": "full_stacked_bar_chart"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 62554,
+			"name": "fullscreen_portrait"
+		},
+		{
+			"codepoint": 63590,
+			"name": "function"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 62583,
+			"name": "funicular"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 63457,
+			"name": "g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 63599,
+			"name": "gallery_thumbnail"
+		},
+		{
+			"codepoint": 61152,
+			"name": "game_bumper_left"
+		},
+		{
+			"codepoint": 61151,
+			"name": "game_bumper_right"
+		},
+		{
+			"codepoint": 61150,
+			"name": "game_button_l"
+		},
+		{
+			"codepoint": 61149,
+			"name": "game_button_l1"
+		},
+		{
+			"codepoint": 61148,
+			"name": "game_button_l2"
+		},
+		{
+			"codepoint": 61147,
+			"name": "game_button_r"
+		},
+		{
+			"codepoint": 61146,
+			"name": "game_button_r1"
+		},
+		{
+			"codepoint": 61145,
+			"name": "game_button_r2"
+		},
+		{
+			"codepoint": 61144,
+			"name": "game_button_zl"
+		},
+		{
+			"codepoint": 61143,
+			"name": "game_button_zr"
+		},
+		{
+			"codepoint": 61142,
+			"name": "game_stick_l3"
+		},
+		{
+			"codepoint": 61141,
+			"name": "game_stick_left"
+		},
+		{
+			"codepoint": 61140,
+			"name": "game_stick_r3"
+		},
+		{
+			"codepoint": 61139,
+			"name": "game_stick_right"
+		},
+		{
+			"codepoint": 61138,
+			"name": "game_trigger_left"
+		},
+		{
+			"codepoint": 61137,
+			"name": "game_trigger_right"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 61136,
+			"name": "gamepad_circle_down"
+		},
+		{
+			"codepoint": 61135,
+			"name": "gamepad_circle_left"
+		},
+		{
+			"codepoint": 61134,
+			"name": "gamepad_circle_right"
+		},
+		{
+			"codepoint": 61133,
+			"name": "gamepad_circle_up"
+		},
+		{
+			"codepoint": 61132,
+			"name": "gamepad_down"
+		},
+		{
+			"codepoint": 61131,
+			"name": "gamepad_left"
+		},
+		{
+			"codepoint": 61130,
+			"name": "gamepad_right"
+		},
+		{
+			"codepoint": 61129,
+			"name": "gamepad_up"
+		},
+		{
+			"codepoint": 58127,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 62093,
+			"name": "garage_check"
+		},
+		{
+			"codepoint": 59156,
+			"name": "garage_door"
+		},
+		{
+			"codepoint": 1048439,
+			"name": "garage_door_open"
+		},
+		{
+			"codepoint": 59437,
+			"name": "garage_home"
+		},
+		{
+			"codepoint": 62092,
+			"name": "garage_money"
+		},
+		{
+			"codepoint": 63657,
+			"name": "garden_cart"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 57585,
+			"name": "gastroenterology"
+		},
+		{
+			"codepoint": 57975,
+			"name": "gate"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59102,
+			"name": "general_device"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57587,
+			"name": "genetics"
+		},
+		{
+			"codepoint": 59118,
+			"name": "genres"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 63063,
+			"name": "gesture_select"
+		},
+		{
+			"codepoint": 61584,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 62478,
+			"name": "gif_2"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 63203,
+			"name": "glass_cup"
+		},
+		{
+			"codepoint": 58956,
+			"name": "globe"
+		},
+		{
+			"codepoint": 1048503,
+			"name": "globe_2_cancel"
+		},
+		{
+			"codepoint": 1048502,
+			"name": "globe_2_question"
+		},
+		{
+			"codepoint": 63385,
+			"name": "globe_asia"
+		},
+		{
+			"codepoint": 62409,
+			"name": "globe_book"
+		},
+		{
+			"codepoint": 62301,
+			"name": "globe_location_pin"
+		},
+		{
+			"codepoint": 63384,
+			"name": "globe_uk"
+		},
+		{
+			"codepoint": 58528,
+			"name": "glucose"
+		},
+		{
+			"codepoint": 63651,
+			"name": "glyphs"
+		},
+		{
+			"codepoint": 63261,
+			"name": "go_to_line"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 62582,
+			"name": "gondola_lift"
+		},
+		{
+			"codepoint": 59157,
+			"name": "google_home_devices"
+		},
+		{
+			"codepoint": 62842,
+			"name": "google_plus_reshare"
+		},
+		{
+			"codepoint": 62939,
+			"name": "google_tv_remote"
+		},
+		{
+			"codepoint": 62841,
+			"name": "google_wifi"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 58716,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57783,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57782,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 61594,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 62368,
+			"name": "graph_1"
+		},
+		{
+			"codepoint": 62367,
+			"name": "graph_2"
+		},
+		{
+			"codepoint": 62366,
+			"name": "graph_3"
+		},
+		{
+			"codepoint": 62365,
+			"name": "graph_4"
+		},
+		{
+			"codepoint": 62364,
+			"name": "graph_5"
+		},
+		{
+			"codepoint": 62363,
+			"name": "graph_6"
+		},
+		{
+			"codepoint": 62278,
+			"name": "graph_7"
+		},
+		{
+			"codepoint": 1048556,
+			"name": "graph_8"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 1048472,
+			"name": "graphic_eq_off"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 63100,
+			"name": "grid_3x3_off"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 63343,
+			"name": "grid_guides"
+		},
+		{
+			"codepoint": 1048461,
+			"name": "grid_layout_side"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 61335,
+			"name": "grocery"
+		},
+		{
+			"codepoint": 59937,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 62414,
+			"name": "group_search"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 61969,
+			"name": "grouped_bar_chart"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 62657,
+			"name": "guardian"
+		},
+		{
+			"codepoint": 57588,
+			"name": "gynecology"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 63456,
+			"name": "h_mobiledata_badge"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 63455,
+			"name": "h_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 59128,
+			"name": "hallway"
+		},
+		{
+			"codepoint": 62015,
+			"name": "hanami_dango"
+		},
+		{
+			"codepoint": 63636,
+			"name": "hand_bones"
+		},
+		{
+			"codepoint": 61340,
+			"name": "hand_gesture"
+		},
+		{
+			"codepoint": 62451,
+			"name": "hand_gesture_off"
+		},
+		{
+			"codepoint": 62100,
+			"name": "hand_meal"
+		},
+		{
+			"codepoint": 62099,
+			"name": "hand_package"
+		},
+		{
+			"codepoint": 62662,
+			"name": "handheld_controller"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 60162,
+			"name": "handwriting_recognition"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 57537,
+			"name": "hangout_video"
+		},
+		{
+			"codepoint": 57538,
+			"name": "hangout_video_off"
+		},
+		{
+			"codepoint": 62426,
+			"name": "hard_disk"
+		},
+		{
+			"codepoint": 63502,
+			"name": "hard_drive"
+		},
+		{
+			"codepoint": 63396,
+			"name": "hard_drive_2"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58351,
+			"name": "hdr_plus_off"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 62661,
+			"name": "head_mounted_device"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 61341,
+			"name": "health_and_beauty"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 62147,
+			"name": "health_cross"
+		},
+		{
+			"codepoint": 63202,
+			"name": "health_metrics"
+		},
+		{
+			"codepoint": 63342,
+			"name": "heap_snapshot_large"
+		},
+		{
+			"codepoint": 63341,
+			"name": "heap_snapshot_multiple"
+		},
+		{
+			"codepoint": 63340,
+			"name": "heap_snapshot_thumbnail"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 62564,
+			"name": "hearing_aid"
+		},
+		{
+			"codepoint": 62384,
+			"name": "hearing_aid_disabled"
+		},
+		{
+			"codepoint": 62188,
+			"name": "hearing_aid_disabled_left"
+		},
+		{
+			"codepoint": 62189,
+			"name": "hearing_aid_left"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 62986,
+			"name": "heart_check"
+		},
+		{
+			"codepoint": 63619,
+			"name": "heart_minus"
+		},
+		{
+			"codepoint": 63620,
+			"name": "heart_plus"
+		},
+		{
+			"codepoint": 62098,
+			"name": "heart_smile"
+		},
+		{
+			"codepoint": 62775,
+			"name": "heat"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 57982,
+			"name": "heat_pump_balance"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 62988,
+			"name": "helicopter"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 63504,
+			"name": "help_clinic"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 57590,
+			"name": "hematology"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61342,
+			"name": "hide"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 62106,
+			"name": "high_chair"
+		},
+		{
+			"codepoint": 63388,
+			"name": "high_density"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 62795,
+			"name": "high_res"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 62736,
+			"name": "highlight_keyboard_focus"
+		},
+		{
+			"codepoint": 62737,
+			"name": "highlight_mouse_cursor"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 62738,
+			"name": "highlight_text_cursor"
+		},
+		{
+			"codepoint": 63339,
+			"name": "highlighter_size_1"
+		},
+		{
+			"codepoint": 63338,
+			"name": "highlighter_size_2"
+		},
+		{
+			"codepoint": 63337,
+			"name": "highlighter_size_3"
+		},
+		{
+			"codepoint": 63336,
+			"name": "highlighter_size_4"
+		},
+		{
+			"codepoint": 63335,
+			"name": "highlighter_size_5"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59571,
+			"name": "history"
+		},
+		{
+			"codepoint": 62438,
+			"name": "history_2"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 62682,
+			"name": "history_off"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home"
+		},
+		{
+			"codepoint": 61343,
+			"name": "home_and_garden"
+		},
+		{
+			"codepoint": 58005,
+			"name": "home_app_logo"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home_filled"
+		},
+		{
+			"codepoint": 58553,
+			"name": "home_health"
+		},
+		{
+			"codepoint": 61344,
+			"name": "home_improvement_and_tools"
+		},
+		{
+			"codepoint": 57987,
+			"name": "home_iot_device"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 59465,
+			"name": "home_max_dots"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61773,
+			"name": "home_pin"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 61724,
+			"name": "home_speaker"
+		},
+		{
+			"codepoint": 63596,
+			"name": "home_storage"
+		},
+		{
+			"codepoint": 1048446,
+			"name": "home_storage_gear"
+		},
+		{
+			"codepoint": 61488,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 1048476,
+			"name": "horizontal_align_center"
+		},
+		{
+			"codepoint": 1048475,
+			"name": "horizontal_align_left"
+		},
+		{
+			"codepoint": 1048474,
+			"name": "horizontal_align_right"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 62425,
+			"name": "host"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58697,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 60415,
+			"name": "hourglass"
+		},
+		{
+			"codepoint": 62334,
+			"name": "hourglass_arrow_down"
+		},
+		{
+			"codepoint": 62333,
+			"name": "hourglass_arrow_up"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 1048557,
+			"name": "hourglass_check"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 62348,
+			"name": "hourglass_pause"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 59270,
+			"name": "house_with_shield"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 61345,
+			"name": "household_supplies"
+		},
+		{
+			"codepoint": 62581,
+			"name": "hov"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 63162,
+			"name": "hr_resting"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59545,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 63637,
+			"name": "humerus"
+		},
+		{
+			"codepoint": 63638,
+			"name": "humerus_alt"
+		},
+		{
+			"codepoint": 61795,
+			"name": "humidity_high"
+		},
+		{
+			"codepoint": 62808,
+			"name": "humidity_indoor"
+		},
+		{
+			"codepoint": 61796,
+			"name": "humidity_low"
+		},
+		{
+			"codepoint": 61797,
+			"name": "humidity_mid"
+		},
+		{
+			"codepoint": 63614,
+			"name": "humidity_percentage"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 62258,
+			"name": "hvac_max_defrost"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 62666,
+			"name": "id_card"
+		},
+		{
+			"codepoint": 1048298,
+			"name": "id_card_2"
+		},
+		{
+			"codepoint": 58077,
+			"name": "identity_aware_proxy"
+		},
+		{
+			"codepoint": 60343,
+			"name": "identity_platform"
+		},
+		{
+			"codepoint": 57381,
+			"name": "ifl"
+		},
+		{
+			"codepoint": 63259,
+			"name": "iframe"
+		},
+		{
+			"codepoint": 63260,
+			"name": "iframe_off"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 62231,
+			"name": "image_arrow_up"
+		},
+		{
+			"codepoint": 59046,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 62023,
+			"name": "image_inset"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 61346,
+			"name": "imagesmode"
+		},
+		{
+			"codepoint": 57595,
+			"name": "immunology"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 59605,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 59443,
+			"name": "in_home_mode"
+		},
+		{
+			"codepoint": 57596,
+			"name": "inactive_order"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 63577,
+			"name": "inbox_customize"
+		},
+		{
+			"codepoint": 62361,
+			"name": "inbox_text"
+		},
+		{
+			"codepoint": 62304,
+			"name": "inbox_text_asterisk"
+		},
+		{
+			"codepoint": 62302,
+			"name": "inbox_text_person"
+		},
+		{
+			"codepoint": 62300,
+			"name": "inbox_text_share"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 62829,
+			"name": "indeterminate_question_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 62875,
+			"name": "info_i"
+		},
+		{
+			"codepoint": 63612,
+			"name": "infrared"
+		},
+		{
+			"codepoint": 59088,
+			"name": "ink_eraser"
+		},
+		{
+			"codepoint": 59363,
+			"name": "ink_eraser_off"
+		},
+		{
+			"codepoint": 59089,
+			"name": "ink_highlighter"
+		},
+		{
+			"codepoint": 62756,
+			"name": "ink_highlighter_move"
+		},
+		{
+			"codepoint": 1048340,
+			"name": "ink_highlighter_off"
+		},
+		{
+			"codepoint": 59090,
+			"name": "ink_marker"
+		},
+		{
+			"codepoint": 59091,
+			"name": "ink_pen"
+		},
+		{
+			"codepoint": 61266,
+			"name": "ink_selection"
+		},
+		{
+			"codepoint": 57598,
+			"name": "inpatient"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 63258,
+			"name": "input_circle"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_filled"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 58996,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 59938,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 59512,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 58356,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 63527,
+			"name": "insert_text"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 62157,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 57382,
+			"name": "instant_mix"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 63487,
+			"name": "interactive_space"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 57383,
+			"name": "ios"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 59829,
+			"name": "jamboard_kiosk"
+		},
+		{
+			"codepoint": 62084,
+			"name": "japanese_curry"
+		},
+		{
+			"codepoint": 62083,
+			"name": "japanese_flag"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 1048283,
+			"name": "jewelry"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 62958,
+			"name": "joystick"
+		},
+		{
+			"codepoint": 63257,
+			"name": "jump_to_element"
+		},
+		{
+			"codepoint": 62014,
+			"name": "kanji_alcohol"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep"
+		},
+		{
+			"codepoint": 59129,
+			"name": "keep_off"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep_pin"
+		},
+		{
+			"codepoint": 62831,
+			"name": "keep_public"
+		},
+		{
+			"codepoint": 58041,
+			"name": "kettle"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 62746,
+			"name": "key_vertical"
+		},
+		{
+			"codepoint": 61849,
+			"name": "key_visualizer"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 63454,
+			"name": "keyboard_capslock_badge"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 63453,
+			"name": "keyboard_external_input"
+		},
+		{
+			"codepoint": 63452,
+			"name": "keyboard_full"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 63099,
+			"name": "keyboard_keys"
+		},
+		{
+			"codepoint": 62610,
+			"name": "keyboard_lock"
+		},
+		{
+			"codepoint": 62609,
+			"name": "keyboard_lock_off"
+		},
+		{
+			"codepoint": 63098,
+			"name": "keyboard_off"
+		},
+		{
+			"codepoint": 63451,
+			"name": "keyboard_onscreen"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 63450,
+			"name": "keyboard_previous_language"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 60531,
+			"name": "keyboard_tab_rtl"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 62758,
+			"name": "kid_star"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 57603,
+			"name": "lab_panel"
+		},
+		{
+			"codepoint": 57604,
+			"name": "lab_profile"
+		},
+		{
+			"codepoint": 63499,
+			"name": "lab_research"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 57605,
+			"name": "labs"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58724,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 62660,
+			"name": "landscape_2"
+		},
+		{
+			"codepoint": 62224,
+			"name": "landscape_2_edit"
+		},
+		{
+			"codepoint": 62659,
+			"name": "landscape_2_off"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59911,
+			"name": "language"
+		},
+		{
+			"codepoint": 63334,
+			"name": "language_chinese_array"
+		},
+		{
+			"codepoint": 63333,
+			"name": "language_chinese_cangjie"
+		},
+		{
+			"codepoint": 63332,
+			"name": "language_chinese_dayi"
+		},
+		{
+			"codepoint": 63331,
+			"name": "language_chinese_pinyin"
+		},
+		{
+			"codepoint": 63330,
+			"name": "language_chinese_quick"
+		},
+		{
+			"codepoint": 63329,
+			"name": "language_chinese_wubi"
+		},
+		{
+			"codepoint": 63328,
+			"name": "language_french"
+		},
+		{
+			"codepoint": 63327,
+			"name": "language_gb_english"
+		},
+		{
+			"codepoint": 63326,
+			"name": "language_international"
+		},
+		{
+			"codepoint": 62739,
+			"name": "language_japanese_kana"
+		},
+		{
+			"codepoint": 63325,
+			"name": "language_korean_latin"
+		},
+		{
+			"codepoint": 63324,
+			"name": "language_pinyin"
+		},
+		{
+			"codepoint": 62953,
+			"name": "language_spanish"
+		},
+		{
+			"codepoint": 63321,
+			"name": "language_us"
+		},
+		{
+			"codepoint": 63323,
+			"name": "language_us_colemak"
+		},
+		{
+			"codepoint": 63322,
+			"name": "language_us_dvorak"
+		},
+		{
+			"codepoint": 63161,
+			"name": "laps"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 62413,
+			"name": "laptop_car"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 60163,
+			"name": "lasso_select"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59550,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58024,
+			"name": "laundry"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 57606,
+			"name": "lda"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 63256,
+			"name": "left_click"
+		},
+		{
+			"codepoint": 63255,
+			"name": "left_panel_close"
+		},
+		{
+			"codepoint": 63254,
+			"name": "left_panel_open"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 63320,
+			"name": "letter_switch"
+		},
+		{
+			"codepoint": 57404,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 60164,
+			"name": "license"
+		},
+		{
+			"codepoint": 61347,
+			"name": "lift_to_talk"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 57995,
+			"name": "light_group"
+		},
+		{
+			"codepoint": 1048438,
+			"name": "light_group_2"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 1048320,
+			"name": "light_mode_auto"
+		},
+		{
+			"codepoint": 59832,
+			"name": "light_off"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 62435,
+			"name": "lightbulb_2"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 61348,
+			"name": "lightning_stand"
+		},
+		{
+			"codepoint": 1048437,
+			"name": "lightstrip"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 63319,
+			"name": "line_curve"
+		},
+		{
+			"codepoint": 63526,
+			"name": "line_end"
+		},
+		{
+			"codepoint": 63517,
+			"name": "line_end_arrow"
+		},
+		{
+			"codepoint": 63516,
+			"name": "line_end_arrow_notch"
+		},
+		{
+			"codepoint": 63515,
+			"name": "line_end_circle"
+		},
+		{
+			"codepoint": 63514,
+			"name": "line_end_diamond"
+		},
+		{
+			"codepoint": 63513,
+			"name": "line_end_square"
+		},
+		{
+			"codepoint": 63525,
+			"name": "line_start"
+		},
+		{
+			"codepoint": 63512,
+			"name": "line_start_arrow"
+		},
+		{
+			"codepoint": 63511,
+			"name": "line_start_arrow_notch"
+		},
+		{
+			"codepoint": 63510,
+			"name": "line_start_circle"
+		},
+		{
+			"codepoint": 63509,
+			"name": "line_start_diamond"
+		},
+		{
+			"codepoint": 63508,
+			"name": "line_start_square"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57936,
+			"name": "link"
+		},
+		{
+			"codepoint": 1048501,
+			"name": "link_2"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 62773,
+			"name": "linked_services"
+		},
+		{
+			"codepoint": 61106,
+			"name": "lips"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 58999,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 63318,
+			"name": "list_alt_add"
+		},
+		{
+			"codepoint": 62430,
+			"name": "list_alt_check"
+		},
+		{
+			"codepoint": 1048371,
+			"name": "list_arrow"
+		},
+		{
+			"codepoint": 59833,
+			"name": "lists"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58938,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 60228,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58721,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 59596,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 59610,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 61531,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 61652,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 59565,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 61775,
+			"name": "location_automation"
+		},
+		{
+			"codepoint": 61776,
+			"name": "location_away"
+		},
+		{
+			"codepoint": 63568,
+			"name": "location_chip"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 61778,
+			"name": "location_home"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_pin"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 63681,
+			"name": "locator_tag"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 62305,
+			"name": "lock_open_circle"
+		},
+		{
+			"codepoint": 63062,
+			"name": "lock_open_right"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 59491,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 63387,
+			"name": "low_density"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 62602,
+			"name": "lowercase"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 63449,
+			"name": "lte_mobiledata_badge"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 63448,
+			"name": "lte_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63218,
+			"name": "macro_auto"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 61750,
+			"name": "magic_button"
+		},
+		{
+			"codepoint": 63476,
+			"name": "magic_exchange"
+		},
+		{
+			"codepoint": 63447,
+			"name": "magic_tether"
+		},
+		{
+			"codepoint": 63549,
+			"name": "magnification_large"
+		},
+		{
+			"codepoint": 63548,
+			"name": "magnification_small"
+		},
+		{
+			"codepoint": 63446,
+			"name": "magnify_docked"
+		},
+		{
+			"codepoint": 63445,
+			"name": "magnify_fullscreen"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail"
+		},
+		{
+			"codepoint": 61172,
+			"name": "mail_asterisk"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 62603,
+			"name": "mail_off"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 62025,
+			"name": "mail_shield"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 62947,
+			"name": "manga"
+		},
+		{
+			"codepoint": 59174,
+			"name": "manufacturing"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 62104,
+			"name": "map_pin_heart"
+		},
+		{
+			"codepoint": 62103,
+			"name": "map_pin_review"
+		},
+		{
+			"codepoint": 62410,
+			"name": "map_search"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 62802,
+			"name": "markdown"
+		},
+		{
+			"codepoint": 62803,
+			"name": "markdown_copy"
+		},
+		{
+			"codepoint": 62804,
+			"name": "markdown_paste"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 59182,
+			"name": "masked_transitions"
+		},
+		{
+			"codepoint": 62507,
+			"name": "masked_transitions_add"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 62146,
+			"name": "massage"
+		},
+		{
+			"codepoint": 63217,
+			"name": "match_case"
+		},
+		{
+			"codepoint": 62319,
+			"name": "match_case_off"
+		},
+		{
+			"codepoint": 63216,
+			"name": "match_word"
+		},
+		{
+			"codepoint": 59655,
+			"name": "matter"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 62013,
+			"name": "meal_dinner"
+		},
+		{
+			"codepoint": 62012,
+			"name": "meal_lunch"
+		},
+		{
+			"codepoint": 63151,
+			"name": "measuring_tape"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 63551,
+			"name": "media_link"
+		},
+		{
+			"codepoint": 62706,
+			"name": "media_output"
+		},
+		{
+			"codepoint": 62707,
+			"name": "media_output_off"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 63498,
+			"name": "medical_mask"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 63395,
+			"name": "memory_alt"
+		},
+		{
+			"codepoint": 63201,
+			"name": "menstrual_health"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 62097,
+			"name": "menu_book_2"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57611,
+			"name": "metabolism"
+		},
+		{
+			"codepoint": 62580,
+			"name": "metro"
+		},
+		{
+			"codepoint": 61725,
+			"name": "mfg_nest_yale_lock"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic"
+		},
+		{
+			"codepoint": 62354,
+			"name": "mic_alert"
+		},
+		{
+			"codepoint": 62929,
+			"name": "mic_double"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 61114,
+			"name": "mic_gear"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 57612,
+			"name": "microbiology"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59463,
+			"name": "microwave_gen"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59838,
+			"name": "mimo"
+		},
+		{
+			"codepoint": 59839,
+			"name": "mimo_disconnect"
+		},
+		{
+			"codepoint": 63200,
+			"name": "mindfulness"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61353,
+			"name": "mintmark"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call_filled"
+		},
+		{
+			"codepoint": 59137,
+			"name": "missing_controller"
+		},
+		{
+			"codepoint": 57736,
+			"name": "mist"
+		},
+		{
+			"codepoint": 62791,
+			"name": "mitre"
+		},
+		{
+			"codepoint": 58568,
+			"name": "mixture_med"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 59322,
+			"name": "mobile"
+		},
+		{
+			"codepoint": 62171,
+			"name": "mobile_2"
+		},
+		{
+			"codepoint": 62170,
+			"name": "mobile_3"
+		},
+		{
+			"codepoint": 62163,
+			"name": "mobile_alert"
+		},
+		{
+			"codepoint": 62157,
+			"name": "mobile_arrow_down"
+		},
+		{
+			"codepoint": 62162,
+			"name": "mobile_arrow_right"
+		},
+		{
+			"codepoint": 62137,
+			"name": "mobile_arrow_up_right"
+		},
+		{
+			"codepoint": 62181,
+			"name": "mobile_block"
+		},
+		{
+			"codepoint": 62542,
+			"name": "mobile_camera"
+		},
+		{
+			"codepoint": 62153,
+			"name": "mobile_camera_front"
+		},
+		{
+			"codepoint": 62152,
+			"name": "mobile_camera_rear"
+		},
+		{
+			"codepoint": 62186,
+			"name": "mobile_cancel"
+		},
+		{
+			"codepoint": 62156,
+			"name": "mobile_cast"
+		},
+		{
+			"codepoint": 62179,
+			"name": "mobile_charge"
+		},
+		{
+			"codepoint": 63391,
+			"name": "mobile_chat"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_check"
+		},
+		{
+			"codepoint": 62178,
+			"name": "mobile_code"
+		},
+		{
+			"codepoint": 62176,
+			"name": "mobile_dock"
+		},
+		{
+			"codepoint": 62160,
+			"name": "mobile_dots"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 62169,
+			"name": "mobile_gear"
+		},
+		{
+			"codepoint": 62243,
+			"name": "mobile_hand"
+		},
+		{
+			"codepoint": 62227,
+			"name": "mobile_hand_left"
+		},
+		{
+			"codepoint": 62226,
+			"name": "mobile_hand_left_off"
+		},
+		{
+			"codepoint": 62228,
+			"name": "mobile_hand_off"
+		},
+		{
+			"codepoint": 62172,
+			"name": "mobile_info"
+		},
+		{
+			"codepoint": 60734,
+			"name": "mobile_landscape"
+		},
+		{
+			"codepoint": 62143,
+			"name": "mobile_layout"
+		},
+		{
+			"codepoint": 62168,
+			"name": "mobile_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "mobile_lock_portrait"
+		},
+		{
+			"codepoint": 62242,
+			"name": "mobile_loupe"
+		},
+		{
+			"codepoint": 62161,
+			"name": "mobile_menu"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 62177,
+			"name": "mobile_question"
+		},
+		{
+			"codepoint": 62165,
+			"name": "mobile_rotate"
+		},
+		{
+			"codepoint": 62166,
+			"name": "mobile_rotate_lock"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 62241,
+			"name": "mobile_screensaver"
+		},
+		{
+			"codepoint": 62191,
+			"name": "mobile_sensor_hi"
+		},
+		{
+			"codepoint": 62190,
+			"name": "mobile_sensor_lo"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_share"
+		},
+		{
+			"codepoint": 62174,
+			"name": "mobile_share_stack"
+		},
+		{
+			"codepoint": 62184,
+			"name": "mobile_sound"
+		},
+		{
+			"codepoint": 62232,
+			"name": "mobile_sound_2"
+		},
+		{
+			"codepoint": 63402,
+			"name": "mobile_sound_off"
+		},
+		{
+			"codepoint": 62240,
+			"name": "mobile_speaker"
+		},
+		{
+			"codepoint": 62187,
+			"name": "mobile_text"
+		},
+		{
+			"codepoint": 62182,
+			"name": "mobile_text_2"
+		},
+		{
+			"codepoint": 62121,
+			"name": "mobile_theft"
+		},
+		{
+			"codepoint": 62180,
+			"name": "mobile_ticket"
+		},
+		{
+			"codepoint": 61162,
+			"name": "mobile_unlock"
+		},
+		{
+			"codepoint": 62155,
+			"name": "mobile_vibrate"
+		},
+		{
+			"codepoint": 62128,
+			"name": "mobile_wrench"
+		},
+		{
+			"codepoint": 1048483,
+			"name": "mobiledata_arrows"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 61798,
+			"name": "mode_cool"
+		},
+		{
+			"codepoint": 61799,
+			"name": "mode_cool_off"
+		},
+		{
+			"codepoint": 62807,
+			"name": "mode_dual"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 61800,
+			"name": "mode_fan"
+		},
+		{
+			"codepoint": 1048528,
+			"name": "mode_fan_2"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61802,
+			"name": "mode_heat"
+		},
+		{
+			"codepoint": 61803,
+			"name": "mode_heat_cool"
+		},
+		{
+			"codepoint": 61805,
+			"name": "mode_heat_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61807,
+			"name": "mode_off_on"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 62378,
+			"name": "modeling"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 62446,
+			"name": "money_bag"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 62021,
+			"name": "money_range"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 63199,
+			"name": "monitor_weight_gain"
+		},
+		{
+			"codepoint": 63198,
+			"name": "monitor_weight_loss"
+		},
+		{
+			"codepoint": 61840,
+			"name": "monitoring"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 62579,
+			"name": "monorail"
+		},
+		{
+			"codepoint": 59938,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 1048500,
+			"name": "mood_heart"
+		},
+		{
+			"codepoint": 62287,
+			"name": "moon_stars"
+		},
+		{
+			"codepoint": 57997,
+			"name": "mop"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 62091,
+			"name": "moped_package"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 61846,
+			"name": "more_down"
+		},
+		{
+			"codepoint": 58835,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 61847,
+			"name": "more_up"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61648,
+			"name": "motion_blur"
+		},
+		{
+			"codepoint": 63554,
+			"name": "motion_mode"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 62475,
+			"name": "motion_play"
+		},
+		{
+			"codepoint": 59282,
+			"name": "motion_sensor_active"
+		},
+		{
+			"codepoint": 59268,
+			"name": "motion_sensor_alert"
+		},
+		{
+			"codepoint": 59267,
+			"name": "motion_sensor_idle"
+		},
+		{
+			"codepoint": 59278,
+			"name": "motion_sensor_urgent"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 62946,
+			"name": "mountain_flag"
+		},
+		{
+			"codepoint": 62082,
+			"name": "mountain_steam"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 62608,
+			"name": "mouse_lock"
+		},
+		{
+			"codepoint": 62607,
+			"name": "mouse_lock_off"
+		},
+		{
+			"codepoint": 59200,
+			"name": "move"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 63253,
+			"name": "move_group"
+		},
+		{
+			"codepoint": 61951,
+			"name": "move_item"
+		},
+		{
+			"codepoint": 59201,
+			"name": "move_location"
+		},
+		{
+			"codepoint": 63252,
+			"name": "move_selection_down"
+		},
+		{
+			"codepoint": 63251,
+			"name": "move_selection_left"
+		},
+		{
+			"codepoint": 63250,
+			"name": "move_selection_right"
+		},
+		{
+			"codepoint": 63249,
+			"name": "move_selection_up"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 58772,
+			"name": "moved_location"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 63552,
+			"name": "movie_edit"
+		},
+		{
+			"codepoint": 1048445,
+			"name": "movie_edit_off"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 57389,
+			"name": "movie_info"
+		},
+		{
+			"codepoint": 62617,
+			"name": "movie_off"
+		},
+		{
+			"codepoint": 62115,
+			"name": "movie_speaker"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59197,
+			"name": "moving_beds"
+		},
+		{
+			"codepoint": 59198,
+			"name": "moving_ministry"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 58003,
+			"name": "multicooker"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 62491,
+			"name": "multimodal_hand_eye"
+		},
+		{
+			"codepoint": 61355,
+			"name": "multiple_airports"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 60186,
+			"name": "music_cast"
+		},
+		{
+			"codepoint": 62145,
+			"name": "music_history"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 1048536,
+			"name": "music_note_2"
+		},
+		{
+			"codepoint": 62353,
+			"name": "music_note_add"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 62945,
+			"name": "mystery"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58827,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58828,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 59063,
+			"name": "nearby"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 57613,
+			"name": "nephrology"
+		},
+		{
+			"codepoint": 60351,
+			"name": "nest_audio"
+		},
+		{
+			"codepoint": 63671,
+			"name": "nest_cam_floodlight"
+		},
+		{
+			"codepoint": 61726,
+			"name": "nest_cam_indoor"
+		},
+		{
+			"codepoint": 61727,
+			"name": "nest_cam_iq"
+		},
+		{
+			"codepoint": 61728,
+			"name": "nest_cam_iq_outdoor"
+		},
+		{
+			"codepoint": 63672,
+			"name": "nest_cam_magnet_mount"
+		},
+		{
+			"codepoint": 61729,
+			"name": "nest_cam_outdoor"
+		},
+		{
+			"codepoint": 63673,
+			"name": "nest_cam_stand"
+		},
+		{
+			"codepoint": 63674,
+			"name": "nest_cam_wall_mount"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 63675,
+			"name": "nest_clock_farsight_analog"
+		},
+		{
+			"codepoint": 63676,
+			"name": "nest_clock_farsight_digital"
+		},
+		{
+			"codepoint": 61730,
+			"name": "nest_connect"
+		},
+		{
+			"codepoint": 61731,
+			"name": "nest_detect"
+		},
+		{
+			"codepoint": 61732,
+			"name": "nest_display"
+		},
+		{
+			"codepoint": 61733,
+			"name": "nest_display_max"
+		},
+		{
+			"codepoint": 63677,
+			"name": "nest_doorbell_visitor"
+		},
+		{
+			"codepoint": 63678,
+			"name": "nest_eco_leaf"
+		},
+		{
+			"codepoint": 62077,
+			"name": "nest_farsight_cool"
+		},
+		{
+			"codepoint": 62076,
+			"name": "nest_farsight_dual"
+		},
+		{
+			"codepoint": 62075,
+			"name": "nest_farsight_eco"
+		},
+		{
+			"codepoint": 62074,
+			"name": "nest_farsight_heat"
+		},
+		{
+			"codepoint": 62073,
+			"name": "nest_farsight_seasonal"
+		},
+		{
+			"codepoint": 63679,
+			"name": "nest_farsight_weather"
+		},
+		{
+			"codepoint": 63680,
+			"name": "nest_found_savings"
+		},
+		{
+			"codepoint": 62841,
+			"name": "nest_gale_wifi"
+		},
+		{
+			"codepoint": 61734,
+			"name": "nest_heat_link_e"
+		},
+		{
+			"codepoint": 61735,
+			"name": "nest_heat_link_gen_3"
+		},
+		{
+			"codepoint": 59436,
+			"name": "nest_hello_doorbell"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_locator_tag"
+		},
+		{
+			"codepoint": 59273,
+			"name": "nest_mini"
+		},
+		{
+			"codepoint": 63682,
+			"name": "nest_multi_room"
+		},
+		{
+			"codepoint": 59022,
+			"name": "nest_protect"
+		},
+		{
+			"codepoint": 62939,
+			"name": "nest_remote"
+		},
+		{
+			"codepoint": 61738,
+			"name": "nest_remote_comfort_sensor"
+		},
+		{
+			"codepoint": 61739,
+			"name": "nest_secure_alarm"
+		},
+		{
+			"codepoint": 63683,
+			"name": "nest_sunblock"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_tag"
+		},
+		{
+			"codepoint": 59023,
+			"name": "nest_thermostat"
+		},
+		{
+			"codepoint": 61741,
+			"name": "nest_thermostat_e_eu"
+		},
+		{
+			"codepoint": 61742,
+			"name": "nest_thermostat_gen_3"
+		},
+		{
+			"codepoint": 61743,
+			"name": "nest_thermostat_sensor"
+		},
+		{
+			"codepoint": 61744,
+			"name": "nest_thermostat_sensor_eu"
+		},
+		{
+			"codepoint": 61745,
+			"name": "nest_thermostat_zirconium_eu"
+		},
+		{
+			"codepoint": 63684,
+			"name": "nest_true_radiant"
+		},
+		{
+			"codepoint": 63685,
+			"name": "nest_wake_on_approach"
+		},
+		{
+			"codepoint": 63686,
+			"name": "nest_wake_on_press"
+		},
+		{
+			"codepoint": 61746,
+			"name": "nest_wifi_gale"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_mistral"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point_vento"
+		},
+		{
+			"codepoint": 62827,
+			"name": "nest_wifi_pro"
+		},
+		{
+			"codepoint": 62826,
+			"name": "nest_wifi_pro_2"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_router"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 62321,
+			"name": "network_intel_node"
+		},
+		{
+			"codepoint": 61356,
+			"name": "network_intelligence"
+		},
+		{
+			"codepoint": 62966,
+			"name": "network_intelligence_history"
+		},
+		{
+			"codepoint": 62965,
+			"name": "network_intelligence_update"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 63403,
+			"name": "network_manage"
+		},
+		{
+			"codepoint": 62830,
+			"name": "network_node"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 62863,
+			"name": "network_wifi_1_bar_locked"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 62862,
+			"name": "network_wifi_2_bar_locked"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 62861,
+			"name": "network_wifi_3_bar_locked"
+		},
+		{
+			"codepoint": 62770,
+			"name": "network_wifi_locked"
+		},
+		{
+			"codepoint": 57614,
+			"name": "neurology"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 61302,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 63248,
+			"name": "new_window"
+		},
+		{
+			"codepoint": 57394,
+			"name": "news"
+		},
+		{
+			"codepoint": 61357,
+			"name": "newsmode"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 59844,
+			"name": "newsstand"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 62313,
+			"name": "nfc_off"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 61911,
+			"name": "night_sight_auto"
+		},
+		{
+			"codepoint": 61945,
+			"name": "night_sight_auto_off"
+		},
+		{
+			"codepoint": 63171,
+			"name": "night_sight_max"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 61812,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57806,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 59152,
+			"name": "no_sound"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 63656,
+			"name": "noise_control_on"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 62794,
+			"name": "not_accessible_forward"
+		},
+		{
+			"codepoint": 61580,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 58996,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 62818,
+			"name": "note_stack"
+		},
+		{
+			"codepoint": 62819,
+			"name": "note_stack_add"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 61121,
+			"name": "notification_audio"
+		},
+		{
+			"codepoint": 61120,
+			"name": "notification_audio_off"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59074,
+			"name": "notification_multiple"
+		},
+		{
+			"codepoint": 62311,
+			"name": "notification_settings"
+		},
+		{
+			"codepoint": 62291,
+			"name": "notification_sound"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 62718,
+			"name": "notifications_unread"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 57616,
+			"name": "nutrition"
+		},
+		{
+			"codepoint": 59112,
+			"name": "ods"
+		},
+		{
+			"codepoint": 59113,
+			"name": "odt"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 62672,
+			"name": "offline_pin_off"
+		},
+		{
+			"codepoint": 62174,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 62081,
+			"name": "okonomiyaki"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 59075,
+			"name": "on_hub_device"
+		},
+		{
+			"codepoint": 57620,
+			"name": "oncology"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 63224,
+			"name": "onsen"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 63247,
+			"name": "open_in_new_down"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 62162,
+			"name": "open_in_phone"
+		},
+		{
+			"codepoint": 61358,
+			"name": "open_jam"
+		},
+		{
+			"codepoint": 62647,
+			"name": "open_run"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 57621,
+			"name": "ophthalmology"
+		},
+		{
+			"codepoint": 57622,
+			"name": "oral_disease"
+		},
+		{
+			"codepoint": 62502,
+			"name": "orbit"
+		},
+		{
+			"codepoint": 63506,
+			"name": "order_approve"
+		},
+		{
+			"codepoint": 63505,
+			"name": "order_play"
+		},
+		{
+			"codepoint": 60180,
+			"name": "orders"
+		},
+		{
+			"codepoint": 63639,
+			"name": "orthopedics"
+		},
+		{
+			"codepoint": 58491,
+			"name": "other_admission"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 60183,
+			"name": "outbox_alt"
+		},
+		{
+			"codepoint": 57861,
+			"name": "outdoor_garden"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61650,
+			"name": "outgoing_mail"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 61638,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 57624,
+			"name": "outpatient"
+		},
+		{
+			"codepoint": 57625,
+			"name": "outpatient_med"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 63246,
+			"name": "output_circle"
+		},
+		{
+			"codepoint": 59847,
+			"name": "oven"
+		},
+		{
+			"codepoint": 59459,
+			"name": "oven_gen"
+		},
+		{
+			"codepoint": 58535,
+			"name": "overview"
+		},
+		{
+			"codepoint": 63444,
+			"name": "overview_key"
+		},
+		{
+			"codepoint": 62388,
+			"name": "owl"
+		},
+		{
+			"codepoint": 58590,
+			"name": "oxygen_saturation"
+		},
+		{
+			"codepoint": 62762,
+			"name": "p2p"
+		},
+		{
+			"codepoint": 63160,
+			"name": "pace"
+		},
+		{
+			"codepoint": 58966,
+			"name": "pacemaker"
+		},
+		{
+			"codepoint": 58511,
+			"name": "package"
+		},
+		{
+			"codepoint": 62825,
+			"name": "package_2"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 62119,
+			"name": "padel"
+		},
+		{
+			"codepoint": 59185,
+			"name": "page_control"
+		},
+		{
+			"codepoint": 62339,
+			"name": "page_footer"
+		},
+		{
+			"codepoint": 62340,
+			"name": "page_header"
+		},
+		{
+			"codepoint": 62996,
+			"name": "page_info"
+		},
+		{
+			"codepoint": 61179,
+			"name": "page_menu_ios"
+		},
+		{
+			"codepoint": 62729,
+			"name": "pageless"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 63594,
+			"name": "pallet"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 63061,
+			"name": "pan_zoom"
+		},
+		{
+			"codepoint": 59025,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 61997,
+			"name": "parent_child_dining"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 62090,
+			"name": "parking_meter"
+		},
+		{
+			"codepoint": 62089,
+			"name": "parking_sign"
+		},
+		{
+			"codepoint": 62088,
+			"name": "parking_valet"
+		},
+		{
+			"codepoint": 61810,
+			"name": "partly_cloudy_day"
+		},
+		{
+			"codepoint": 61812,
+			"name": "partly_cloudy_night"
+		},
+		{
+			"codepoint": 63481,
+			"name": "partner_exchange"
+		},
+		{
+			"codepoint": 61230,
+			"name": "partner_heart"
+		},
+		{
+			"codepoint": 61359,
+			"name": "partner_reports"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 63615,
+			"name": "passkey"
+		},
+		{
+			"codepoint": 61124,
+			"name": "passport"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 62633,
+			"name": "password_2"
+		},
+		{
+			"codepoint": 62632,
+			"name": "password_2_off"
+		},
+		{
+			"codepoint": 58963,
+			"name": "patient_list"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 62144,
+			"name": "payment_arrow_down"
+		},
+		{
+			"codepoint": 62113,
+			"name": "payment_card"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 57629,
+			"name": "pediatrics"
+		},
+		{
+			"codepoint": 63317,
+			"name": "pen_size_1"
+		},
+		{
+			"codepoint": 63316,
+			"name": "pen_size_2"
+		},
+		{
+			"codepoint": 63315,
+			"name": "pen_size_3"
+		},
+		{
+			"codepoint": 63314,
+			"name": "pen_size_4"
+		},
+		{
+			"codepoint": 63313,
+			"name": "pen_size_5"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 62020,
+			"name": "percent_discount"
+		},
+		{
+			"codepoint": 58650,
+			"name": "performance_max"
+		},
+		{
+			"codepoint": 57859,
+			"name": "pergola"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 62172,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 61651,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 62823,
+			"name": "person_alert"
+		},
+		{
+			"codepoint": 62883,
+			"name": "person_apron"
+		},
+		{
+			"codepoint": 62952,
+			"name": "person_book"
+		},
+		{
+			"codepoint": 62822,
+			"name": "person_cancel"
+		},
+		{
+			"codepoint": 63486,
+			"name": "person_celebrate"
+		},
+		{
+			"codepoint": 62821,
+			"name": "person_check"
+		},
+		{
+			"codepoint": 62714,
+			"name": "person_edit"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_filled"
+		},
+		{
+			"codepoint": 62096,
+			"name": "person_heart"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 63485,
+			"name": "person_play"
+		},
+		{
+			"codepoint": 62874,
+			"name": "person_raised_hand"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 58244,
+			"name": "person_shield"
+		},
+		{
+			"codepoint": 61117,
+			"name": "person_text"
+		},
+		{
+			"codepoint": 60174,
+			"name": "personal_bag"
+		},
+		{
+			"codepoint": 60175,
+			"name": "personal_bag_off"
+		},
+		{
+			"codepoint": 60176,
+			"name": "personal_bag_question"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 59139,
+			"name": "personal_places"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 61361,
+			"name": "pet_supplies"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone_alt"
+		},
+		{
+			"codepoint": 62171,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 1048477,
+			"name": "phone_cancel"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 62170,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 62186,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 62142,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 63397,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 62184,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 63402,
+			"name": "phonelink_ring_off"
+		},
+		{
+			"codepoint": 62169,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 62768,
+			"name": "photo_auto_merge"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 61657,
+			"name": "photo_frame"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 61362,
+			"name": "photo_prints"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 57630,
+			"name": "physical_therapy"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 62118,
+			"name": "pickleball"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 62800,
+			"name": "picture_in_picture_center"
+		},
+		{
+			"codepoint": 62799,
+			"name": "picture_in_picture_large"
+		},
+		{
+			"codepoint": 62798,
+			"name": "picture_in_picture_medium"
+		},
+		{
+			"codepoint": 62743,
+			"name": "picture_in_picture_mobile"
+		},
+		{
+			"codepoint": 62767,
+			"name": "picture_in_picture_off"
+		},
+		{
+			"codepoint": 62797,
+			"name": "picture_in_picture_small"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_filled"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outlined"
+		},
+		{
+			"codepoint": 57631,
+			"name": "pill"
+		},
+		{
+			"codepoint": 63497,
+			"name": "pill_off"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 1048366,
+			"name": "pin_history"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 1048365,
+			"name": "pin_road"
+		},
+		{
+			"codepoint": 1048299,
+			"name": "pin_road_2"
+		},
+		{
+			"codepoint": 62379,
+			"name": "pinboard"
+		},
+		{
+			"codepoint": 62380,
+			"name": "pinboard_unread"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 61946,
+			"name": "pinch_zoom_in"
+		},
+		{
+			"codepoint": 61947,
+			"name": "pinch_zoom_out"
+		},
+		{
+			"codepoint": 63053,
+			"name": "pip"
+		},
+		{
+			"codepoint": 63245,
+			"name": "pip_exit"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 61915,
+			"name": "place"
+		},
+		{
+			"codepoint": 61936,
+			"name": "place_item"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 62124,
+			"name": "plane_contrails"
+		},
+		{
+			"codepoint": 62343,
+			"name": "planet"
+		},
+		{
+			"codepoint": 59026,
+			"name": "planner_banner_ad_pt"
+		},
+		{
+			"codepoint": 59028,
+			"name": "planner_review"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 59118,
+			"name": "play_music"
+		},
+		{
+			"codepoint": 61751,
+			"name": "play_pause"
+		},
+		{
+			"codepoint": 63484,
+			"name": "play_shapes"
+		},
+		{
+			"codepoint": 62094,
+			"name": "playground"
+		},
+		{
+			"codepoint": 62095,
+			"name": "playground_2"
+		},
+		{
+			"codepoint": 62940,
+			"name": "playing_cards"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 62298,
+			"name": "plug_connect"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 57632,
+			"name": "podiatry"
+		},
+		{
+			"codepoint": 63483,
+			"name": "podium"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 63244,
+			"name": "point_scan"
+		},
+		{
+			"codepoint": 62619,
+			"name": "poker_chip"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 62471,
+			"name": "policy_alert"
+		},
+		{
+			"codepoint": 61644,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 61575,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 59473,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 63243,
+			"name": "position_bottom_left"
+		},
+		{
+			"codepoint": 63242,
+			"name": "position_bottom_right"
+		},
+		{
+			"codepoint": 63241,
+			"name": "position_top_right"
+		},
+		{
+			"codepoint": 59141,
+			"name": "post"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 63658,
+			"name": "potted_plant"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_rounded"
+		},
+		{
+			"codepoint": 62488,
+			"name": "power_settings_circle"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 63544,
+			"name": "prayer_times"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnancy"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 59352,
+			"name": "preliminary"
+		},
+		{
+			"codepoint": 57633,
+			"name": "prescriptions"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 63407,
+			"name": "preview_off"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 63394,
+			"name": "print_add"
+		},
+		{
+			"codepoint": 63393,
+			"name": "print_connect"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 63392,
+			"name": "print_error"
+		},
+		{
+			"codepoint": 63057,
+			"name": "print_lock"
+		},
+		{
+			"codepoint": 61364,
+			"name": "priority"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61768,
+			"name": "privacy"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57634,
+			"name": "problem"
+		},
+		{
+			"codepoint": 58961,
+			"name": "procedure"
+		},
+		{
+			"codepoint": 63573,
+			"name": "process_chart"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 58006,
+			"name": "productivity"
+		},
+		{
+			"codepoint": 59856,
+			"name": "progress_activity"
+		},
+		{
+			"codepoint": 62710,
+			"name": "prompt_suggestion"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 57635,
+			"name": "psychiatry"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 57636,
+			"name": "pulmonology"
+		},
+		{
+			"codepoint": 62721,
+			"name": "pulse_alert"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 63064,
+			"name": "qr_code_2_add"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 61398,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 63475,
+			"name": "question_exchange"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 59345,
+			"name": "quick_phrases"
+		},
+		{
+			"codepoint": 58478,
+			"name": "quick_reference"
+		},
+		{
+			"codepoint": 63489,
+			"name": "quick_reference_all"
+		},
+		{
+			"codepoint": 60181,
+			"name": "quick_reorder"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61785,
+			"name": "quiet_time"
+		},
+		{
+			"codepoint": 60278,
+			"name": "quiet_time_active"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 62816,
+			"name": "radio_button_partial"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 57637,
+			"name": "radiology"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 62561,
+			"name": "railway_alert_2"
+		},
+		{
+			"codepoint": 61814,
+			"name": "rainy"
+		},
+		{
+			"codepoint": 63007,
+			"name": "rainy_heavy"
+		},
+		{
+			"codepoint": 63006,
+			"name": "rainy_light"
+		},
+		{
+			"codepoint": 63005,
+			"name": "rainy_snow"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 57834,
+			"name": "range_hood"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 59142,
+			"name": "rate_review_rtl"
+		},
+		{
+			"codepoint": 62805,
+			"name": "raven"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 63197,
+			"name": "readiness_score"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 63170,
+			"name": "rear_camera"
+		},
+		{
+			"codepoint": 63557,
+			"name": "rebase"
+		},
+		{
+			"codepoint": 63558,
+			"name": "rebase_edit"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 62474,
+			"name": "receipt_long_off"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 63496,
+			"name": "recent_patient"
+		},
+		{
+			"codepoint": 62656,
+			"name": "recenter"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 61128,
+			"name": "rectangle_add"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 59638,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 63312,
+			"name": "regular_expression"
+		},
+		{
+			"codepoint": 63196,
+			"name": "relax"
+		},
+		{
+			"codepoint": 63060,
+			"name": "release_alert"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminder"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminders_alt"
+		},
+		{
+			"codepoint": 59454,
+			"name": "remote_gen"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 59636,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59861,
+			"name": "remove_selection"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 63240,
+			"name": "reopen_window"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 62545,
+			"name": "replace_audio"
+		},
+		{
+			"codepoint": 62544,
+			"name": "replace_image"
+		},
+		{
+			"codepoint": 62543,
+			"name": "replace_video"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 61571,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 62594,
+			"name": "reset_brightness"
+		},
+		{
+			"codepoint": 1048290,
+			"name": "reset_colors"
+		},
+		{
+			"codepoint": 62054,
+			"name": "reset_exposure"
+		},
+		{
+			"codepoint": 62593,
+			"name": "reset_focus"
+		},
+		{
+			"codepoint": 63524,
+			"name": "reset_image"
+		},
+		{
+			"codepoint": 62592,
+			"name": "reset_iso"
+		},
+		{
+			"codepoint": 62591,
+			"name": "reset_settings"
+		},
+		{
+			"codepoint": 62590,
+			"name": "reset_shadow"
+		},
+		{
+			"codepoint": 62589,
+			"name": "reset_shutter_speed"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 62588,
+			"name": "reset_white_balance"
+		},
+		{
+			"codepoint": 62828,
+			"name": "reset_wrench"
+		},
+		{
+			"codepoint": 63239,
+			"name": "resize"
+		},
+		{
+			"codepoint": 1048473,
+			"name": "resize_window"
+		},
+		{
+			"codepoint": 57639,
+			"name": "respiratory_rate"
+		},
+		{
+			"codepoint": 59866,
+			"name": "responsive_layout"
+		},
+		{
+			"codepoint": 61994,
+			"name": "rest_area"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 63440,
+			"name": "resume"
+		},
+		{
+			"codepoint": 61564,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61366,
+			"name": "rewarded_ads"
+		},
+		{
+			"codepoint": 57640,
+			"name": "rheumatology"
+		},
+		{
+			"codepoint": 63640,
+			"name": "rib_cage"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 63238,
+			"name": "right_click"
+		},
+		{
+			"codepoint": 63237,
+			"name": "right_panel_close"
+		},
+		{
+			"codepoint": 63236,
+			"name": "right_panel_open"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume_filled"
+		},
+		{
+			"codepoint": 59867,
+			"name": "ripples"
+		},
+		{
+			"codepoint": 62578,
+			"name": "road"
+		},
+		{
+			"codepoint": 63618,
+			"name": "robot"
+		},
+		{
+			"codepoint": 62928,
+			"name": "robot_2"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 61915,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 62487,
+			"name": "rotate_auto"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 62196,
+			"name": "router_off"
+		},
+		{
+			"codepoint": 57868,
+			"name": "routine"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 60199,
+			"name": "rubric"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 63052,
+			"name": "rule_settings"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 62877,
+			"name": "safety_check_off"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 63606,
+			"name": "salinity"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 63223,
+			"name": "sauna"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 61584,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 62360,
+			"name": "save_clock"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 63310,
+			"name": "scan"
+		},
+		{
+			"codepoint": 63311,
+			"name": "scan_delete"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 58023,
+			"name": "scene"
+		},
+		{
+			"codepoint": 61398,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 62786,
+			"name": "science_off"
+		},
+		{
+			"codepoint": 62577,
+			"name": "scooter"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 62168,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 62166,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 63097,
+			"name": "screen_record"
+		},
+		{
+			"codepoint": 62165,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 63096,
+			"name": "screen_rotation_up"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 63095,
+			"name": "screenshot_frame"
+		},
+		{
+			"codepoint": 62324,
+			"name": "screenshot_frame_2"
+		},
+		{
+			"codepoint": 63443,
+			"name": "screenshot_keyboard"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 63442,
+			"name": "screenshot_region"
+		},
+		{
+			"codepoint": 63127,
+			"name": "screenshot_tablet"
+		},
+		{
+			"codepoint": 62559,
+			"name": "script"
+		},
+		{
+			"codepoint": 59868,
+			"name": "scrollable_header"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59168,
+			"name": "sdk"
+		},
+		{
+			"codepoint": 61306,
+			"name": "search"
+		},
+		{
+			"codepoint": 62437,
+			"name": "search_activity"
+		},
+		{
+			"codepoint": 63488,
+			"name": "search_check"
+		},
+		{
+			"codepoint": 62569,
+			"name": "search_check_2"
+		},
+		{
+			"codepoint": 61178,
+			"name": "search_gear"
+		},
+		{
+			"codepoint": 59030,
+			"name": "search_hands_free"
+		},
+		{
+			"codepoint": 62652,
+			"name": "search_insights"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 62257,
+			"name": "seat_cool_left"
+		},
+		{
+			"codepoint": 62256,
+			"name": "seat_cool_right"
+		},
+		{
+			"codepoint": 62255,
+			"name": "seat_heat_left"
+		},
+		{
+			"codepoint": 62254,
+			"name": "seat_heat_right"
+		},
+		{
+			"codepoint": 1048282,
+			"name": "seat_read"
+		},
+		{
+			"codepoint": 62253,
+			"name": "seat_vent_left"
+		},
+		{
+			"codepoint": 62252,
+			"name": "seat_vent_right"
+		},
+		{
+			"codepoint": 1048289,
+			"name": "seat_window"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 62723,
+			"name": "security_key"
+		},
+		{
+			"codepoint": 62157,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 63309,
+			"name": "select"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 61950,
+			"name": "select_check_box"
+		},
+		{
+			"codepoint": 63439,
+			"name": "select_to_speak"
+		},
+		{
+			"codepoint": 59130,
+			"name": "select_window"
+		},
+		{
+			"codepoint": 62664,
+			"name": "select_window_2"
+		},
+		{
+			"codepoint": 58630,
+			"name": "select_window_off"
+		},
+		{
+			"codepoint": 63597,
+			"name": "self_care"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 1048443,
+			"name": "sell_cloud"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 59575,
+			"name": "send_money"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 62162,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 62806,
+			"name": "sensors_krx"
+		},
+		{
+			"codepoint": 62741,
+			"name": "sensors_krx_off"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 63143,
+			"name": "sentiment_calm"
+		},
+		{
+			"codepoint": 63142,
+			"name": "sentiment_content"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 63141,
+			"name": "sentiment_excited"
+		},
+		{
+			"codepoint": 61844,
+			"name": "sentiment_extremely_dissatisfied"
+		},
+		{
+			"codepoint": 63140,
+			"name": "sentiment_frustrated"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 63139,
+			"name": "sentiment_sad"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 63138,
+			"name": "sentiment_stressed"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 63137,
+			"name": "sentiment_worried"
+		},
+		{
+			"codepoint": 62636,
+			"name": "serif"
+		},
+		{
+			"codepoint": 62397,
+			"name": "server_person"
+		},
+		{
+			"codepoint": 59159,
+			"name": "service_toolbox"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 63541,
+			"name": "settings_account_box"
+		},
+		{
+			"codepoint": 61763,
+			"name": "settings_alert"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 63013,
+			"name": "settings_b_roll"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 62161,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 63012,
+			"name": "settings_cinematic_blur"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 62754,
+			"name": "settings_heart"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 63539,
+			"name": "settings_motion_mode"
+		},
+		{
+			"codepoint": 63538,
+			"name": "settings_night_sight"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 63537,
+			"name": "settings_panorama"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 63540,
+			"name": "settings_photo_camera"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 1048287,
+			"name": "settings_screen"
+		},
+		{
+			"codepoint": 61229,
+			"name": "settings_seating"
+		},
+		{
+			"codepoint": 63011,
+			"name": "settings_slow_motion"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 63010,
+			"name": "settings_timelapse"
+		},
+		{
+			"codepoint": 63009,
+			"name": "settings_video_camera"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 58028,
+			"name": "settop_component"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 1048435,
+			"name": "shades"
+		},
+		{
+			"codepoint": 1048436,
+			"name": "shades_closed"
+		},
+		{
+			"codepoint": 59871,
+			"name": "shadow"
+		},
+		{
+			"codepoint": 62852,
+			"name": "shadow_add"
+		},
+		{
+			"codepoint": 62851,
+			"name": "shadow_minus"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 60161,
+			"name": "shape_recognition"
+		},
+		{
+			"codepoint": 58882,
+			"name": "shapes"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58871,
+			"name": "share_eta"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 63179,
+			"name": "share_off"
+		},
+		{
+			"codepoint": 63652,
+			"name": "share_reviews"
+		},
+		{
+			"codepoint": 62995,
+			"name": "share_windows"
+		},
+		{
+			"codepoint": 61989,
+			"name": "shaved_ice"
+		},
+		{
+			"codepoint": 63523,
+			"name": "sheets_rtl"
+		},
+		{
+			"codepoint": 63235,
+			"name": "shelf_auto_hide"
+		},
+		{
+			"codepoint": 63234,
+			"name": "shelf_position"
+		},
+		{
+			"codepoint": 63598,
+			"name": "shelves"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 1048368,
+			"name": "shield_card"
+		},
+		{
+			"codepoint": 63110,
+			"name": "shield_lock"
+		},
+		{
+			"codepoint": 62866,
+			"name": "shield_locked"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 63056,
+			"name": "shield_person"
+		},
+		{
+			"codepoint": 62761,
+			"name": "shield_question"
+		},
+		{
+			"codepoint": 1048367,
+			"name": "shield_radar"
+		},
+		{
+			"codepoint": 62125,
+			"name": "shield_toggle"
+		},
+		{
+			"codepoint": 62223,
+			"name": "shield_watch"
+		},
+		{
+			"codepoint": 59279,
+			"name": "shield_with_heart"
+		},
+		{
+			"codepoint": 59277,
+			"name": "shield_with_house"
+		},
+		{
+			"codepoint": 58866,
+			"name": "shift"
+		},
+		{
+			"codepoint": 63406,
+			"name": "shift_lock"
+		},
+		{
+			"codepoint": 62595,
+			"name": "shift_lock_off"
+		},
+		{
+			"codepoint": 1048499,
+			"name": "shoe_cleats"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 62362,
+			"name": "shopping_bag_speed"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 62711,
+			"name": "shopping_cart_off"
+		},
+		{
+			"codepoint": 61367,
+			"name": "shoppingmode"
+		},
+		{
+			"codepoint": 58576,
+			"name": "short_stay"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 62842,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 62846,
+			"name": "shutter_speed_add"
+		},
+		{
+			"codepoint": 62845,
+			"name": "shutter_speed_minus"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 59874,
+			"name": "side_navigation"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 62040,
+			"name": "sign_language_2"
+		},
+		{
+			"codepoint": 1048292,
+			"name": "sign_language_off"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 61609,
+			"name": "signal_cellular_1_bar"
+		},
+		{
+			"codepoint": 61610,
+			"name": "signal_cellular_2_bar"
+		},
+		{
+			"codepoint": 61611,
+			"name": "signal_cellular_3_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 63401,
+			"name": "signal_cellular_add"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 1048458,
+			"name": "signal_cellular_alt_off"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 62887,
+			"name": "signal_cellular_pause"
+		},
+		{
+			"codepoint": 62009,
+			"name": "signal_disconnected"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57825,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61679,
+			"name": "signal_wifi_statusbar_not_connected"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 63308,
+			"name": "signature"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 62433,
+			"name": "simulation"
+		},
+		{
+			"codepoint": 1048281,
+			"name": "single_arrow"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 62375,
+			"name": "siren"
+		},
+		{
+			"codepoint": 62374,
+			"name": "siren_check"
+		},
+		{
+			"codepoint": 62373,
+			"name": "siren_open"
+		},
+		{
+			"codepoint": 62372,
+			"name": "siren_question"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 63641,
+			"name": "skeleton"
+		},
+		{
+			"codepoint": 62787,
+			"name": "skillet"
+		},
+		{
+			"codepoint": 62788,
+			"name": "skillet_cooktop"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 63642,
+			"name": "skull"
+		},
+		{
+			"codepoint": 62320,
+			"name": "skull_list"
+		},
+		{
+			"codepoint": 62635,
+			"name": "slab_serif"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 57875,
+			"name": "sleep"
+		},
+		{
+			"codepoint": 63159,
+			"name": "sleep_score"
+		},
+		{
+			"codepoint": 63522,
+			"name": "slide_library"
+		},
+		{
+			"codepoint": 59875,
+			"name": "sliders"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 62629,
+			"name": "smart_card_reader"
+		},
+		{
+			"codepoint": 62630,
+			"name": "smart_card_reader_off"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 59460,
+			"name": "smart_outlet"
+		},
+		{
+			"codepoint": 62160,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 59322,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 62542,
+			"name": "smartphone_camera"
+		},
+		{
+			"codepoint": 63307,
+			"name": "smb_share"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 59519,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 1048286,
+			"name": "snail"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 60763,
+			"name": "snowflake"
+		},
+		{
+			"codepoint": 59407,
+			"name": "snowing"
+		},
+		{
+			"codepoint": 63004,
+			"name": "snowing_heavy"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 61238,
+			"name": "soba"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 63136,
+			"name": "social_leaderboard"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 61237,
+			"name": "solo_dining"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 61769,
+			"name": "sound_detection_dog_barking"
+		},
+		{
+			"codepoint": 61770,
+			"name": "sound_detection_glass_break"
+		},
+		{
+			"codepoint": 61771,
+			"name": "sound_detection_loud_sound"
+		},
+		{
+			"codepoint": 63156,
+			"name": "sound_sampler"
+		},
+		{
+			"codepoint": 1048434,
+			"name": "soundbar"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61896,
+			"name": "source"
+		},
+		{
+			"codepoint": 58663,
+			"name": "source_environment"
+		},
+		{
+			"codepoint": 57645,
+			"name": "source_notes"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 1048460,
+			"name": "space_dashboard_2"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 62671,
+			"name": "spatial_speaker"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 1048433,
+			"name": "speaker_2"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 63306,
+			"name": "special_character"
+		},
+		{
+			"codepoint": 63602,
+			"name": "specific_gravity"
+		},
+		{
+			"codepoint": 63655,
+			"name": "speech_to_text"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 62676,
+			"name": "speed_0_25"
+		},
+		{
+			"codepoint": 62616,
+			"name": "speed_0_2x"
+		},
+		{
+			"codepoint": 62690,
+			"name": "speed_0_5"
+		},
+		{
+			"codepoint": 62615,
+			"name": "speed_0_5x"
+		},
+		{
+			"codepoint": 62675,
+			"name": "speed_0_75"
+		},
+		{
+			"codepoint": 62614,
+			"name": "speed_0_7x"
+		},
+		{
+			"codepoint": 62689,
+			"name": "speed_1_2"
+		},
+		{
+			"codepoint": 62674,
+			"name": "speed_1_25"
+		},
+		{
+			"codepoint": 62613,
+			"name": "speed_1_2x"
+		},
+		{
+			"codepoint": 62688,
+			"name": "speed_1_5"
+		},
+		{
+			"codepoint": 62612,
+			"name": "speed_1_5x"
+		},
+		{
+			"codepoint": 62673,
+			"name": "speed_1_75"
+		},
+		{
+			"codepoint": 62611,
+			"name": "speed_1_7x"
+		},
+		{
+			"codepoint": 1048376,
+			"name": "speed_2"
+		},
+		{
+			"codepoint": 62699,
+			"name": "speed_2x"
+		},
+		{
+			"codepoint": 1048375,
+			"name": "speed_3"
+		},
+		{
+			"codepoint": 1048374,
+			"name": "speed_4"
+		},
+		{
+			"codepoint": 62576,
+			"name": "speed_camera"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 62399,
+			"name": "split_scene"
+		},
+		{
+			"codepoint": 1048311,
+			"name": "split_scene_2"
+		},
+		{
+			"codepoint": 62207,
+			"name": "split_scene_down"
+		},
+		{
+			"codepoint": 62206,
+			"name": "split_scene_left"
+		},
+		{
+			"codepoint": 62205,
+			"name": "split_scene_right"
+		},
+		{
+			"codepoint": 62204,
+			"name": "split_scene_up"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 62717,
+			"name": "splitscreen_add"
+		},
+		{
+			"codepoint": 63094,
+			"name": "splitscreen_bottom"
+		},
+		{
+			"codepoint": 62553,
+			"name": "splitscreen_landscape"
+		},
+		{
+			"codepoint": 1048506,
+			"name": "splitscreen_landscape_add"
+		},
+		{
+			"codepoint": 63093,
+			"name": "splitscreen_left"
+		},
+		{
+			"codepoint": 62552,
+			"name": "splitscreen_portrait"
+		},
+		{
+			"codepoint": 63092,
+			"name": "splitscreen_right"
+		},
+		{
+			"codepoint": 63091,
+			"name": "splitscreen_top"
+		},
+		{
+			"codepoint": 62716,
+			"name": "splitscreen_vertical_add"
+		},
+		{
+			"codepoint": 63195,
+			"name": "spo2"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61368,
+			"name": "sports_and_outdoors"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 58010,
+			"name": "sprinkler"
+		},
+		{
+			"codepoint": 63519,
+			"name": "sprint"
+		},
+		{
+			"codepoint": 1048469,
+			"name": "sql"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 61127,
+			"name": "square_circle"
+		},
+		{
+			"codepoint": 62387,
+			"name": "square_dot"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 62985,
+			"name": "stack"
+		},
+		{
+			"codepoint": 62297,
+			"name": "stack_group"
+		},
+		{
+			"codepoint": 62492,
+			"name": "stack_hexagon"
+		},
+		{
+			"codepoint": 62984,
+			"name": "stack_off"
+		},
+		{
+			"codepoint": 62983,
+			"name": "stack_star"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 59079,
+			"name": "stacked_email"
+		},
+		{
+			"codepoint": 59081,
+			"name": "stacked_inbox"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 62720,
+			"name": "stacks"
+		},
+		{
+			"codepoint": 61749,
+			"name": "stadia_controller"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 62572,
+			"name": "stairs_2"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 60485,
+			"name": "star_rate_half"
+		},
+		{
+			"codepoint": 62237,
+			"name": "star_shine"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 62236,
+			"name": "stars_2"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 59031,
+			"name": "stat_0"
+		},
+		{
+			"codepoint": 59032,
+			"name": "stat_1"
+		},
+		{
+			"codepoint": 59033,
+			"name": "stat_2"
+		},
+		{
+			"codepoint": 59034,
+			"name": "stat_3"
+		},
+		{
+			"codepoint": 59035,
+			"name": "stat_minus_1"
+		},
+		{
+			"codepoint": 59036,
+			"name": "stat_minus_2"
+		},
+		{
+			"codepoint": 59037,
+			"name": "stat_minus_3"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 59322,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 62163,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 62251,
+			"name": "steering_wheel_heat"
+		},
+		{
+			"codepoint": 63230,
+			"name": "step"
+		},
+		{
+			"codepoint": 63233,
+			"name": "step_into"
+		},
+		{
+			"codepoint": 63232,
+			"name": "step_out"
+		},
+		{
+			"codepoint": 63231,
+			"name": "step_over"
+		},
+		{
+			"codepoint": 59879,
+			"name": "steppers"
+		},
+		{
+			"codepoint": 63194,
+			"name": "steps"
+		},
+		{
+			"codepoint": 63493,
+			"name": "stethoscope"
+		},
+		{
+			"codepoint": 63495,
+			"name": "stethoscope_arrow"
+		},
+		{
+			"codepoint": 63494,
+			"name": "stethoscope_check"
+		},
+		{
+			"codepoint": 59143,
+			"name": "sticker"
+		},
+		{
+			"codepoint": 61122,
+			"name": "sticker_add"
+		},
+		{
+			"codepoint": 59880,
+			"name": "sticky_note"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 62832,
+			"name": "stock_media"
+		},
+		{
+			"codepoint": 62789,
+			"name": "stockpot"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 62943,
+			"name": "strategy"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 63391,
+			"name": "stream_apps"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 63193,
+			"name": "stress_management"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 63305,
+			"name": "stroke_full"
+		},
+		{
+			"codepoint": 63304,
+			"name": "stroke_partial"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 57971,
+			"name": "styler"
+		},
+		{
+			"codepoint": 62980,
+			"name": "stylus"
+		},
+		{
+			"codepoint": 62310,
+			"name": "stylus_brush"
+		},
+		{
+			"codepoint": 62309,
+			"name": "stylus_fountain_pen"
+		},
+		{
+			"codepoint": 62308,
+			"name": "stylus_highlighter"
+		},
+		{
+			"codepoint": 63303,
+			"name": "stylus_laser_pointer"
+		},
+		{
+			"codepoint": 62979,
+			"name": "stylus_note"
+		},
+		{
+			"codepoint": 62307,
+			"name": "stylus_pen"
+		},
+		{
+			"codepoint": 62306,
+			"name": "stylus_pencil"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59882,
+			"name": "subheader"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 62293,
+			"name": "subtitles_gear"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 62087,
+			"name": "subway_walk"
+		},
+		{
+			"codepoint": 1048432,
+			"name": "subwoofer"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 59418,
+			"name": "sunny"
+		},
+		{
+			"codepoint": 59417,
+			"name": "sunny_snowing"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 62990,
+			"name": "supervised_user_circle_off"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57649,
+			"name": "surgical"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59038,
+			"name": "swap_driving_apps"
+		},
+		{
+			"codepoint": 59039,
+			"name": "swap_driving_apps_wheel"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59052,
+			"name": "sweep"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 1048468,
+			"name": "swipe_left_2"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 1048467,
+			"name": "swipe_right_2"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 57844,
+			"name": "switch"
+		},
+		{
+			"codepoint": 63229,
+			"name": "switch_access"
+		},
+		{
+			"codepoint": 62726,
+			"name": "switch_access_2"
+		},
+		{
+			"codepoint": 62285,
+			"name": "switch_access_3"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 1048431,
+			"name": "switch_off"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 59187,
+			"name": "switches"
+		},
+		{
+			"codepoint": 62942,
+			"name": "sword_rose"
+		},
+		{
+			"codepoint": 63625,
+			"name": "swords"
+		},
+		{
+			"codepoint": 57650,
+			"name": "symptoms"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 62332,
+			"name": "sync_arrow_down"
+		},
+		{
+			"codepoint": 62331,
+			"name": "sync_arrow_up"
+		},
+		{
+			"codepoint": 62490,
+			"name": "sync_desktop"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 63520,
+			"name": "sync_saved_locally"
+		},
+		{
+			"codepoint": 62052,
+			"name": "sync_saved_locally_off"
+		},
+		{
+			"codepoint": 57651,
+			"name": "syringe"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 63301,
+			"name": "tab_close"
+		},
+		{
+			"codepoint": 62416,
+			"name": "tab_close_inactive"
+		},
+		{
+			"codepoint": 63302,
+			"name": "tab_close_right"
+		},
+		{
+			"codepoint": 63300,
+			"name": "tab_duplicate"
+		},
+		{
+			"codepoint": 63299,
+			"name": "tab_group"
+		},
+		{
+			"codepoint": 62523,
+			"name": "tab_inactive"
+		},
+		{
+			"codepoint": 63298,
+			"name": "tab_move"
+		},
+		{
+			"codepoint": 63297,
+			"name": "tab_new_right"
+		},
+		{
+			"codepoint": 63296,
+			"name": "tab_recent"
+		},
+		{
+			"codepoint": 62194,
+			"name": "tab_search"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 61841,
+			"name": "table"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 63215,
+			"name": "table_chart_view"
+		},
+		{
+			"codepoint": 62407,
+			"name": "table_convert"
+		},
+		{
+			"codepoint": 62406,
+			"name": "table_edit"
+		},
+		{
+			"codepoint": 62566,
+			"name": "table_eye"
+		},
+		{
+			"codepoint": 57842,
+			"name": "table_lamp"
+		},
+		{
+			"codepoint": 62105,
+			"name": "table_large"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 63295,
+			"name": "table_rows_narrow"
+		},
+		{
+			"codepoint": 61228,
+			"name": "table_sign"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 62541,
+			"name": "tablet_camera"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59886,
+			"name": "tabs"
+		},
+		{
+			"codepoint": 62820,
+			"name": "tactic"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 59938,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 61236,
+			"name": "takeout_dining_2"
+		},
+		{
+			"codepoint": 59438,
+			"name": "tamper_detection_off"
+		},
+		{
+			"codepoint": 63688,
+			"name": "tamper_detection_on"
+		},
+		{
+			"codepoint": 62156,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 59161,
+			"name": "target"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61235,
+			"name": "tatami_seat"
+		},
+		{
+			"codepoint": 63135,
+			"name": "taunt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 57363,
+			"name": "team_dashboard"
+		},
+		{
+			"codepoint": 63689,
+			"name": "temp_preferences_custom"
+		},
+		{
+			"codepoint": 63690,
+			"name": "temp_preferences_eco"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 61667,
+			"name": "tenancy"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 1048462,
+			"name": "terminal_2"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 59176,
+			"name": "text_ad"
+		},
+		{
+			"codepoint": 1048466,
+			"name": "text_ad_off"
+		},
+		{
+			"codepoint": 62405,
+			"name": "text_compare"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 59889,
+			"name": "text_fields_alt"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 63294,
+			"name": "text_select_end"
+		},
+		{
+			"codepoint": 63293,
+			"name": "text_select_jump_to_beginning"
+		},
+		{
+			"codepoint": 63292,
+			"name": "text_select_jump_to_end"
+		},
+		{
+			"codepoint": 63291,
+			"name": "text_select_move_back_character"
+		},
+		{
+			"codepoint": 63290,
+			"name": "text_select_move_back_word"
+		},
+		{
+			"codepoint": 63289,
+			"name": "text_select_move_down"
+		},
+		{
+			"codepoint": 63288,
+			"name": "text_select_move_forward_character"
+		},
+		{
+			"codepoint": 63287,
+			"name": "text_select_move_forward_word"
+		},
+		{
+			"codepoint": 63286,
+			"name": "text_select_move_up"
+		},
+		{
+			"codepoint": 63285,
+			"name": "text_select_start"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 61884,
+			"name": "text_to_speech"
+		},
+		{
+			"codepoint": 62622,
+			"name": "text_up"
+		},
+		{
+			"codepoint": 58917,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 62844,
+			"name": "texture_add"
+		},
+		{
+			"codepoint": 62843,
+			"name": "texture_minus"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 59462,
+			"name": "thermometer"
+		},
+		{
+			"codepoint": 62850,
+			"name": "thermometer_add"
+		},
+		{
+			"codepoint": 1048571,
+			"name": "thermometer_alert"
+		},
+		{
+			"codepoint": 63192,
+			"name": "thermometer_gain"
+		},
+		{
+			"codepoint": 63191,
+			"name": "thermometer_loss"
+		},
+		{
+			"codepoint": 62849,
+			"name": "thermometer_minus"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 62330,
+			"name": "thermostat_arrow_down"
+		},
+		{
+			"codepoint": 62329,
+			"name": "thermostat_arrow_up"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 61816,
+			"name": "thermostat_carbon"
+		},
+		{
+			"codepoint": 60202,
+			"name": "things_to_do"
+		},
+		{
+			"codepoint": 62713,
+			"name": "thread_unread"
+		},
+		{
+			"codepoint": 60141,
+			"name": "threat_intelligence"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_filled"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_filled"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 63284,
+			"name": "thumbnail_bar"
+		},
+		{
+			"codepoint": 61180,
+			"name": "thumbs_up_double"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 63643,
+			"name": "tibia"
+		},
+		{
+			"codepoint": 63644,
+			"name": "tibia_alt"
+		},
+		{
+			"codepoint": 62403,
+			"name": "tile_large"
+		},
+		{
+			"codepoint": 62402,
+			"name": "tile_medium"
+		},
+		{
+			"codepoint": 62401,
+			"name": "tile_small"
+		},
+		{
+			"codepoint": 1048358,
+			"name": "tilt_arrow_down"
+		},
+		{
+			"codepoint": 1048357,
+			"name": "tilt_arrow_up"
+		},
+		{
+			"codepoint": 61668,
+			"name": "time_auto"
+		},
+		{
+			"codepoint": 61431,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 62127,
+			"name": "timer_1"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61375,
+			"name": "timer_10_alt_1"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 62126,
+			"name": "timer_2"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61376,
+			"name": "timer_3_alt_1"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 62641,
+			"name": "timer_5"
+		},
+		{
+			"codepoint": 62642,
+			"name": "timer_5_shutter"
+		},
+		{
+			"codepoint": 62328,
+			"name": "timer_arrow_down"
+		},
+		{
+			"codepoint": 62327,
+			"name": "timer_arrow_up"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 62651,
+			"name": "timer_pause"
+		},
+		{
+			"codepoint": 62650,
+			"name": "timer_play"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 62601,
+			"name": "titlecase"
+		},
+		{
+			"codepoint": 61377,
+			"name": "toast"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 62132,
+			"name": "tonality_2"
+		},
+		{
+			"codepoint": 59895,
+			"name": "toolbar"
+		},
+		{
+			"codepoint": 63691,
+			"name": "tools_flat_head"
+		},
+		{
+			"codepoint": 58027,
+			"name": "tools_installation_kit"
+		},
+		{
+			"codepoint": 58059,
+			"name": "tools_ladder"
+		},
+		{
+			"codepoint": 59259,
+			"name": "tools_level"
+		},
+		{
+			"codepoint": 63692,
+			"name": "tools_phillips"
+		},
+		{
+			"codepoint": 58026,
+			"name": "tools_pliers_wire_stripper"
+		},
+		{
+			"codepoint": 57833,
+			"name": "tools_power_drill"
+		},
+		{
+			"codepoint": 63693,
+			"name": "tools_wrench"
+		},
+		{
+			"codepoint": 59896,
+			"name": "tooltip"
+		},
+		{
+			"codepoint": 62445,
+			"name": "tooltip_2"
+		},
+		{
+			"codepoint": 63283,
+			"name": "top_panel_close"
+		},
+		{
+			"codepoint": 63282,
+			"name": "top_panel_open"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 63607,
+			"name": "total_dissolved_solids"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 62347,
+			"name": "touch_double"
+		},
+		{
+			"codepoint": 1048373,
+			"name": "touch_double_2"
+		},
+		{
+			"codepoint": 62346,
+			"name": "touch_long"
+		},
+		{
+			"codepoint": 62345,
+			"name": "touch_triple"
+		},
+		{
+			"codepoint": 63111,
+			"name": "touchpad_mouse"
+		},
+		{
+			"codepoint": 62694,
+			"name": "touchpad_mouse_off"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 61378,
+			"name": "toys_and_games"
+		},
+		{
+			"codepoint": 63623,
+			"name": "toys_fan"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 62663,
+			"name": "trackpad_input"
+		},
+		{
+			"codepoint": 62473,
+			"name": "trackpad_input_2"
+		},
+		{
+			"codepoint": 62472,
+			"name": "trackpad_input_3"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 62575,
+			"name": "traffic_jam"
+		},
+		{
+			"codepoint": 60254,
+			"name": "trail_length"
+		},
+		{
+			"codepoint": 60259,
+			"name": "trail_length_medium"
+		},
+		{
+			"codepoint": 60269,
+			"name": "trail_length_short"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 62449,
+			"name": "transit_ticket"
+		},
+		{
+			"codepoint": 62734,
+			"name": "transition_chop"
+		},
+		{
+			"codepoint": 62733,
+			"name": "transition_dissolve"
+		},
+		{
+			"codepoint": 62732,
+			"name": "transition_fade"
+		},
+		{
+			"codepoint": 62731,
+			"name": "transition_push"
+		},
+		{
+			"codepoint": 62730,
+			"name": "transition_slide"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 62051,
+			"name": "translate_indic"
+		},
+		{
+			"codepoint": 57885,
+			"name": "transportation"
+		},
+		{
+			"codepoint": 61331,
+			"name": "travel"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 61379,
+			"name": "travel_luggage_and_bags"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 61126,
+			"name": "triangle_circle"
+		},
+		{
+			"codepoint": 59131,
+			"name": "trip"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 63595,
+			"name": "trolley"
+		},
+		{
+			"codepoint": 62574,
+			"name": "trolley_cable_car"
+		},
+		{
+			"codepoint": 59939,
+			"name": "trophy"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 59094,
+			"name": "tsv"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58939,
+			"name": "tv"
+		},
+		{
+			"codepoint": 62444,
+			"name": "tv_displays"
+		},
+		{
+			"codepoint": 59440,
+			"name": "tv_gen"
+		},
+		{
+			"codepoint": 57820,
+			"name": "tv_guide"
+		},
+		{
+			"codepoint": 62443,
+			"name": "tv_next"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 57821,
+			"name": "tv_options_edit_channels"
+		},
+		{
+			"codepoint": 57822,
+			"name": "tv_options_input_settings"
+		},
+		{
+			"codepoint": 62937,
+			"name": "tv_remote"
+		},
+		{
+			"codepoint": 59163,
+			"name": "tv_signin"
+		},
+		{
+			"codepoint": 59269,
+			"name": "tv_with_assistant"
+		},
+		{
+			"codepoint": 62751,
+			"name": "two_pager"
+		},
+		{
+			"codepoint": 62404,
+			"name": "two_pager_store"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61234,
+			"name": "udon"
+		},
+		{
+			"codepoint": 63645,
+			"name": "ulna_radius"
+		},
+		{
+			"codepoint": 63646,
+			"name": "ulna_radius_alt"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 61105,
+			"name": "undereye"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 63281,
+			"name": "ungroup"
+		},
+		{
+			"codepoint": 59898,
+			"name": "universal_currency"
+		},
+		{
+			"codepoint": 59188,
+			"name": "universal_currency_alt"
+		},
+		{
+			"codepoint": 59899,
+			"name": "universal_local"
+		},
+		{
+			"codepoint": 62623,
+			"name": "unknown_2"
+		},
+		{
+			"codepoint": 59045,
+			"name": "unknown_5"
+		},
+		{
+			"codepoint": 62622,
+			"name": "unknown_7"
+		},
+		{
+			"codepoint": 63492,
+			"name": "unknown_document"
+		},
+		{
+			"codepoint": 60093,
+			"name": "unknown_med"
+		},
+		{
+			"codepoint": 60165,
+			"name": "unlicense"
+		},
+		{
+			"codepoint": 62573,
+			"name": "unpaved_road"
+		},
+		{
+			"codepoint": 59129,
+			"name": "unpin"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 62415,
+			"name": "upi_pay"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 62753,
+			"name": "upload_2"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 62600,
+			"name": "uppercase"
+		},
+		{
+			"codepoint": 57655,
+			"name": "urology"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 59144,
+			"name": "user_attributes"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 61381,
+			"name": "vacuum"
+		},
+		{
+			"codepoint": 1048429,
+			"name": "vacuum_2"
+		},
+		{
+			"codepoint": 1048430,
+			"name": "vacuum_2_on"
+		},
+		{
+			"codepoint": 57892,
+			"name": "valve"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 62750,
+			"name": "variable_add"
+		},
+		{
+			"codepoint": 62749,
+			"name": "variable_insert"
+		},
+		{
+			"codepoint": 62748,
+			"name": "variable_remove"
+		},
+		{
+			"codepoint": 63569,
+			"name": "variables"
+		},
+		{
+			"codepoint": 57657,
+			"name": "ventilator"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 62222,
+			"name": "verified_off"
+		},
+		{
+			"codepoint": 61459,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 62155,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 62476,
+			"name": "video_camera_back_add"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63547,
+			"name": "video_camera_front_off"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 1048333,
+			"name": "video_frame_copy"
+		},
+		{
+			"codepoint": 1048332,
+			"name": "video_frame_save"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 61382,
+			"name": "video_search"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 1048531,
+			"name": "video_template"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 62352,
+			"name": "videocam_alert"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 62326,
+			"name": "view_apps"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 63559,
+			"name": "view_column_2"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar_new"
+		},
+		{
+			"codepoint": 63003,
+			"name": "view_in_ar_off"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 62514,
+			"name": "view_object_track"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 62658,
+			"name": "view_real_size"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 62131,
+			"name": "vignette_2"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 63059,
+			"name": "visibility_lock"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58960,
+			"name": "vital_signs"
+		},
+		{
+			"codepoint": 57659,
+			"name": "vitals"
+		},
+		{
+			"codepoint": 62634,
+			"name": "vo2_max"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 61118,
+			"name": "voice_chat_off"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 62858,
+			"name": "voice_selection"
+		},
+		{
+			"codepoint": 62508,
+			"name": "voice_selection_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 62290,
+			"name": "voicemail_2"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 59292,
+			"name": "volume_down_alt"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 63570,
+			"name": "voting_chip"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 63180,
+			"name": "vpn_key_alert"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 62288,
+			"name": "vpn_lock_2"
+		},
+		{
+			"codepoint": 61386,
+			"name": "vr180_create2d"
+		},
+		{
+			"codepoint": 62833,
+			"name": "vr180_create2d_off"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 1048321,
+			"name": "walk_bike"
+		},
+		{
+			"codepoint": 61387,
+			"name": "wall_art"
+		},
+		{
+			"codepoint": 58036,
+			"name": "wall_lamp"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 57788,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 63090,
+			"name": "wallpaper_slideshow"
+		},
+		{
+			"codepoint": 62239,
+			"name": "wand_shine"
+		},
+		{
+			"codepoint": 62238,
+			"name": "wand_stars"
+		},
+		{
+			"codepoint": 57660,
+			"name": "ward"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 63405,
+			"name": "warning_off"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 62080,
+			"name": "washoku"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 1048529,
+			"name": "watch_alert"
+		},
+		{
+			"codepoint": 62154,
+			"name": "watch_arrow"
+		},
+		{
+			"codepoint": 1048527,
+			"name": "watch_arrow_down"
+		},
+		{
+			"codepoint": 1048352,
+			"name": "watch_button"
+		},
+		{
+			"codepoint": 63146,
+			"name": "watch_button_press"
+		},
+		{
+			"codepoint": 62568,
+			"name": "watch_check"
+		},
+		{
+			"codepoint": 61398,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 61161,
+			"name": "watch_lock"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 63150,
+			"name": "watch_screentime"
+		},
+		{
+			"codepoint": 62567,
+			"name": "watch_vibration"
+		},
+		{
+			"codepoint": 63145,
+			"name": "watch_wake"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 63133,
+			"name": "water_bottle"
+		},
+		{
+			"codepoint": 63134,
+			"name": "water_bottle_large"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 63600,
+			"name": "water_do"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 1048485,
+			"name": "water_drops"
+		},
+		{
+			"codepoint": 63605,
+			"name": "water_ec"
+		},
+		{
+			"codepoint": 63190,
+			"name": "water_full"
+		},
+		{
+			"codepoint": 57988,
+			"name": "water_heater"
+		},
+		{
+			"codepoint": 63149,
+			"name": "water_lock"
+		},
+		{
+			"codepoint": 63189,
+			"name": "water_loss"
+		},
+		{
+			"codepoint": 63604,
+			"name": "water_lux"
+		},
+		{
+			"codepoint": 63188,
+			"name": "water_medium"
+		},
+		{
+			"codepoint": 63608,
+			"name": "water_orp"
+		},
+		{
+			"codepoint": 63610,
+			"name": "water_ph"
+		},
+		{
+			"codepoint": 62936,
+			"name": "water_pump"
+		},
+		{
+			"codepoint": 63611,
+			"name": "water_voc"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 61788,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 61565,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 1048351,
+			"name": "wb_twilight_2"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 63103,
+			"name": "weather_hail"
+		},
+		{
+			"codepoint": 62987,
+			"name": "weather_mix"
+		},
+		{
+			"codepoint": 58061,
+			"name": "weather_snowy"
+		},
+		{
+			"codepoint": 59009,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 61255,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 59907,
+			"name": "web_traffic"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 57661,
+			"name": "weight"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 1048484,
+			"name": "wheat"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 62394,
+			"name": "widget_medium"
+		},
+		{
+			"codepoint": 61111,
+			"name": "widget_menu"
+		},
+		{
+			"codepoint": 62393,
+			"name": "widget_small"
+		},
+		{
+			"codepoint": 62392,
+			"name": "widget_width"
+		},
+		{
+			"codepoint": 57789,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63280,
+			"name": "width"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 63400,
+			"name": "wifi_add"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_1"
+		},
+		{
+			"codepoint": 61686,
+			"name": "wifi_calling_2"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 62540,
+			"name": "wifi_calling_bar_1"
+		},
+		{
+			"codepoint": 62539,
+			"name": "wifi_calling_bar_2"
+		},
+		{
+			"codepoint": 62538,
+			"name": "wifi_calling_bar_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 1048372,
+			"name": "wifi_device"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 63089,
+			"name": "wifi_home"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 63088,
+			"name": "wifi_notification"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 63399,
+			"name": "wifi_proxy"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 60121,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 59262,
+			"name": "window_closed"
+		},
+		{
+			"codepoint": 59276,
+			"name": "window_open"
+		},
+		{
+			"codepoint": 58043,
+			"name": "window_sensor"
+		},
+		{
+			"codepoint": 62024,
+			"name": "windshield_defrost_auto"
+		},
+		{
+			"codepoint": 62250,
+			"name": "windshield_defrost_front"
+		},
+		{
+			"codepoint": 62249,
+			"name": "windshield_defrost_rear"
+		},
+		{
+			"codepoint": 62248,
+			"name": "windshield_heat_front"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work"
+		},
+		{
+			"codepoint": 62967,
+			"name": "work_alert"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 62968,
+			"name": "work_update"
+		},
+		{
+			"codepoint": 59908,
+			"name": "workflow"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces_outline"
+		},
+		{
+			"codepoint": 57663,
+			"name": "wounds_injuries"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 63132,
+			"name": "wrist"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 58185,
+			"name": "x_circle"
+		},
+		{
+			"codepoint": 61125,
+			"name": "y_circle"
+		},
+		{
+			"codepoint": 61233,
+			"name": "yakitori"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 62079,
+			"name": "yoshoku"
+		},
+		{
+			"codepoint": 60203,
+			"name": "your_trips"
+		},
+		{
+			"codepoint": 63578,
+			"name": "youtube_activity"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59265,
+			"name": "zone_person_alert"
+		},
+		{
+			"codepoint": 59258,
+			"name": "zone_person_idle"
+		},
+		{
+			"codepoint": 59272,
+			"name": "zone_person_urgent"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "variablefont/MaterialSymbolsRounded[FILL,GRAD,opsz,wght].codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"sha256": "8567a3d0512ce8a735a739d325e83ee7010d9bf7f6f8ed6a699c07c817ea907d"
+	}
+}

--- a/registry/data/families/google-icons/material-symbols-rounded/inspection.json
+++ b/registry/data/families/google-icons/material-symbols-rounded/inspection.json
@@ -1,0 +1,46 @@
+{
+	"files": [
+		{
+			"axes": [
+				{
+					"default": 0,
+					"max": 1,
+					"min": 0,
+					"tag": "FILL"
+				},
+				{
+					"default": 0,
+					"max": 200,
+					"min": -50,
+					"tag": "GRAD"
+				},
+				{
+					"default": 24,
+					"max": 48,
+					"min": 20,
+					"tag": "opsz"
+				},
+				{
+					"default": 400,
+					"max": 700,
+					"min": 100,
+					"tag": "wght"
+				}
+			],
+			"cmap": {
+				"codepointCount": 4382,
+				"sha256": "c7e2330b037a77ee633c96bab75b961eb0376d69ff3e00ecce87a89de557b18d"
+			},
+			"colorTables": [],
+			"fontVersion": "Version 2.961",
+			"outline": "glyf",
+			"path": "variablefont/MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf",
+			"style": "normal",
+			"weight": {
+				"default": 400,
+				"max": 700,
+				"min": 100
+			}
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-rounded/license.txt
+++ b/registry/data/families/google-icons/material-symbols-rounded/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-symbols-rounded/metadata.json
+++ b/registry/data/families/google-icons/material-symbols-rounded/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Symbols Rounded",
+	"id": "material-symbols-rounded",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "variablefont",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "variablefont/MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf",
+			"sha256": "8817f9df195b582d45a6031c1d9e1533595dd7a6f0e76abc309bdc3cc4d72ee1",
+			"size": 15073992,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2026-07-24",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-sharp/description.en-US.md
+++ b/registry/data/families/google-icons/material-symbols-sharp/description.en-US.md
@@ -1,0 +1,1 @@
+Material Symbols Sharp is part of Google's current Material Symbols collection. It is a variable icon font with fill, weight, grade, and optical size axes.

--- a/registry/data/families/google-icons/material-symbols-sharp/icons.json
+++ b/registry/data/families/google-icons/material-symbols-sharp/icons.json
@@ -1,0 +1,17078 @@
+{
+	"icons": [
+		{
+			"codepoint": 59729,
+			"name": "10k"
+		},
+		{
+			"codepoint": 59730,
+			"name": "10mp"
+		},
+		{
+			"codepoint": 59731,
+			"name": "11mp"
+		},
+		{
+			"codepoint": 60301,
+			"name": "123"
+		},
+		{
+			"codepoint": 59732,
+			"name": "12mp"
+		},
+		{
+			"codepoint": 59733,
+			"name": "13mp"
+		},
+		{
+			"codepoint": 59734,
+			"name": "14mp"
+		},
+		{
+			"codepoint": 59735,
+			"name": "15mp"
+		},
+		{
+			"codepoint": 59736,
+			"name": "16mp"
+		},
+		{
+			"codepoint": 59737,
+			"name": "17mp"
+		},
+		{
+			"codepoint": 63741,
+			"name": "18_up_rating"
+		},
+		{
+			"codepoint": 59738,
+			"name": "18mp"
+		},
+		{
+			"codepoint": 59739,
+			"name": "19mp"
+		},
+		{
+			"codepoint": 59740,
+			"name": "1k"
+		},
+		{
+			"codepoint": 59741,
+			"name": "1k_plus"
+		},
+		{
+			"codepoint": 61389,
+			"name": "1x_mobiledata"
+		},
+		{
+			"codepoint": 63473,
+			"name": "1x_mobiledata_badge"
+		},
+		{
+			"codepoint": 59742,
+			"name": "20mp"
+		},
+		{
+			"codepoint": 59743,
+			"name": "21mp"
+		},
+		{
+			"codepoint": 59744,
+			"name": "22mp"
+		},
+		{
+			"codepoint": 59745,
+			"name": "23mp"
+		},
+		{
+			"codepoint": 62450,
+			"name": "24fps_select"
+		},
+		{
+			"codepoint": 59746,
+			"name": "24mp"
+		},
+		{
+			"codepoint": 61239,
+			"name": "2d"
+		},
+		{
+			"codepoint": 1048334,
+			"name": "2d_2"
+		},
+		{
+			"codepoint": 59747,
+			"name": "2k"
+		},
+		{
+			"codepoint": 59748,
+			"name": "2k_plus"
+		},
+		{
+			"codepoint": 59749,
+			"name": "2mp"
+		},
+		{
+			"codepoint": 61390,
+			"name": "30fps"
+		},
+		{
+			"codepoint": 61391,
+			"name": "30fps_select"
+		},
+		{
+			"codepoint": 58743,
+			"name": "360"
+		},
+		{
+			"codepoint": 60728,
+			"name": "3d"
+		},
+		{
+			"codepoint": 1048335,
+			"name": "3d_2"
+		},
+		{
+			"codepoint": 59469,
+			"name": "3d_rotation"
+		},
+		{
+			"codepoint": 61392,
+			"name": "3g_mobiledata"
+		},
+		{
+			"codepoint": 63472,
+			"name": "3g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59750,
+			"name": "3k"
+		},
+		{
+			"codepoint": 59751,
+			"name": "3k_plus"
+		},
+		{
+			"codepoint": 59752,
+			"name": "3mp"
+		},
+		{
+			"codepoint": 61393,
+			"name": "3p"
+		},
+		{
+			"codepoint": 61394,
+			"name": "4g_mobiledata"
+		},
+		{
+			"codepoint": 63471,
+			"name": "4g_mobiledata_badge"
+		},
+		{
+			"codepoint": 61395,
+			"name": "4g_plus_mobiledata"
+		},
+		{
+			"codepoint": 57458,
+			"name": "4k"
+		},
+		{
+			"codepoint": 59753,
+			"name": "4k_plus"
+		},
+		{
+			"codepoint": 59754,
+			"name": "4mp"
+		},
+		{
+			"codepoint": 63219,
+			"name": "50mp"
+		},
+		{
+			"codepoint": 61240,
+			"name": "5g"
+		},
+		{
+			"codepoint": 63470,
+			"name": "5g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59755,
+			"name": "5k"
+		},
+		{
+			"codepoint": 59756,
+			"name": "5k_plus"
+		},
+		{
+			"codepoint": 59757,
+			"name": "5mp"
+		},
+		{
+			"codepoint": 61396,
+			"name": "60fps"
+		},
+		{
+			"codepoint": 61397,
+			"name": "60fps_select"
+		},
+		{
+			"codepoint": 61982,
+			"name": "6_ft_apart"
+		},
+		{
+			"codepoint": 59758,
+			"name": "6k"
+		},
+		{
+			"codepoint": 59759,
+			"name": "6k_plus"
+		},
+		{
+			"codepoint": 59760,
+			"name": "6mp"
+		},
+		{
+			"codepoint": 59761,
+			"name": "7k"
+		},
+		{
+			"codepoint": 59762,
+			"name": "7k_plus"
+		},
+		{
+			"codepoint": 59763,
+			"name": "7mp"
+		},
+		{
+			"codepoint": 59764,
+			"name": "8k"
+		},
+		{
+			"codepoint": 59765,
+			"name": "8k_plus"
+		},
+		{
+			"codepoint": 59766,
+			"name": "8mp"
+		},
+		{
+			"codepoint": 59767,
+			"name": "9k"
+		},
+		{
+			"codepoint": 59768,
+			"name": "9k_plus"
+		},
+		{
+			"codepoint": 59769,
+			"name": "9mp"
+		},
+		{
+			"codepoint": 60308,
+			"name": "abc"
+		},
+		{
+			"codepoint": 60219,
+			"name": "ac_unit"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarm"
+		},
+		{
+			"codepoint": 59477,
+			"name": "access_alarms"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time"
+		},
+		{
+			"codepoint": 61398,
+			"name": "access_time_filled"
+		},
+		{
+			"codepoint": 59470,
+			"name": "accessibility"
+		},
+		{
+			"codepoint": 59692,
+			"name": "accessibility_new"
+		},
+		{
+			"codepoint": 59668,
+			"name": "accessible"
+		},
+		{
+			"codepoint": 59700,
+			"name": "accessible_forward"
+		},
+		{
+			"codepoint": 62286,
+			"name": "accessible_menu"
+		},
+		{
+			"codepoint": 59471,
+			"name": "account_balance"
+		},
+		{
+			"codepoint": 59472,
+			"name": "account_balance_wallet"
+		},
+		{
+			"codepoint": 59473,
+			"name": "account_box"
+		},
+		{
+			"codepoint": 59474,
+			"name": "account_child"
+		},
+		{
+			"codepoint": 58969,
+			"name": "account_child_invert"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle"
+		},
+		{
+			"codepoint": 61963,
+			"name": "account_circle_filled"
+		},
+		{
+			"codepoint": 63411,
+			"name": "account_circle_off"
+		},
+		{
+			"codepoint": 59770,
+			"name": "account_tree"
+		},
+		{
+			"codepoint": 62722,
+			"name": "action_key"
+		},
+		{
+			"codepoint": 57830,
+			"name": "activity_zone"
+		},
+		{
+			"codepoint": 62148,
+			"name": "acupuncture"
+		},
+		{
+			"codepoint": 58571,
+			"name": "acute"
+		},
+		{
+			"codepoint": 58970,
+			"name": "ad"
+		},
+		{
+			"codepoint": 58971,
+			"name": "ad_group"
+		},
+		{
+			"codepoint": 60133,
+			"name": "ad_group_off"
+		},
+		{
+			"codepoint": 63410,
+			"name": "ad_off"
+		},
+		{
+			"codepoint": 62187,
+			"name": "ad_units"
+		},
+		{
+			"codepoint": 62668,
+			"name": "adaptive_audio_mic"
+		},
+		{
+			"codepoint": 62667,
+			"name": "adaptive_audio_mic_off"
+		},
+		{
+			"codepoint": 58894,
+			"name": "adb"
+		},
+		{
+			"codepoint": 57669,
+			"name": "add"
+		},
+		{
+			"codepoint": 62429,
+			"name": "add_2"
+		},
+		{
+			"codepoint": 58425,
+			"name": "add_a_photo"
+		},
+		{
+			"codepoint": 59178,
+			"name": "add_ad"
+		},
+		{
+			"codepoint": 59478,
+			"name": "add_alarm"
+		},
+		{
+			"codepoint": 57347,
+			"name": "add_alert"
+		},
+		{
+			"codepoint": 57670,
+			"name": "add_box"
+		},
+		{
+			"codepoint": 59177,
+			"name": "add_business"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_call"
+		},
+		{
+			"codepoint": 60294,
+			"name": "add_card"
+		},
+		{
+			"codepoint": 61244,
+			"name": "add_chart"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle"
+		},
+		{
+			"codepoint": 59792,
+			"name": "add_circle_outline"
+		},
+		{
+			"codepoint": 62501,
+			"name": "add_column_left"
+		},
+		{
+			"codepoint": 62500,
+			"name": "add_column_right"
+		},
+		{
+			"codepoint": 57958,
+			"name": "add_comment"
+		},
+		{
+			"codepoint": 62620,
+			"name": "add_diamond"
+		},
+		{
+			"codepoint": 63723,
+			"name": "add_home"
+		},
+		{
+			"codepoint": 63725,
+			"name": "add_home_work"
+		},
+		{
+			"codepoint": 61623,
+			"name": "add_ic_call"
+		},
+		{
+			"codepoint": 57720,
+			"name": "add_link"
+		},
+		{
+			"codepoint": 58727,
+			"name": "add_location"
+		},
+		{
+			"codepoint": 61242,
+			"name": "add_location_alt"
+		},
+		{
+			"codepoint": 59773,
+			"name": "add_moderator"
+		},
+		{
+			"codepoint": 57489,
+			"name": "add_notes"
+		},
+		{
+			"codepoint": 58430,
+			"name": "add_photo_alternate"
+		},
+		{
+			"codepoint": 57811,
+			"name": "add_reaction"
+		},
+		{
+			"codepoint": 61243,
+			"name": "add_road"
+		},
+		{
+			"codepoint": 62499,
+			"name": "add_row_above"
+		},
+		{
+			"codepoint": 62498,
+			"name": "add_row_below"
+		},
+		{
+			"codepoint": 59476,
+			"name": "add_shopping_cart"
+		},
+		{
+			"codepoint": 62010,
+			"name": "add_task"
+		},
+		{
+			"codepoint": 58972,
+			"name": "add_to_drive"
+		},
+		{
+			"codepoint": 62137,
+			"name": "add_to_home_screen"
+		},
+		{
+			"codepoint": 58269,
+			"name": "add_to_photos"
+		},
+		{
+			"codepoint": 57436,
+			"name": "add_to_queue"
+		},
+		{
+			"codepoint": 62606,
+			"name": "add_triangle"
+		},
+		{
+			"codepoint": 61244,
+			"name": "addchart"
+		},
+		{
+			"codepoint": 60122,
+			"name": "adf_scanner"
+		},
+		{
+			"codepoint": 58270,
+			"name": "adjust"
+		},
+		{
+			"codepoint": 58509,
+			"name": "admin_meds"
+		},
+		{
+			"codepoint": 61245,
+			"name": "admin_panel_settings"
+		},
+		{
+			"codepoint": 59234,
+			"name": "ads_click"
+		},
+		{
+			"codepoint": 63624,
+			"name": "agender"
+		},
+		{
+			"codepoint": 60025,
+			"name": "agriculture"
+		},
+		{
+			"codepoint": 61400,
+			"name": "air"
+		},
+		{
+			"codepoint": 58058,
+			"name": "air_freshener"
+		},
+		{
+			"codepoint": 59774,
+			"name": "air_purifier"
+		},
+		{
+			"codepoint": 59433,
+			"name": "air_purifier_gen"
+		},
+		{
+			"codepoint": 58928,
+			"name": "airline_seat_flat"
+		},
+		{
+			"codepoint": 58929,
+			"name": "airline_seat_flat_angled"
+		},
+		{
+			"codepoint": 58930,
+			"name": "airline_seat_individual_suite"
+		},
+		{
+			"codepoint": 58931,
+			"name": "airline_seat_legroom_extra"
+		},
+		{
+			"codepoint": 58932,
+			"name": "airline_seat_legroom_normal"
+		},
+		{
+			"codepoint": 58933,
+			"name": "airline_seat_legroom_reduced"
+		},
+		{
+			"codepoint": 58934,
+			"name": "airline_seat_recline_extra"
+		},
+		{
+			"codepoint": 58935,
+			"name": "airline_seat_recline_normal"
+		},
+		{
+			"codepoint": 59344,
+			"name": "airline_stops"
+		},
+		{
+			"codepoint": 59338,
+			"name": "airlines"
+		},
+		{
+			"codepoint": 61401,
+			"name": "airplane_ticket"
+		},
+		{
+			"codepoint": 58685,
+			"name": "airplanemode_active"
+		},
+		{
+			"codepoint": 57748,
+			"name": "airplanemode_inactive"
+		},
+		{
+			"codepoint": 57429,
+			"name": "airplay"
+		},
+		{
+			"codepoint": 60220,
+			"name": "airport_shuttle"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airware"
+		},
+		{
+			"codepoint": 61780,
+			"name": "airwave"
+		},
+		{
+			"codepoint": 59477,
+			"name": "alarm"
+		},
+		{
+			"codepoint": 59478,
+			"name": "alarm_add"
+		},
+		{
+			"codepoint": 59479,
+			"name": "alarm_off"
+		},
+		{
+			"codepoint": 59480,
+			"name": "alarm_on"
+		},
+		{
+			"codepoint": 62299,
+			"name": "alarm_pause"
+		},
+		{
+			"codepoint": 63152,
+			"name": "alarm_smart_wake"
+		},
+		{
+			"codepoint": 57369,
+			"name": "album"
+		},
+		{
+			"codepoint": 58198,
+			"name": "align_center"
+		},
+		{
+			"codepoint": 63383,
+			"name": "align_end"
+		},
+		{
+			"codepoint": 63382,
+			"name": "align_flex_center"
+		},
+		{
+			"codepoint": 63381,
+			"name": "align_flex_end"
+		},
+		{
+			"codepoint": 63380,
+			"name": "align_flex_start"
+		},
+		{
+			"codepoint": 57359,
+			"name": "align_horizontal_center"
+		},
+		{
+			"codepoint": 57357,
+			"name": "align_horizontal_left"
+		},
+		{
+			"codepoint": 57360,
+			"name": "align_horizontal_right"
+		},
+		{
+			"codepoint": 63379,
+			"name": "align_items_stretch"
+		},
+		{
+			"codepoint": 63378,
+			"name": "align_justify_center"
+		},
+		{
+			"codepoint": 63377,
+			"name": "align_justify_flex_end"
+		},
+		{
+			"codepoint": 63376,
+			"name": "align_justify_flex_start"
+		},
+		{
+			"codepoint": 63375,
+			"name": "align_justify_space_around"
+		},
+		{
+			"codepoint": 63374,
+			"name": "align_justify_space_between"
+		},
+		{
+			"codepoint": 63373,
+			"name": "align_justify_space_even"
+		},
+		{
+			"codepoint": 63372,
+			"name": "align_justify_stretch"
+		},
+		{
+			"codepoint": 63371,
+			"name": "align_self_stretch"
+		},
+		{
+			"codepoint": 63370,
+			"name": "align_space_around"
+		},
+		{
+			"codepoint": 63369,
+			"name": "align_space_between"
+		},
+		{
+			"codepoint": 63368,
+			"name": "align_space_even"
+		},
+		{
+			"codepoint": 63367,
+			"name": "align_start"
+		},
+		{
+			"codepoint": 63366,
+			"name": "align_stretch"
+		},
+		{
+			"codepoint": 57365,
+			"name": "align_vertical_bottom"
+		},
+		{
+			"codepoint": 57361,
+			"name": "align_vertical_center"
+		},
+		{
+			"codepoint": 57356,
+			"name": "align_vertical_top"
+		},
+		{
+			"codepoint": 59775,
+			"name": "all_inbox"
+		},
+		{
+			"codepoint": 60221,
+			"name": "all_inclusive"
+		},
+		{
+			"codepoint": 57491,
+			"name": "all_match"
+		},
+		{
+			"codepoint": 59659,
+			"name": "all_out"
+		},
+		{
+			"codepoint": 57492,
+			"name": "allergies"
+		},
+		{
+			"codepoint": 58958,
+			"name": "allergy"
+		},
+		{
+			"codepoint": 61828,
+			"name": "alt_route"
+		},
+		{
+			"codepoint": 57574,
+			"name": "alternate_email"
+		},
+		{
+			"codepoint": 63603,
+			"name": "altitude"
+		},
+		{
+			"codepoint": 63172,
+			"name": "ambient_screen"
+		},
+		{
+			"codepoint": 63491,
+			"name": "ambulance"
+		},
+		{
+			"codepoint": 63490,
+			"name": "amend"
+		},
+		{
+			"codepoint": 59923,
+			"name": "amp_stories"
+		},
+		{
+			"codepoint": 61246,
+			"name": "analytics"
+		},
+		{
+			"codepoint": 61901,
+			"name": "anchor"
+		},
+		{
+			"codepoint": 59481,
+			"name": "android"
+		},
+		{
+			"codepoint": 61190,
+			"name": "android_cell_4_bar"
+		},
+		{
+			"codepoint": 61193,
+			"name": "android_cell_4_bar_alert"
+		},
+		{
+			"codepoint": 61192,
+			"name": "android_cell_4_bar_off"
+		},
+		{
+			"codepoint": 61191,
+			"name": "android_cell_4_bar_plus"
+		},
+		{
+			"codepoint": 61186,
+			"name": "android_cell_5_bar"
+		},
+		{
+			"codepoint": 61189,
+			"name": "android_cell_5_bar_alert"
+		},
+		{
+			"codepoint": 61188,
+			"name": "android_cell_5_bar_off"
+		},
+		{
+			"codepoint": 61187,
+			"name": "android_cell_5_bar_plus"
+		},
+		{
+			"codepoint": 61197,
+			"name": "android_cell_dual_4_bar"
+		},
+		{
+			"codepoint": 61199,
+			"name": "android_cell_dual_4_bar_alert"
+		},
+		{
+			"codepoint": 61198,
+			"name": "android_cell_dual_4_bar_plus"
+		},
+		{
+			"codepoint": 61194,
+			"name": "android_cell_dual_5_bar"
+		},
+		{
+			"codepoint": 61196,
+			"name": "android_cell_dual_5_bar_alert"
+		},
+		{
+			"codepoint": 61195,
+			"name": "android_cell_dual_5_bar_plus"
+		},
+		{
+			"codepoint": 61206,
+			"name": "android_wifi_3_bar"
+		},
+		{
+			"codepoint": 61211,
+			"name": "android_wifi_3_bar_alert"
+		},
+		{
+			"codepoint": 61210,
+			"name": "android_wifi_3_bar_lock"
+		},
+		{
+			"codepoint": 61209,
+			"name": "android_wifi_3_bar_off"
+		},
+		{
+			"codepoint": 61208,
+			"name": "android_wifi_3_bar_plus"
+		},
+		{
+			"codepoint": 61207,
+			"name": "android_wifi_3_bar_question"
+		},
+		{
+			"codepoint": 61200,
+			"name": "android_wifi_4_bar"
+		},
+		{
+			"codepoint": 61205,
+			"name": "android_wifi_4_bar_alert"
+		},
+		{
+			"codepoint": 61204,
+			"name": "android_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61203,
+			"name": "android_wifi_4_bar_off"
+		},
+		{
+			"codepoint": 61202,
+			"name": "android_wifi_4_bar_plus"
+		},
+		{
+			"codepoint": 61201,
+			"name": "android_wifi_4_bar_question"
+		},
+		{
+			"codepoint": 62618,
+			"name": "animated_images"
+		},
+		{
+			"codepoint": 59164,
+			"name": "animation"
+		},
+		{
+			"codepoint": 59519,
+			"name": "announcement"
+		},
+		{
+			"codepoint": 1048530,
+			"name": "antigravity"
+		},
+		{
+			"codepoint": 62182,
+			"name": "aod"
+		},
+		{
+			"codepoint": 63647,
+			"name": "aod_tablet"
+		},
+		{
+			"codepoint": 63148,
+			"name": "aod_watch"
+		},
+		{
+			"codepoint": 59968,
+			"name": "apartment"
+		},
+		{
+			"codepoint": 61879,
+			"name": "api"
+		},
+		{
+			"codepoint": 63630,
+			"name": "apk_document"
+		},
+		{
+			"codepoint": 63631,
+			"name": "apk_install"
+		},
+		{
+			"codepoint": 63279,
+			"name": "app_badging"
+		},
+		{
+			"codepoint": 62181,
+			"name": "app_blocking"
+		},
+		{
+			"codepoint": 62157,
+			"name": "app_promo"
+		},
+		{
+			"codepoint": 61248,
+			"name": "app_registration"
+		},
+		{
+			"codepoint": 62169,
+			"name": "app_settings_alt"
+		},
+		{
+			"codepoint": 62175,
+			"name": "app_shortcut"
+		},
+		{
+			"codepoint": 61307,
+			"name": "apparel"
+		},
+		{
+			"codepoint": 59778,
+			"name": "approval"
+		},
+		{
+			"codepoint": 63562,
+			"name": "approval_delegation"
+		},
+		{
+			"codepoint": 62149,
+			"name": "approval_delegation_off"
+		},
+		{
+			"codepoint": 58819,
+			"name": "apps"
+		},
+		{
+			"codepoint": 59340,
+			"name": "apps_outage"
+		},
+		{
+			"codepoint": 62810,
+			"name": "aq"
+		},
+		{
+			"codepoint": 62811,
+			"name": "aq_indoor"
+		},
+		{
+			"codepoint": 61308,
+			"name": "ar_on_you"
+		},
+		{
+			"codepoint": 59779,
+			"name": "ar_stickers"
+		},
+		{
+			"codepoint": 59963,
+			"name": "architecture"
+		},
+		{
+			"codepoint": 57673,
+			"name": "archive"
+		},
+		{
+			"codepoint": 59248,
+			"name": "area_chart"
+		},
+		{
+			"codepoint": 59274,
+			"name": "arming_countdown"
+		},
+		{
+			"codepoint": 62935,
+			"name": "arrow_and_edge"
+		},
+		{
+			"codepoint": 58820,
+			"name": "arrow_back"
+		},
+		{
+			"codepoint": 62522,
+			"name": "arrow_back_2"
+		},
+		{
+			"codepoint": 58848,
+			"name": "arrow_back_ios"
+		},
+		{
+			"codepoint": 58090,
+			"name": "arrow_back_ios_new"
+		},
+		{
+			"codepoint": 61825,
+			"name": "arrow_circle_down"
+		},
+		{
+			"codepoint": 60071,
+			"name": "arrow_circle_left"
+		},
+		{
+			"codepoint": 60074,
+			"name": "arrow_circle_right"
+		},
+		{
+			"codepoint": 61826,
+			"name": "arrow_circle_up"
+		},
+		{
+			"codepoint": 62646,
+			"name": "arrow_cool_down"
+		},
+		{
+			"codepoint": 58843,
+			"name": "arrow_downward"
+		},
+		{
+			"codepoint": 59780,
+			"name": "arrow_downward_alt"
+		},
+		{
+			"codepoint": 58821,
+			"name": "arrow_drop_down"
+		},
+		{
+			"codepoint": 58822,
+			"name": "arrow_drop_down_circle"
+		},
+		{
+			"codepoint": 58823,
+			"name": "arrow_drop_up"
+		},
+		{
+			"codepoint": 58824,
+			"name": "arrow_forward"
+		},
+		{
+			"codepoint": 58849,
+			"name": "arrow_forward_ios"
+		},
+		{
+			"codepoint": 63543,
+			"name": "arrow_insert"
+		},
+		{
+			"codepoint": 58846,
+			"name": "arrow_left"
+		},
+		{
+			"codepoint": 61309,
+			"name": "arrow_left_alt"
+		},
+		{
+			"codepoint": 62419,
+			"name": "arrow_menu_close"
+		},
+		{
+			"codepoint": 62418,
+			"name": "arrow_menu_open"
+		},
+		{
+			"codepoint": 62934,
+			"name": "arrow_or_edge"
+		},
+		{
+			"codepoint": 63694,
+			"name": "arrow_outward"
+		},
+		{
+			"codepoint": 63131,
+			"name": "arrow_range"
+		},
+		{
+			"codepoint": 58847,
+			"name": "arrow_right"
+		},
+		{
+			"codepoint": 59713,
+			"name": "arrow_right_alt"
+		},
+		{
+			"codepoint": 63535,
+			"name": "arrow_selector_tool"
+		},
+		{
+			"codepoint": 61174,
+			"name": "arrow_shape_up"
+		},
+		{
+			"codepoint": 61175,
+			"name": "arrow_shape_up_stack"
+		},
+		{
+			"codepoint": 61176,
+			"name": "arrow_shape_up_stack_2"
+		},
+		{
+			"codepoint": 59908,
+			"name": "arrow_split"
+		},
+		{
+			"codepoint": 63278,
+			"name": "arrow_top_left"
+		},
+		{
+			"codepoint": 63277,
+			"name": "arrow_top_right"
+		},
+		{
+			"codepoint": 62452,
+			"name": "arrow_upload_progress"
+		},
+		{
+			"codepoint": 62453,
+			"name": "arrow_upload_ready"
+		},
+		{
+			"codepoint": 58840,
+			"name": "arrow_upward"
+		},
+		{
+			"codepoint": 59782,
+			"name": "arrow_upward_alt"
+		},
+		{
+			"codepoint": 62645,
+			"name": "arrow_warm_up"
+		},
+		{
+			"codepoint": 62356,
+			"name": "arrows_input"
+		},
+		{
+			"codepoint": 61156,
+			"name": "arrows_left_right_circle"
+		},
+		{
+			"codepoint": 63659,
+			"name": "arrows_more_down"
+		},
+		{
+			"codepoint": 63660,
+			"name": "arrows_more_up"
+		},
+		{
+			"codepoint": 62355,
+			"name": "arrows_output"
+		},
+		{
+			"codepoint": 63276,
+			"name": "arrows_outward"
+		},
+		{
+			"codepoint": 61155,
+			"name": "arrows_up_down_circle"
+		},
+		{
+			"codepoint": 57440,
+			"name": "art_track"
+		},
+		{
+			"codepoint": 61319,
+			"name": "article"
+		},
+		{
+			"codepoint": 62312,
+			"name": "article_person"
+		},
+		{
+			"codepoint": 62855,
+			"name": "article_shortcut"
+		},
+		{
+			"codepoint": 57370,
+			"name": "artist"
+		},
+		{
+			"codepoint": 59483,
+			"name": "aspect_ratio"
+		},
+		{
+			"codepoint": 61644,
+			"name": "assessment"
+		},
+		{
+			"codepoint": 59485,
+			"name": "assignment"
+		},
+		{
+			"codepoint": 63560,
+			"name": "assignment_add"
+		},
+		{
+			"codepoint": 61164,
+			"name": "assignment_globe"
+		},
+		{
+			"codepoint": 59486,
+			"name": "assignment_ind"
+		},
+		{
+			"codepoint": 59487,
+			"name": "assignment_late"
+		},
+		{
+			"codepoint": 59488,
+			"name": "assignment_return"
+		},
+		{
+			"codepoint": 59489,
+			"name": "assignment_returned"
+		},
+		{
+			"codepoint": 59490,
+			"name": "assignment_turned_in"
+		},
+		{
+			"codepoint": 63701,
+			"name": "assist_walker"
+		},
+		{
+			"codepoint": 58271,
+			"name": "assistant"
+		},
+		{
+			"codepoint": 59783,
+			"name": "assistant_device"
+		},
+		{
+			"codepoint": 59784,
+			"name": "assistant_direction"
+		},
+		{
+			"codepoint": 59785,
+			"name": "assistant_navigation"
+		},
+		{
+			"codepoint": 63169,
+			"name": "assistant_on_hub"
+		},
+		{
+			"codepoint": 61638,
+			"name": "assistant_photo"
+		},
+		{
+			"codepoint": 60271,
+			"name": "assured_workload"
+		},
+		{
+			"codepoint": 62757,
+			"name": "asterisk"
+		},
+		{
+			"codepoint": 61913,
+			"name": "astrophotography_auto"
+		},
+		{
+			"codepoint": 61914,
+			"name": "astrophotography_off"
+		},
+		{
+			"codepoint": 58739,
+			"name": "atm"
+		},
+		{
+			"codepoint": 60359,
+			"name": "atr"
+		},
+		{
+			"codepoint": 59998,
+			"name": "attach_email"
+		},
+		{
+			"codepoint": 57894,
+			"name": "attach_file"
+		},
+		{
+			"codepoint": 63553,
+			"name": "attach_file_add"
+		},
+		{
+			"codepoint": 62681,
+			"name": "attach_file_off"
+		},
+		{
+			"codepoint": 57895,
+			"name": "attach_money"
+		},
+		{
+			"codepoint": 58044,
+			"name": "attachment"
+		},
+		{
+			"codepoint": 59986,
+			"name": "attractions"
+		},
+		{
+			"codepoint": 61403,
+			"name": "attribution"
+		},
+		{
+			"codepoint": 1048323,
+			"name": "audio_capture"
+		},
+		{
+			"codepoint": 62860,
+			"name": "audio_description"
+		},
+		{
+			"codepoint": 60290,
+			"name": "audio_file"
+		},
+		{
+			"codepoint": 62931,
+			"name": "audio_video_receiver"
+		},
+		{
+			"codepoint": 58373,
+			"name": "audiotrack"
+		},
+		{
+			"codepoint": 63661,
+			"name": "auto_activity_zone"
+		},
+		{
+			"codepoint": 58975,
+			"name": "auto_awesome"
+		},
+		{
+			"codepoint": 58976,
+			"name": "auto_awesome_mosaic"
+		},
+		{
+			"codepoint": 58977,
+			"name": "auto_awesome_motion"
+		},
+		{
+			"codepoint": 59980,
+			"name": "auto_delete"
+		},
+		{
+			"codepoint": 63550,
+			"name": "auto_detect_voice"
+		},
+		{
+			"codepoint": 59786,
+			"name": "auto_draw_solid"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix"
+		},
+		{
+			"codepoint": 58979,
+			"name": "auto_fix_high"
+		},
+		{
+			"codepoint": 58980,
+			"name": "auto_fix_normal"
+		},
+		{
+			"codepoint": 58981,
+			"name": "auto_fix_off"
+		},
+		{
+			"codepoint": 58619,
+			"name": "auto_graph"
+		},
+		{
+			"codepoint": 63166,
+			"name": "auto_label"
+		},
+		{
+			"codepoint": 63167,
+			"name": "auto_meeting_room"
+		},
+		{
+			"codepoint": 60448,
+			"name": "auto_mode"
+		},
+		{
+			"codepoint": 61977,
+			"name": "auto_read_pause"
+		},
+		{
+			"codepoint": 61974,
+			"name": "auto_read_play"
+		},
+		{
+			"codepoint": 57876,
+			"name": "auto_schedule"
+		},
+		{
+			"codepoint": 58982,
+			"name": "auto_stories"
+		},
+		{
+			"codepoint": 62055,
+			"name": "auto_stories_off"
+		},
+		{
+			"codepoint": 61311,
+			"name": "auto_timer"
+		},
+		{
+			"codepoint": 59166,
+			"name": "auto_towing"
+		},
+		{
+			"codepoint": 62783,
+			"name": "auto_transmission"
+		},
+		{
+			"codepoint": 63168,
+			"name": "auto_videocam"
+		},
+		{
+			"codepoint": 61404,
+			"name": "autofps_select"
+		},
+		{
+			"codepoint": 62497,
+			"name": "automation"
+		},
+		{
+			"codepoint": 63158,
+			"name": "autopause"
+		},
+		{
+			"codepoint": 63563,
+			"name": "autopay"
+		},
+		{
+			"codepoint": 63157,
+			"name": "autoplay"
+		},
+		{
+			"codepoint": 59491,
+			"name": "autorenew"
+		},
+		{
+			"codepoint": 63106,
+			"name": "autostop"
+		},
+		{
+			"codepoint": 62640,
+			"name": "av1"
+		},
+		{
+			"codepoint": 57371,
+			"name": "av_timer"
+		},
+		{
+			"codepoint": 62639,
+			"name": "avc"
+		},
+		{
+			"codepoint": 63163,
+			"name": "avg_pace"
+		},
+		{
+			"codepoint": 63507,
+			"name": "avg_time"
+		},
+		{
+			"codepoint": 1048487,
+			"name": "avocado_bean"
+		},
+		{
+			"codepoint": 62017,
+			"name": "award_meal"
+		},
+		{
+			"codepoint": 62994,
+			"name": "award_star"
+		},
+		{
+			"codepoint": 63212,
+			"name": "azm"
+		},
+		{
+			"codepoint": 61154,
+			"name": "b_circle"
+		},
+		{
+			"codepoint": 61851,
+			"name": "baby_changing_station"
+		},
+		{
+			"codepoint": 59236,
+			"name": "back_hand"
+		},
+		{
+			"codepoint": 63275,
+			"name": "back_to_tab"
+		},
+		{
+			"codepoint": 63390,
+			"name": "background_dot_large"
+		},
+		{
+			"codepoint": 62740,
+			"name": "background_dot_small"
+		},
+		{
+			"codepoint": 63389,
+			"name": "background_grid_small"
+		},
+		{
+			"codepoint": 61962,
+			"name": "background_replace"
+		},
+		{
+			"codepoint": 63469,
+			"name": "backlight_high"
+		},
+		{
+			"codepoint": 62703,
+			"name": "backlight_high_off"
+		},
+		{
+			"codepoint": 63468,
+			"name": "backlight_low"
+		},
+		{
+			"codepoint": 61852,
+			"name": "backpack"
+		},
+		{
+			"codepoint": 57674,
+			"name": "backspace"
+		},
+		{
+			"codepoint": 59492,
+			"name": "backup"
+		},
+		{
+			"codepoint": 61251,
+			"name": "backup_table"
+		},
+		{
+			"codepoint": 60007,
+			"name": "badge"
+		},
+		{
+			"codepoint": 61782,
+			"name": "badge_critical_battery"
+		},
+		{
+			"codepoint": 62120,
+			"name": "badminton"
+		},
+		{
+			"codepoint": 59987,
+			"name": "bakery_dining"
+		},
+		{
+			"codepoint": 60150,
+			"name": "balance"
+		},
+		{
+			"codepoint": 58767,
+			"name": "balcony"
+		},
+		{
+			"codepoint": 57714,
+			"name": "ballot"
+		},
+		{
+			"codepoint": 57963,
+			"name": "bar_chart"
+		},
+		{
+			"codepoint": 63105,
+			"name": "bar_chart_4_bars"
+		},
+		{
+			"codepoint": 62481,
+			"name": "bar_chart_off"
+		},
+		{
+			"codepoint": 59147,
+			"name": "barcode"
+		},
+		{
+			"codepoint": 63580,
+			"name": "barcode_reader"
+		},
+		{
+			"codepoint": 59148,
+			"name": "barcode_scanner"
+		},
+		{
+			"codepoint": 63601,
+			"name": "barefoot"
+		},
+		{
+			"codepoint": 61685,
+			"name": "batch_prediction"
+		},
+		{
+			"codepoint": 62086,
+			"name": "bath_bedrock"
+		},
+		{
+			"codepoint": 63227,
+			"name": "bath_outdoor"
+		},
+		{
+			"codepoint": 63226,
+			"name": "bath_private"
+		},
+		{
+			"codepoint": 63225,
+			"name": "bath_public_large"
+		},
+		{
+			"codepoint": 62112,
+			"name": "bath_soak"
+		},
+		{
+			"codepoint": 61405,
+			"name": "bathroom"
+		},
+		{
+			"codepoint": 59969,
+			"name": "bathtub"
+		},
+		{
+			"codepoint": 60380,
+			"name": "battery_0_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_1_bar"
+		},
+		{
+			"codepoint": 61596,
+			"name": "battery_20"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_2_bar"
+		},
+		{
+			"codepoint": 61597,
+			"name": "battery_30"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_3_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_4_bar"
+		},
+		{
+			"codepoint": 61598,
+			"name": "battery_50"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_5_bar"
+		},
+		{
+			"codepoint": 61599,
+			"name": "battery_60"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_6_bar"
+		},
+		{
+			"codepoint": 61600,
+			"name": "battery_80"
+		},
+		{
+			"codepoint": 61601,
+			"name": "battery_90"
+		},
+		{
+			"codepoint": 57756,
+			"name": "battery_alert"
+		},
+		{
+			"codepoint": 62221,
+			"name": "battery_android_0"
+		},
+		{
+			"codepoint": 62220,
+			"name": "battery_android_1"
+		},
+		{
+			"codepoint": 62219,
+			"name": "battery_android_2"
+		},
+		{
+			"codepoint": 62218,
+			"name": "battery_android_3"
+		},
+		{
+			"codepoint": 62217,
+			"name": "battery_android_4"
+		},
+		{
+			"codepoint": 62216,
+			"name": "battery_android_5"
+		},
+		{
+			"codepoint": 62215,
+			"name": "battery_android_6"
+		},
+		{
+			"codepoint": 62214,
+			"name": "battery_android_alert"
+		},
+		{
+			"codepoint": 62213,
+			"name": "battery_android_bolt"
+		},
+		{
+			"codepoint": 62039,
+			"name": "battery_android_frame_1"
+		},
+		{
+			"codepoint": 62038,
+			"name": "battery_android_frame_2"
+		},
+		{
+			"codepoint": 62037,
+			"name": "battery_android_frame_3"
+		},
+		{
+			"codepoint": 62036,
+			"name": "battery_android_frame_4"
+		},
+		{
+			"codepoint": 62035,
+			"name": "battery_android_frame_5"
+		},
+		{
+			"codepoint": 62034,
+			"name": "battery_android_frame_6"
+		},
+		{
+			"codepoint": 62033,
+			"name": "battery_android_frame_alert"
+		},
+		{
+			"codepoint": 62032,
+			"name": "battery_android_frame_bolt"
+		},
+		{
+			"codepoint": 62031,
+			"name": "battery_android_frame_full"
+		},
+		{
+			"codepoint": 62030,
+			"name": "battery_android_frame_plus"
+		},
+		{
+			"codepoint": 62029,
+			"name": "battery_android_frame_question"
+		},
+		{
+			"codepoint": 62028,
+			"name": "battery_android_frame_share"
+		},
+		{
+			"codepoint": 62027,
+			"name": "battery_android_frame_shield"
+		},
+		{
+			"codepoint": 62212,
+			"name": "battery_android_full"
+		},
+		{
+			"codepoint": 62211,
+			"name": "battery_android_plus"
+		},
+		{
+			"codepoint": 62210,
+			"name": "battery_android_question"
+		},
+		{
+			"codepoint": 62209,
+			"name": "battery_android_share"
+		},
+		{
+			"codepoint": 62208,
+			"name": "battery_android_shield"
+		},
+		{
+			"codepoint": 63467,
+			"name": "battery_change"
+		},
+		{
+			"codepoint": 61602,
+			"name": "battery_charging_20"
+		},
+		{
+			"codepoint": 1048382,
+			"name": "battery_charging_20_2"
+		},
+		{
+			"codepoint": 61603,
+			"name": "battery_charging_30"
+		},
+		{
+			"codepoint": 1048381,
+			"name": "battery_charging_30_2"
+		},
+		{
+			"codepoint": 61604,
+			"name": "battery_charging_50"
+		},
+		{
+			"codepoint": 1048380,
+			"name": "battery_charging_50_2"
+		},
+		{
+			"codepoint": 61605,
+			"name": "battery_charging_60"
+		},
+		{
+			"codepoint": 1048379,
+			"name": "battery_charging_60_2"
+		},
+		{
+			"codepoint": 61606,
+			"name": "battery_charging_80"
+		},
+		{
+			"codepoint": 1048378,
+			"name": "battery_charging_80_2"
+		},
+		{
+			"codepoint": 61607,
+			"name": "battery_charging_90"
+		},
+		{
+			"codepoint": 57763,
+			"name": "battery_charging_full"
+		},
+		{
+			"codepoint": 1048377,
+			"name": "battery_charging_full_2"
+		},
+		{
+			"codepoint": 63466,
+			"name": "battery_error"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_full"
+		},
+		{
+			"codepoint": 61755,
+			"name": "battery_full_alt"
+		},
+		{
+			"codepoint": 63662,
+			"name": "battery_horiz_000"
+		},
+		{
+			"codepoint": 63663,
+			"name": "battery_horiz_050"
+		},
+		{
+			"codepoint": 63664,
+			"name": "battery_horiz_075"
+		},
+		{
+			"codepoint": 61781,
+			"name": "battery_low"
+		},
+		{
+			"codepoint": 63465,
+			"name": "battery_plus"
+		},
+		{
+			"codepoint": 57862,
+			"name": "battery_profile"
+		},
+		{
+			"codepoint": 61406,
+			"name": "battery_saver"
+		},
+		{
+			"codepoint": 63102,
+			"name": "battery_share"
+		},
+		{
+			"codepoint": 63101,
+			"name": "battery_status_good"
+		},
+		{
+			"codepoint": 57765,
+			"name": "battery_std"
+		},
+		{
+			"codepoint": 57766,
+			"name": "battery_unknown"
+		},
+		{
+			"codepoint": 63665,
+			"name": "battery_vert_005"
+		},
+		{
+			"codepoint": 63666,
+			"name": "battery_vert_020"
+		},
+		{
+			"codepoint": 63667,
+			"name": "battery_vert_050"
+		},
+		{
+			"codepoint": 61782,
+			"name": "battery_very_low"
+		},
+		{
+			"codepoint": 60222,
+			"name": "beach_access"
+		},
+		{
+			"codepoint": 61407,
+			"name": "bed"
+		},
+		{
+			"codepoint": 61408,
+			"name": "bedroom_baby"
+		},
+		{
+			"codepoint": 61409,
+			"name": "bedroom_child"
+		},
+		{
+			"codepoint": 61410,
+			"name": "bedroom_parent"
+		},
+		{
+			"codepoint": 61785,
+			"name": "bedtime"
+		},
+		{
+			"codepoint": 60278,
+			"name": "bedtime_off"
+		},
+		{
+			"codepoint": 58669,
+			"name": "beenhere"
+		},
+		{
+			"codepoint": 62085,
+			"name": "beer_meal"
+		},
+		{
+			"codepoint": 61940,
+			"name": "bento"
+		},
+		{
+			"codepoint": 63211,
+			"name": "bia"
+		},
+		{
+			"codepoint": 59000,
+			"name": "bid_landscape"
+		},
+		{
+			"codepoint": 61313,
+			"name": "bid_landscape_disabled"
+		},
+		{
+			"codepoint": 58985,
+			"name": "bigtop_updates"
+		},
+		{
+			"codepoint": 62587,
+			"name": "bike_dock"
+		},
+		{
+			"codepoint": 62586,
+			"name": "bike_lane"
+		},
+		{
+			"codepoint": 61253,
+			"name": "bike_scooter"
+		},
+		{
+			"codepoint": 59962,
+			"name": "biotech"
+		},
+		{
+			"codepoint": 59432,
+			"name": "blanket"
+		},
+		{
+			"codepoint": 61411,
+			"name": "blender"
+		},
+		{
+			"codepoint": 63702,
+			"name": "blind"
+		},
+		{
+			"codepoint": 57990,
+			"name": "blinds"
+		},
+		{
+			"codepoint": 1048440,
+			"name": "blinds_2"
+		},
+		{
+			"codepoint": 1048441,
+			"name": "blinds_2_closed"
+		},
+		{
+			"codepoint": 60447,
+			"name": "blinds_closed"
+		},
+		{
+			"codepoint": 61580,
+			"name": "block"
+		},
+		{
+			"codepoint": 57495,
+			"name": "blood_pressure"
+		},
+		{
+			"codepoint": 61412,
+			"name": "bloodtype"
+		},
+		{
+			"codepoint": 57767,
+			"name": "bluetooth"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_audio"
+		},
+		{
+			"codepoint": 57768,
+			"name": "bluetooth_connected"
+		},
+		{
+			"codepoint": 57769,
+			"name": "bluetooth_disabled"
+		},
+		{
+			"codepoint": 61413,
+			"name": "bluetooth_drive"
+		},
+		{
+			"codepoint": 58895,
+			"name": "bluetooth_searching"
+		},
+		{
+			"codepoint": 58274,
+			"name": "blur_circular"
+		},
+		{
+			"codepoint": 58275,
+			"name": "blur_linear"
+		},
+		{
+			"codepoint": 59468,
+			"name": "blur_medium"
+		},
+		{
+			"codepoint": 58276,
+			"name": "blur_off"
+		},
+		{
+			"codepoint": 58277,
+			"name": "blur_on"
+		},
+		{
+			"codepoint": 59599,
+			"name": "blur_short"
+		},
+		{
+			"codepoint": 62317,
+			"name": "boat_bus"
+		},
+		{
+			"codepoint": 62316,
+			"name": "boat_railway"
+		},
+		{
+			"codepoint": 57496,
+			"name": "body_fat"
+		},
+		{
+			"codepoint": 57497,
+			"name": "body_system"
+		},
+		{
+			"codepoint": 59915,
+			"name": "bolt"
+		},
+		{
+			"codepoint": 1048426,
+			"name": "bolt_boost"
+		},
+		{
+			"codepoint": 62824,
+			"name": "bomb"
+		},
+		{
+			"codepoint": 59502,
+			"name": "book"
+		},
+		{
+			"codepoint": 62782,
+			"name": "book_2"
+		},
+		{
+			"codepoint": 62781,
+			"name": "book_3"
+		},
+		{
+			"codepoint": 62780,
+			"name": "book_4"
+		},
+		{
+			"codepoint": 62779,
+			"name": "book_5"
+		},
+		{
+			"codepoint": 62431,
+			"name": "book_6"
+		},
+		{
+			"codepoint": 62180,
+			"name": "book_online"
+		},
+		{
+			"codepoint": 62439,
+			"name": "book_ribbon"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark"
+		},
+		{
+			"codepoint": 58776,
+			"name": "bookmark_add"
+		},
+		{
+			"codepoint": 58777,
+			"name": "bookmark_added"
+		},
+		{
+			"codepoint": 62480,
+			"name": "bookmark_bag"
+		},
+		{
+			"codepoint": 59623,
+			"name": "bookmark_border"
+		},
+		{
+			"codepoint": 62551,
+			"name": "bookmark_check"
+		},
+		{
+			"codepoint": 62550,
+			"name": "bookmark_flag"
+		},
+		{
+			"codepoint": 62549,
+			"name": "bookmark_heart"
+		},
+		{
+			"codepoint": 63409,
+			"name": "bookmark_manager"
+		},
+		{
+			"codepoint": 58778,
+			"name": "bookmark_remove"
+		},
+		{
+			"codepoint": 61160,
+			"name": "bookmark_stacks"
+		},
+		{
+			"codepoint": 62548,
+			"name": "bookmark_star"
+		},
+		{
+			"codepoint": 59787,
+			"name": "bookmarks"
+		},
+		{
+			"codepoint": 61314,
+			"name": "books_movies_and_music"
+		},
+		{
+			"codepoint": 57896,
+			"name": "border_all"
+		},
+		{
+			"codepoint": 57897,
+			"name": "border_bottom"
+		},
+		{
+			"codepoint": 57898,
+			"name": "border_clear"
+		},
+		{
+			"codepoint": 57899,
+			"name": "border_color"
+		},
+		{
+			"codepoint": 57900,
+			"name": "border_horizontal"
+		},
+		{
+			"codepoint": 57901,
+			"name": "border_inner"
+		},
+		{
+			"codepoint": 57902,
+			"name": "border_left"
+		},
+		{
+			"codepoint": 57903,
+			"name": "border_outer"
+		},
+		{
+			"codepoint": 57904,
+			"name": "border_right"
+		},
+		{
+			"codepoint": 57905,
+			"name": "border_style"
+		},
+		{
+			"codepoint": 57906,
+			"name": "border_top"
+		},
+		{
+			"codepoint": 57907,
+			"name": "border_vertical"
+		},
+		{
+			"codepoint": 62477,
+			"name": "borg"
+		},
+		{
+			"codepoint": 59184,
+			"name": "bottom_app_bar"
+		},
+		{
+			"codepoint": 59181,
+			"name": "bottom_drawer"
+		},
+		{
+			"codepoint": 59788,
+			"name": "bottom_navigation"
+		},
+		{
+			"codepoint": 63274,
+			"name": "bottom_panel_close"
+		},
+		{
+			"codepoint": 63273,
+			"name": "bottom_panel_open"
+		},
+		{
+			"codepoint": 63108,
+			"name": "bottom_right_click"
+		},
+		{
+			"codepoint": 59789,
+			"name": "bottom_sheets"
+		},
+		{
+			"codepoint": 62884,
+			"name": "box"
+		},
+		{
+			"codepoint": 62885,
+			"name": "box_add"
+		},
+		{
+			"codepoint": 62886,
+			"name": "box_edit"
+		},
+		{
+			"codepoint": 60263,
+			"name": "boy"
+		},
+		{
+			"codepoint": 59790,
+			"name": "brand_awareness"
+		},
+		{
+			"codepoint": 62705,
+			"name": "brand_family"
+		},
+		{
+			"codepoint": 57451,
+			"name": "branding_watermark"
+		},
+		{
+			"codepoint": 59988,
+			"name": "breakfast_dining"
+		},
+		{
+			"codepoint": 59912,
+			"name": "breaking_news"
+		},
+		{
+			"codepoint": 61626,
+			"name": "breaking_news_alt_1"
+		},
+		{
+			"codepoint": 63574,
+			"name": "breastfeeding"
+		},
+		{
+			"codepoint": 62344,
+			"name": "brick"
+		},
+		{
+			"codepoint": 62022,
+			"name": "briefcase_meal"
+		},
+		{
+			"codepoint": 58362,
+			"name": "brightness_1"
+		},
+		{
+			"codepoint": 61494,
+			"name": "brightness_2"
+		},
+		{
+			"codepoint": 58280,
+			"name": "brightness_3"
+		},
+		{
+			"codepoint": 58281,
+			"name": "brightness_4"
+		},
+		{
+			"codepoint": 58282,
+			"name": "brightness_5"
+		},
+		{
+			"codepoint": 58283,
+			"name": "brightness_6"
+		},
+		{
+			"codepoint": 58284,
+			"name": "brightness_7"
+		},
+		{
+			"codepoint": 62927,
+			"name": "brightness_alert"
+		},
+		{
+			"codepoint": 57771,
+			"name": "brightness_auto"
+		},
+		{
+			"codepoint": 63464,
+			"name": "brightness_empty"
+		},
+		{
+			"codepoint": 57772,
+			"name": "brightness_high"
+		},
+		{
+			"codepoint": 57773,
+			"name": "brightness_low"
+		},
+		{
+			"codepoint": 57774,
+			"name": "brightness_medium"
+		},
+		{
+			"codepoint": 57366,
+			"name": "bring_your_own_ip"
+		},
+		{
+			"codepoint": 63736,
+			"name": "broadcast_on_home"
+		},
+		{
+			"codepoint": 63737,
+			"name": "broadcast_on_personal"
+		},
+		{
+			"codepoint": 58285,
+			"name": "broken_image"
+		},
+		{
+			"codepoint": 60179,
+			"name": "browse"
+		},
+		{
+			"codepoint": 63653,
+			"name": "browse_activity"
+		},
+		{
+			"codepoint": 60369,
+			"name": "browse_gallery"
+		},
+		{
+			"codepoint": 61255,
+			"name": "browser_not_supported"
+		},
+		{
+			"codepoint": 59343,
+			"name": "browser_updated"
+		},
+		{
+			"codepoint": 60019,
+			"name": "brunch_dining"
+		},
+		{
+			"codepoint": 58286,
+			"name": "brush"
+		},
+		{
+			"codepoint": 61315,
+			"name": "bubble"
+		},
+		{
+			"codepoint": 59101,
+			"name": "bubble_chart"
+		},
+		{
+			"codepoint": 63054,
+			"name": "bubbles"
+		},
+		{
+			"codepoint": 61226,
+			"name": "bucket_check"
+		},
+		{
+			"codepoint": 59496,
+			"name": "bug_report"
+		},
+		{
+			"codepoint": 63693,
+			"name": "build"
+		},
+		{
+			"codepoint": 61256,
+			"name": "build_circle"
+		},
+		{
+			"codepoint": 58769,
+			"name": "bungalow"
+		},
+		{
+			"codepoint": 58428,
+			"name": "burst_mode"
+		},
+		{
+			"codepoint": 59791,
+			"name": "bus_alert"
+		},
+		{
+			"codepoint": 1048482,
+			"name": "bus_map_pin"
+		},
+		{
+			"codepoint": 62315,
+			"name": "bus_railway"
+		},
+		{
+			"codepoint": 59374,
+			"name": "business"
+		},
+		{
+			"codepoint": 60223,
+			"name": "business_center"
+		},
+		{
+			"codepoint": 63564,
+			"name": "business_chip"
+		},
+		{
+			"codepoint": 61316,
+			"name": "business_messages"
+		},
+		{
+			"codepoint": 59183,
+			"name": "buttons_alt"
+		},
+		{
+			"codepoint": 58761,
+			"name": "cabin"
+		},
+		{
+			"codepoint": 61414,
+			"name": "cable"
+		},
+		{
+			"codepoint": 62585,
+			"name": "cable_car"
+		},
+		{
+			"codepoint": 59498,
+			"name": "cached"
+		},
+		{
+			"codepoint": 62644,
+			"name": "cadence"
+		},
+		{
+			"codepoint": 59369,
+			"name": "cake"
+		},
+		{
+			"codepoint": 63579,
+			"name": "cake_add"
+		},
+		{
+			"codepoint": 59999,
+			"name": "calculate"
+		},
+		{
+			"codepoint": 61317,
+			"name": "calendar_add_on"
+		},
+		{
+			"codepoint": 61627,
+			"name": "calendar_apps_script"
+		},
+		{
+			"codepoint": 62019,
+			"name": "calendar_check"
+		},
+		{
+			"codepoint": 62784,
+			"name": "calendar_clock"
+		},
+		{
+			"codepoint": 62018,
+			"name": "calendar_lock"
+		},
+		{
+			"codepoint": 62102,
+			"name": "calendar_meal"
+		},
+		{
+			"codepoint": 62016,
+			"name": "calendar_meal_2"
+		},
+		{
+			"codepoint": 60364,
+			"name": "calendar_month"
+		},
+		{
+			"codepoint": 59701,
+			"name": "calendar_today"
+		},
+		{
+			"codepoint": 59702,
+			"name": "calendar_view_day"
+		},
+		{
+			"codepoint": 61415,
+			"name": "calendar_view_month"
+		},
+		{
+			"codepoint": 61416,
+			"name": "calendar_view_week"
+		},
+		{
+			"codepoint": 61652,
+			"name": "call"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end"
+		},
+		{
+			"codepoint": 61628,
+			"name": "call_end_alt"
+		},
+		{
+			"codepoint": 57486,
+			"name": "call_log"
+		},
+		{
+			"codepoint": 57522,
+			"name": "call_made"
+		},
+		{
+			"codepoint": 57523,
+			"name": "call_merge"
+		},
+		{
+			"codepoint": 57524,
+			"name": "call_missed"
+		},
+		{
+			"codepoint": 57572,
+			"name": "call_missed_outgoing"
+		},
+		{
+			"codepoint": 63058,
+			"name": "call_quality"
+		},
+		{
+			"codepoint": 57525,
+			"name": "call_received"
+		},
+		{
+			"codepoint": 57526,
+			"name": "call_split"
+		},
+		{
+			"codepoint": 57452,
+			"name": "call_to_action"
+		},
+		{
+			"codepoint": 58287,
+			"name": "camera"
+		},
+		{
+			"codepoint": 58386,
+			"name": "camera_alt"
+		},
+		{
+			"codepoint": 59644,
+			"name": "camera_enhance"
+		},
+		{
+			"codepoint": 62153,
+			"name": "camera_front"
+		},
+		{
+			"codepoint": 61417,
+			"name": "camera_indoor"
+		},
+		{
+			"codepoint": 61418,
+			"name": "camera_outdoor"
+		},
+		{
+			"codepoint": 62152,
+			"name": "camera_rear"
+		},
+		{
+			"codepoint": 58291,
+			"name": "camera_roll"
+		},
+		{
+			"codepoint": 63398,
+			"name": "camera_video"
+		},
+		{
+			"codepoint": 61419,
+			"name": "cameraswitch"
+		},
+		{
+			"codepoint": 61257,
+			"name": "campaign"
+		},
+		{
+			"codepoint": 63650,
+			"name": "camping"
+		},
+		{
+			"codepoint": 59528,
+			"name": "cancel"
+		},
+		{
+			"codepoint": 57577,
+			"name": "cancel_presentation"
+		},
+		{
+			"codepoint": 59961,
+			"name": "cancel_schedule_send"
+		},
+		{
+			"codepoint": 62856,
+			"name": "candle"
+		},
+		{
+			"codepoint": 60116,
+			"name": "candlestick_chart"
+		},
+		{
+			"codepoint": 62195,
+			"name": "cannabis"
+		},
+		{
+			"codepoint": 63272,
+			"name": "captive_portal"
+		},
+		{
+			"codepoint": 63271,
+			"name": "capture"
+		},
+		{
+			"codepoint": 60402,
+			"name": "car_crash"
+		},
+		{
+			"codepoint": 62276,
+			"name": "car_defrost_left"
+		},
+		{
+			"codepoint": 62275,
+			"name": "car_defrost_low_left"
+		},
+		{
+			"codepoint": 62274,
+			"name": "car_defrost_low_right"
+		},
+		{
+			"codepoint": 62072,
+			"name": "car_defrost_mid_left"
+		},
+		{
+			"codepoint": 62273,
+			"name": "car_defrost_mid_low_left"
+		},
+		{
+			"codepoint": 62071,
+			"name": "car_defrost_mid_low_right"
+		},
+		{
+			"codepoint": 62272,
+			"name": "car_defrost_mid_right"
+		},
+		{
+			"codepoint": 62271,
+			"name": "car_defrost_right"
+		},
+		{
+			"codepoint": 62270,
+			"name": "car_fan_low_left"
+		},
+		{
+			"codepoint": 62269,
+			"name": "car_fan_low_mid_left"
+		},
+		{
+			"codepoint": 62268,
+			"name": "car_fan_low_right"
+		},
+		{
+			"codepoint": 62267,
+			"name": "car_fan_mid_left"
+		},
+		{
+			"codepoint": 62266,
+			"name": "car_fan_mid_low_right"
+		},
+		{
+			"codepoint": 62265,
+			"name": "car_fan_mid_right"
+		},
+		{
+			"codepoint": 62264,
+			"name": "car_fan_recirculate"
+		},
+		{
+			"codepoint": 1048384,
+			"name": "car_fan_recirculate_2"
+		},
+		{
+			"codepoint": 62263,
+			"name": "car_gear"
+		},
+		{
+			"codepoint": 62262,
+			"name": "car_lock"
+		},
+		{
+			"codepoint": 62261,
+			"name": "car_mirror_heat"
+		},
+		{
+			"codepoint": 59989,
+			"name": "car_rental"
+		},
+		{
+			"codepoint": 59990,
+			"name": "car_repair"
+		},
+		{
+			"codepoint": 62691,
+			"name": "car_tag"
+		},
+		{
+			"codepoint": 59638,
+			"name": "card_giftcard"
+		},
+		{
+			"codepoint": 59639,
+			"name": "card_membership"
+		},
+		{
+			"codepoint": 59640,
+			"name": "card_travel"
+		},
+		{
+			"codepoint": 62649,
+			"name": "cardio_load"
+		},
+		{
+			"codepoint": 57500,
+			"name": "cardiology"
+		},
+		{
+			"codepoint": 59793,
+			"name": "cards"
+		},
+		{
+			"codepoint": 62351,
+			"name": "cards_stack"
+		},
+		{
+			"codepoint": 62325,
+			"name": "cards_star"
+		},
+		{
+			"codepoint": 61944,
+			"name": "carpenter"
+		},
+		{
+			"codepoint": 60168,
+			"name": "carry_on_bag"
+		},
+		{
+			"codepoint": 60171,
+			"name": "carry_on_bag_checked"
+		},
+		{
+			"codepoint": 60170,
+			"name": "carry_on_bag_inactive"
+		},
+		{
+			"codepoint": 60169,
+			"name": "carry_on_bag_question"
+		},
+		{
+			"codepoint": 59794,
+			"name": "cases"
+		},
+		{
+			"codepoint": 60224,
+			"name": "casino"
+		},
+		{
+			"codepoint": 58119,
+			"name": "cast"
+		},
+		{
+			"codepoint": 58120,
+			"name": "cast_connected"
+		},
+		{
+			"codepoint": 61420,
+			"name": "cast_for_education"
+		},
+		{
+			"codepoint": 62960,
+			"name": "cast_pause"
+		},
+		{
+			"codepoint": 62959,
+			"name": "cast_warning"
+		},
+		{
+			"codepoint": 60081,
+			"name": "castle"
+		},
+		{
+			"codepoint": 59180,
+			"name": "category"
+		},
+		{
+			"codepoint": 62519,
+			"name": "category_search"
+		},
+		{
+			"codepoint": 60005,
+			"name": "celebration"
+		},
+		{
+			"codepoint": 63534,
+			"name": "cell_merge"
+		},
+		{
+			"codepoint": 60346,
+			"name": "cell_tower"
+		},
+		{
+			"codepoint": 57580,
+			"name": "cell_wifi"
+		},
+		{
+			"codepoint": 58292,
+			"name": "center_focus_strong"
+		},
+		{
+			"codepoint": 58293,
+			"name": "center_focus_weak"
+		},
+		{
+			"codepoint": 61421,
+			"name": "chair"
+		},
+		{
+			"codepoint": 61422,
+			"name": "chair_alt"
+		},
+		{
+			"codepoint": 62111,
+			"name": "chair_counter"
+		},
+		{
+			"codepoint": 62110,
+			"name": "chair_fireplace"
+		},
+		{
+			"codepoint": 62109,
+			"name": "chair_umbrella"
+		},
+		{
+			"codepoint": 58757,
+			"name": "chalet"
+		},
+		{
+			"codepoint": 58087,
+			"name": "change_circle"
+		},
+		{
+			"codepoint": 59499,
+			"name": "change_history"
+		},
+		{
+			"codepoint": 58030,
+			"name": "charger"
+		},
+		{
+			"codepoint": 62179,
+			"name": "charging_station"
+		},
+		{
+			"codepoint": 58483,
+			"name": "chart_data"
+		},
+		{
+			"codepoint": 57545,
+			"name": "chat"
+		},
+		{
+			"codepoint": 61683,
+			"name": "chat_add_on"
+		},
+		{
+			"codepoint": 61629,
+			"name": "chat_apps_script"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble"
+		},
+		{
+			"codepoint": 1048507,
+			"name": "chat_bubble_off"
+		},
+		{
+			"codepoint": 57547,
+			"name": "chat_bubble_outline"
+		},
+		{
+			"codepoint": 61165,
+			"name": "chat_dashed"
+		},
+		{
+			"codepoint": 63404,
+			"name": "chat_error"
+		},
+		{
+			"codepoint": 62763,
+			"name": "chat_info"
+		},
+		{
+			"codepoint": 63165,
+			"name": "chat_paste_go"
+		},
+		{
+			"codepoint": 62411,
+			"name": "chat_paste_go_2"
+		},
+		{
+			"codepoint": 58984,
+			"name": "check"
+		},
+		{
+			"codepoint": 1048453,
+			"name": "check_alert"
+		},
+		{
+			"codepoint": 59870,
+			"name": "check_box"
+		},
+		{
+			"codepoint": 59445,
+			"name": "check_box_outline_blank"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_filled"
+		},
+		{
+			"codepoint": 61630,
+			"name": "check_circle_outline"
+		},
+		{
+			"codepoint": 62078,
+			"name": "check_circle_unread"
+		},
+		{
+			"codepoint": 63222,
+			"name": "check_in_out"
+		},
+		{
+			"codepoint": 63626,
+			"name": "check_indeterminate_small"
+		},
+		{
+			"codepoint": 63627,
+			"name": "check_small"
+		},
+		{
+			"codepoint": 59149,
+			"name": "checkbook"
+		},
+		{
+			"codepoint": 60172,
+			"name": "checked_bag"
+		},
+		{
+			"codepoint": 60173,
+			"name": "checked_bag_question"
+		},
+		{
+			"codepoint": 59057,
+			"name": "checklist"
+		},
+		{
+			"codepoint": 59059,
+			"name": "checklist_rtl"
+		},
+		{
+			"codepoint": 61854,
+			"name": "checkroom"
+		},
+		{
+			"codepoint": 63144,
+			"name": "cheer"
+		},
+		{
+			"codepoint": 62295,
+			"name": "chef_hat"
+		},
+		{
+			"codepoint": 62951,
+			"name": "chess"
+		},
+		{
+			"codepoint": 62049,
+			"name": "chess_bishop"
+		},
+		{
+			"codepoint": 62050,
+			"name": "chess_bishop_2"
+		},
+		{
+			"codepoint": 62047,
+			"name": "chess_king"
+		},
+		{
+			"codepoint": 62048,
+			"name": "chess_king_2"
+		},
+		{
+			"codepoint": 62046,
+			"name": "chess_knight"
+		},
+		{
+			"codepoint": 62390,
+			"name": "chess_pawn"
+		},
+		{
+			"codepoint": 62045,
+			"name": "chess_pawn_2"
+		},
+		{
+			"codepoint": 62044,
+			"name": "chess_queen"
+		},
+		{
+			"codepoint": 62043,
+			"name": "chess_rook"
+		},
+		{
+			"codepoint": 62571,
+			"name": "chevron_backward"
+		},
+		{
+			"codepoint": 62570,
+			"name": "chevron_forward"
+		},
+		{
+			"codepoint": 58827,
+			"name": "chevron_left"
+		},
+		{
+			"codepoint": 61123,
+			"name": "chevron_line_up"
+		},
+		{
+			"codepoint": 58828,
+			"name": "chevron_right"
+		},
+		{
+			"codepoint": 60225,
+			"name": "child_care"
+		},
+		{
+			"codepoint": 61312,
+			"name": "child_friendly"
+		},
+		{
+			"codepoint": 61232,
+			"name": "child_hat"
+		},
+		{
+			"codepoint": 63521,
+			"name": "chip_extraction"
+		},
+		{
+			"codepoint": 59795,
+			"name": "chips"
+		},
+		{
+			"codepoint": 59501,
+			"name": "chrome_reader_mode"
+		},
+		{
+			"codepoint": 61819,
+			"name": "chromecast_2"
+		},
+		{
+			"codepoint": 59452,
+			"name": "chromecast_device"
+		},
+		{
+			"codepoint": 60338,
+			"name": "chronic"
+		},
+		{
+			"codepoint": 60078,
+			"name": "church"
+		},
+		{
+			"codepoint": 63571,
+			"name": "cinematic_blur"
+		},
+		{
+			"codepoint": 61258,
+			"name": "circle"
+		},
+		{
+			"codepoint": 61153,
+			"name": "circle_circle"
+		},
+		{
+			"codepoint": 59796,
+			"name": "circle_notifications"
+		},
+		{
+			"codepoint": 59370,
+			"name": "circles"
+		},
+		{
+			"codepoint": 59372,
+			"name": "circles_ext"
+		},
+		{
+			"codepoint": 61631,
+			"name": "clarify"
+		},
+		{
+			"codepoint": 59502,
+			"name": "class"
+		},
+		{
+			"codepoint": 61983,
+			"name": "clean_hands"
+		},
+		{
+			"codepoint": 59797,
+			"name": "cleaning"
+		},
+		{
+			"codepoint": 63668,
+			"name": "cleaning_bucket"
+		},
+		{
+			"codepoint": 61695,
+			"name": "cleaning_services"
+		},
+		{
+			"codepoint": 58829,
+			"name": "clear"
+		},
+		{
+			"codepoint": 57528,
+			"name": "clear_all"
+		},
+		{
+			"codepoint": 61783,
+			"name": "clear_day"
+		},
+		{
+			"codepoint": 61785,
+			"name": "clear_night"
+		},
+		{
+			"codepoint": 63669,
+			"name": "climate_mini_split"
+		},
+		{
+			"codepoint": 57502,
+			"name": "clinical_notes"
+		},
+		{
+			"codepoint": 62338,
+			"name": "clock_arrow_down"
+		},
+		{
+			"codepoint": 62337,
+			"name": "clock_arrow_up"
+		},
+		{
+			"codepoint": 63270,
+			"name": "clock_loader_10"
+		},
+		{
+			"codepoint": 63269,
+			"name": "clock_loader_20"
+		},
+		{
+			"codepoint": 63268,
+			"name": "clock_loader_40"
+		},
+		{
+			"codepoint": 63267,
+			"name": "clock_loader_60"
+		},
+		{
+			"codepoint": 63266,
+			"name": "clock_loader_80"
+		},
+		{
+			"codepoint": 63265,
+			"name": "clock_loader_90"
+		},
+		{
+			"codepoint": 58829,
+			"name": "close"
+		},
+		{
+			"codepoint": 61903,
+			"name": "close_fullscreen"
+		},
+		{
+			"codepoint": 62728,
+			"name": "close_small"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption"
+		},
+		{
+			"codepoint": 62638,
+			"name": "closed_caption_add"
+		},
+		{
+			"codepoint": 61916,
+			"name": "closed_caption_disabled"
+		},
+		{
+			"codepoint": 59798,
+			"name": "closed_caption_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud"
+		},
+		{
+			"codepoint": 62412,
+			"name": "cloud_alert"
+		},
+		{
+			"codepoint": 58046,
+			"name": "cloud_circle"
+		},
+		{
+			"codepoint": 58047,
+			"name": "cloud_done"
+		},
+		{
+			"codepoint": 58048,
+			"name": "cloud_download"
+		},
+		{
+			"codepoint": 62342,
+			"name": "cloud_lock"
+		},
+		{
+			"codepoint": 58049,
+			"name": "cloud_off"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloud_queue"
+		},
+		{
+			"codepoint": 60250,
+			"name": "cloud_sync"
+		},
+		{
+			"codepoint": 58051,
+			"name": "cloud_upload"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy"
+		},
+		{
+			"codepoint": 61788,
+			"name": "cloudy_filled"
+		},
+		{
+			"codepoint": 59408,
+			"name": "cloudy_snowing"
+		},
+		{
+			"codepoint": 59312,
+			"name": "co2"
+		},
+		{
+			"codepoint": 60144,
+			"name": "co_present"
+		},
+		{
+			"codepoint": 59503,
+			"name": "code"
+		},
+		{
+			"codepoint": 63565,
+			"name": "code_blocks"
+		},
+		{
+			"codepoint": 58611,
+			"name": "code_off"
+		},
+		{
+			"codepoint": 1048459,
+			"name": "code_xml"
+		},
+		{
+			"codepoint": 61423,
+			"name": "coffee"
+		},
+		{
+			"codepoint": 61424,
+			"name": "coffee_maker"
+		},
+		{
+			"codepoint": 57503,
+			"name": "cognition"
+		},
+		{
+			"codepoint": 62389,
+			"name": "cognition_2"
+		},
+		{
+			"codepoint": 59716,
+			"name": "collapse_all"
+		},
+		{
+			"codepoint": 62727,
+			"name": "collapse_content"
+		},
+		{
+			"codepoint": 58323,
+			"name": "collections"
+		},
+		{
+			"codepoint": 58417,
+			"name": "collections_bookmark"
+		},
+		{
+			"codepoint": 58378,
+			"name": "color_lens"
+		},
+		{
+			"codepoint": 58296,
+			"name": "colorize"
+		},
+		{
+			"codepoint": 59799,
+			"name": "colors"
+		},
+		{
+			"codepoint": 62496,
+			"name": "combine_columns"
+		},
+		{
+			"codepoint": 62678,
+			"name": "comedy_mask"
+		},
+		{
+			"codepoint": 62941,
+			"name": "comic_bubble"
+		},
+		{
+			"codepoint": 57932,
+			"name": "comment"
+		},
+		{
+			"codepoint": 59982,
+			"name": "comment_bank"
+		},
+		{
+			"codepoint": 59298,
+			"name": "comments_disabled"
+		},
+		{
+			"codepoint": 60149,
+			"name": "commit"
+		},
+		{
+			"codepoint": 57980,
+			"name": "communication"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities"
+		},
+		{
+			"codepoint": 60182,
+			"name": "communities_filled"
+		},
+		{
+			"codepoint": 59712,
+			"name": "commute"
+		},
+		{
+			"codepoint": 58297,
+			"name": "compare"
+		},
+		{
+			"codepoint": 59669,
+			"name": "compare_arrows"
+		},
+		{
+			"codepoint": 58748,
+			"name": "compass_calibration"
+		},
+		{
+			"codepoint": 61927,
+			"name": "component_exchange"
+		},
+		{
+			"codepoint": 59233,
+			"name": "compost"
+		},
+		{
+			"codepoint": 59725,
+			"name": "compress"
+		},
+		{
+			"codepoint": 58142,
+			"name": "computer"
+		},
+		{
+			"codepoint": 62199,
+			"name": "computer_arrow_up"
+		},
+		{
+			"codepoint": 62198,
+			"name": "computer_cancel"
+		},
+		{
+			"codepoint": 61108,
+			"name": "computer_sound"
+		},
+		{
+			"codepoint": 62817,
+			"name": "concierge"
+		},
+		{
+			"codepoint": 57504,
+			"name": "conditions"
+		},
+		{
+			"codepoint": 58936,
+			"name": "confirmation_number"
+		},
+		{
+			"codepoint": 57505,
+			"name": "congenital"
+		},
+		{
+			"codepoint": 61987,
+			"name": "connect_without_contact"
+		},
+		{
+			"codepoint": 59800,
+			"name": "connected_tv"
+		},
+		{
+			"codepoint": 59337,
+			"name": "connecting_airports"
+		},
+		{
+			"codepoint": 59964,
+			"name": "construction"
+		},
+		{
+			"codepoint": 63697,
+			"name": "contact_emergency"
+		},
+		{
+			"codepoint": 57552,
+			"name": "contact_mail"
+		},
+		{
+			"codepoint": 61998,
+			"name": "contact_page"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone"
+		},
+		{
+			"codepoint": 61632,
+			"name": "contact_phone_filled"
+		},
+		{
+			"codepoint": 59724,
+			"name": "contact_support"
+		},
+		{
+			"codepoint": 60017,
+			"name": "contactless"
+		},
+		{
+			"codepoint": 63576,
+			"name": "contactless_off"
+		},
+		{
+			"codepoint": 57530,
+			"name": "contacts"
+		},
+		{
+			"codepoint": 59801,
+			"name": "contacts_product"
+		},
+		{
+			"codepoint": 57677,
+			"name": "content_copy"
+		},
+		{
+			"codepoint": 57678,
+			"name": "content_cut"
+		},
+		{
+			"codepoint": 57679,
+			"name": "content_paste"
+		},
+		{
+			"codepoint": 60046,
+			"name": "content_paste_go"
+		},
+		{
+			"codepoint": 58616,
+			"name": "content_paste_off"
+		},
+		{
+			"codepoint": 60059,
+			"name": "content_paste_search"
+		},
+		{
+			"codepoint": 62598,
+			"name": "contextual_token"
+		},
+		{
+			"codepoint": 62597,
+			"name": "contextual_token_add"
+		},
+		{
+			"codepoint": 62880,
+			"name": "contract"
+		},
+		{
+			"codepoint": 62882,
+			"name": "contract_delete"
+		},
+		{
+			"codepoint": 62881,
+			"name": "contract_edit"
+		},
+		{
+			"codepoint": 60215,
+			"name": "contrast"
+		},
+		{
+			"codepoint": 62623,
+			"name": "contrast_circle"
+		},
+		{
+			"codepoint": 60530,
+			"name": "contrast_rtl_off"
+		},
+		{
+			"codepoint": 62624,
+			"name": "contrast_square"
+		},
+		{
+			"codepoint": 57460,
+			"name": "control_camera"
+		},
+		{
+			"codepoint": 59792,
+			"name": "control_point"
+		},
+		{
+			"codepoint": 58299,
+			"name": "control_point_duplicate"
+		},
+		{
+			"codepoint": 59453,
+			"name": "controller_gen"
+		},
+		{
+			"codepoint": 61231,
+			"name": "conversation"
+		},
+		{
+			"codepoint": 61633,
+			"name": "conversion_path"
+		},
+		{
+			"codepoint": 63412,
+			"name": "conversion_path_off"
+		},
+		{
+			"codepoint": 62495,
+			"name": "convert_to_text"
+		},
+		{
+			"codepoint": 63591,
+			"name": "conveyor_belt"
+		},
+		{
+			"codepoint": 60076,
+			"name": "cookie"
+		},
+		{
+			"codepoint": 63386,
+			"name": "cookie_off"
+		},
+		{
+			"codepoint": 58038,
+			"name": "cooking"
+		},
+		{
+			"codepoint": 57974,
+			"name": "cool_to_dry"
+		},
+		{
+			"codepoint": 58092,
+			"name": "copy_all"
+		},
+		{
+			"codepoint": 59660,
+			"name": "copyright"
+		},
+		{
+			"codepoint": 61985,
+			"name": "coronavirus"
+		},
+		{
+			"codepoint": 61904,
+			"name": "corporate_fare"
+		},
+		{
+			"codepoint": 58759,
+			"name": "cottage"
+		},
+		{
+			"codepoint": 63365,
+			"name": "counter_0"
+		},
+		{
+			"codepoint": 63364,
+			"name": "counter_1"
+		},
+		{
+			"codepoint": 63363,
+			"name": "counter_2"
+		},
+		{
+			"codepoint": 63362,
+			"name": "counter_3"
+		},
+		{
+			"codepoint": 63361,
+			"name": "counter_4"
+		},
+		{
+			"codepoint": 63360,
+			"name": "counter_5"
+		},
+		{
+			"codepoint": 63359,
+			"name": "counter_6"
+		},
+		{
+			"codepoint": 63358,
+			"name": "counter_7"
+		},
+		{
+			"codepoint": 63357,
+			"name": "counter_8"
+		},
+		{
+			"codepoint": 63356,
+			"name": "counter_9"
+		},
+		{
+			"codepoint": 61943,
+			"name": "countertops"
+		},
+		{
+			"codepoint": 61591,
+			"name": "create"
+		},
+		{
+			"codepoint": 58060,
+			"name": "create_new_folder"
+		},
+		{
+			"codepoint": 59553,
+			"name": "credit_card"
+		},
+		{
+			"codepoint": 62520,
+			"name": "credit_card_clock"
+		},
+		{
+			"codepoint": 62765,
+			"name": "credit_card_gear"
+		},
+		{
+			"codepoint": 62764,
+			"name": "credit_card_heart"
+		},
+		{
+			"codepoint": 58612,
+			"name": "credit_card_off"
+		},
+		{
+			"codepoint": 61425,
+			"name": "credit_score"
+		},
+		{
+			"codepoint": 58760,
+			"name": "crib"
+		},
+		{
+			"codepoint": 60393,
+			"name": "crisis_alert"
+		},
+		{
+			"codepoint": 58302,
+			"name": "crop"
+		},
+		{
+			"codepoint": 58300,
+			"name": "crop_16_9"
+		},
+		{
+			"codepoint": 1048330,
+			"name": "crop_21_9"
+		},
+		{
+			"codepoint": 1048331,
+			"name": "crop_2_3"
+		},
+		{
+			"codepoint": 58301,
+			"name": "crop_3_2"
+		},
+		{
+			"codepoint": 58303,
+			"name": "crop_5_4"
+		},
+		{
+			"codepoint": 58304,
+			"name": "crop_7_5"
+		},
+		{
+			"codepoint": 62793,
+			"name": "crop_9_16"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_din"
+		},
+		{
+			"codepoint": 58306,
+			"name": "crop_free"
+		},
+		{
+			"codepoint": 58307,
+			"name": "crop_landscape"
+		},
+		{
+			"codepoint": 58356,
+			"name": "crop_original"
+		},
+		{
+			"codepoint": 58309,
+			"name": "crop_portrait"
+		},
+		{
+			"codepoint": 58423,
+			"name": "crop_rotate"
+		},
+		{
+			"codepoint": 58310,
+			"name": "crop_square"
+		},
+		{
+			"codepoint": 62949,
+			"name": "crossword"
+		},
+		{
+			"codepoint": 60184,
+			"name": "crowdsource"
+		},
+		{
+			"codepoint": 60595,
+			"name": "crown"
+		},
+		{
+			"codepoint": 59289,
+			"name": "cruelty_free"
+		},
+		{
+			"codepoint": 60307,
+			"name": "css"
+		},
+		{
+			"codepoint": 59087,
+			"name": "csv"
+		},
+		{
+			"codepoint": 60357,
+			"name": "currency_bitcoin"
+		},
+		{
+			"codepoint": 60272,
+			"name": "currency_exchange"
+		},
+		{
+			"codepoint": 60154,
+			"name": "currency_franc"
+		},
+		{
+			"codepoint": 60143,
+			"name": "currency_lira"
+		},
+		{
+			"codepoint": 60145,
+			"name": "currency_pound"
+		},
+		{
+			"codepoint": 60140,
+			"name": "currency_ruble"
+		},
+		{
+			"codepoint": 60151,
+			"name": "currency_rupee"
+		},
+		{
+			"codepoint": 62560,
+			"name": "currency_rupee_circle"
+		},
+		{
+			"codepoint": 60155,
+			"name": "currency_yen"
+		},
+		{
+			"codepoint": 60153,
+			"name": "currency_yuan"
+		},
+		{
+			"codepoint": 60446,
+			"name": "curtains"
+		},
+		{
+			"codepoint": 60445,
+			"name": "curtains_closed"
+		},
+		{
+			"codepoint": 59186,
+			"name": "custom_typography"
+		},
+		{
+			"codepoint": 61579,
+			"name": "cut"
+		},
+		{
+			"codepoint": 63572,
+			"name": "cycle"
+		},
+		{
+			"codepoint": 60373,
+			"name": "cyclone"
+		},
+		{
+			"codepoint": 59802,
+			"name": "dangerous"
+		},
+		{
+			"codepoint": 58652,
+			"name": "dark_mode"
+		},
+		{
+			"codepoint": 59505,
+			"name": "dashboard"
+		},
+		{
+			"codepoint": 62442,
+			"name": "dashboard_2"
+		},
+		{
+			"codepoint": 1048297,
+			"name": "dashboard_2_add"
+		},
+		{
+			"codepoint": 1048535,
+			"name": "dashboard_2_edit"
+		},
+		{
+			"codepoint": 1048534,
+			"name": "dashboard_2_gear"
+		},
+		{
+			"codepoint": 59803,
+			"name": "dashboard_customize"
+		},
+		{
+			"codepoint": 63478,
+			"name": "data_alert"
+		},
+		{
+			"codepoint": 60113,
+			"name": "data_array"
+		},
+		{
+			"codepoint": 63474,
+			"name": "data_check"
+		},
+		{
+			"codepoint": 59247,
+			"name": "data_exploration"
+		},
+		{
+			"codepoint": 63477,
+			"name": "data_info_alert"
+		},
+		{
+			"codepoint": 58076,
+			"name": "data_loss_prevention"
+		},
+		{
+			"codepoint": 60115,
+			"name": "data_object"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_saver_off"
+		},
+		{
+			"codepoint": 61427,
+			"name": "data_saver_on"
+		},
+		{
+			"codepoint": 59804,
+			"name": "data_table"
+		},
+		{
+			"codepoint": 60319,
+			"name": "data_thresholding"
+		},
+		{
+			"codepoint": 61426,
+			"name": "data_usage"
+		},
+		{
+			"codepoint": 61966,
+			"name": "database"
+		},
+		{
+			"codepoint": 62484,
+			"name": "database_off"
+		},
+		{
+			"codepoint": 62350,
+			"name": "database_search"
+		},
+		{
+			"codepoint": 62428,
+			"name": "database_upload"
+		},
+		{
+			"codepoint": 63726,
+			"name": "dataset"
+		},
+		{
+			"codepoint": 63727,
+			"name": "dataset_linked"
+		},
+		{
+			"codepoint": 59670,
+			"name": "date_range"
+		},
+		{
+			"codepoint": 60279,
+			"name": "deblur"
+		},
+		{
+			"codepoint": 57509,
+			"name": "deceased"
+		},
+		{
+			"codepoint": 63533,
+			"name": "decimal_decrease"
+		},
+		{
+			"codepoint": 63532,
+			"name": "decimal_increase"
+		},
+		{
+			"codepoint": 59970,
+			"name": "deck"
+		},
+		{
+			"codepoint": 58311,
+			"name": "dehaze"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete"
+		},
+		{
+			"codepoint": 59691,
+			"name": "delete_forever"
+		},
+		{
+			"codepoint": 62744,
+			"name": "delete_history"
+		},
+		{
+			"codepoint": 59694,
+			"name": "delete_outline"
+		},
+		{
+			"codepoint": 57708,
+			"name": "delete_sweep"
+		},
+		{
+			"codepoint": 60200,
+			"name": "delivery_dining"
+		},
+		{
+			"codepoint": 62370,
+			"name": "delivery_truck_bolt"
+		},
+		{
+			"codepoint": 62369,
+			"name": "delivery_truck_speed"
+		},
+		{
+			"codepoint": 58505,
+			"name": "demography"
+		},
+		{
+			"codepoint": 60329,
+			"name": "density_large"
+		},
+		{
+			"codepoint": 60318,
+			"name": "density_medium"
+		},
+		{
+			"codepoint": 60328,
+			"name": "density_small"
+		},
+		{
+			"codepoint": 57510,
+			"name": "dentistry"
+		},
+		{
+			"codepoint": 58742,
+			"name": "departure_board"
+		},
+		{
+			"codepoint": 63264,
+			"name": "deployed_code"
+		},
+		{
+			"codepoint": 62747,
+			"name": "deployed_code_account"
+		},
+		{
+			"codepoint": 62962,
+			"name": "deployed_code_alert"
+		},
+		{
+			"codepoint": 62963,
+			"name": "deployed_code_history"
+		},
+		{
+			"codepoint": 62964,
+			"name": "deployed_code_update"
+		},
+		{
+			"codepoint": 57511,
+			"name": "dermatology"
+		},
+		{
+			"codepoint": 59507,
+			"name": "description"
+		},
+		{
+			"codepoint": 60342,
+			"name": "deselect"
+		},
+		{
+			"codepoint": 61706,
+			"name": "design_services"
+		},
+		{
+			"codepoint": 63732,
+			"name": "desk"
+		},
+		{
+			"codepoint": 63482,
+			"name": "deskphone"
+		},
+		{
+			"codepoint": 59805,
+			"name": "desktop_access_disabled"
+		},
+		{
+			"codepoint": 62427,
+			"name": "desktop_cloud"
+		},
+		{
+			"codepoint": 62398,
+			"name": "desktop_cloud_stack"
+		},
+		{
+			"codepoint": 62558,
+			"name": "desktop_landscape"
+		},
+		{
+			"codepoint": 62521,
+			"name": "desktop_landscape_add"
+		},
+		{
+			"codepoint": 58123,
+			"name": "desktop_mac"
+		},
+		{
+			"codepoint": 62557,
+			"name": "desktop_portrait"
+		},
+		{
+			"codepoint": 58124,
+			"name": "desktop_windows"
+		},
+		{
+			"codepoint": 62853,
+			"name": "destruction"
+		},
+		{
+			"codepoint": 58312,
+			"name": "details"
+		},
+		{
+			"codepoint": 58015,
+			"name": "detection_and_zone"
+		},
+		{
+			"codepoint": 61119,
+			"name": "detection_and_zone_off"
+		},
+		{
+			"codepoint": 57986,
+			"name": "detector"
+		},
+		{
+			"codepoint": 57847,
+			"name": "detector_alarm"
+		},
+		{
+			"codepoint": 57860,
+			"name": "detector_battery"
+		},
+		{
+			"codepoint": 58031,
+			"name": "detector_co"
+		},
+		{
+			"codepoint": 57891,
+			"name": "detector_offline"
+		},
+		{
+			"codepoint": 57989,
+			"name": "detector_smoke"
+		},
+		{
+			"codepoint": 57832,
+			"name": "detector_status"
+		},
+		{
+			"codepoint": 58125,
+			"name": "developer_board"
+		},
+		{
+			"codepoint": 58623,
+			"name": "developer_board_off"
+		},
+		{
+			"codepoint": 59806,
+			"name": "developer_guide"
+		},
+		{
+			"codepoint": 62178,
+			"name": "developer_mode"
+		},
+		{
+			"codepoint": 59508,
+			"name": "developer_mode_tv"
+		},
+		{
+			"codepoint": 62197,
+			"name": "device_band"
+		},
+		{
+			"codepoint": 58165,
+			"name": "device_hub"
+		},
+		{
+			"codepoint": 59571,
+			"name": "device_reset"
+		},
+		{
+			"codepoint": 57855,
+			"name": "device_thermostat"
+		},
+		{
+			"codepoint": 62177,
+			"name": "device_unknown"
+		},
+		{
+			"codepoint": 58150,
+			"name": "devices"
+		},
+		{
+			"codepoint": 60382,
+			"name": "devices_fold"
+		},
+		{
+			"codepoint": 62470,
+			"name": "devices_fold_2"
+		},
+		{
+			"codepoint": 63397,
+			"name": "devices_off"
+		},
+		{
+			"codepoint": 58167,
+			"name": "devices_other"
+		},
+		{
+			"codepoint": 63147,
+			"name": "devices_wearables"
+		},
+		{
+			"codepoint": 63609,
+			"name": "dew_point"
+		},
+		{
+			"codepoint": 57512,
+			"name": "diagnosis"
+		},
+		{
+			"codepoint": 62494,
+			"name": "diagonal_line"
+		},
+		{
+			"codepoint": 57531,
+			"name": "dialer_sip"
+		},
+		{
+			"codepoint": 59807,
+			"name": "dialogs"
+		},
+		{
+			"codepoint": 57532,
+			"name": "dialpad"
+		},
+		{
+			"codepoint": 60117,
+			"name": "diamond"
+		},
+		{
+			"codepoint": 62130,
+			"name": "diamond_shine"
+		},
+		{
+			"codepoint": 62777,
+			"name": "dictionary"
+		},
+		{
+			"codepoint": 60285,
+			"name": "difference"
+		},
+		{
+			"codepoint": 61918,
+			"name": "digital_out_of_home"
+		},
+		{
+			"codepoint": 61318,
+			"name": "digital_wellbeing"
+		},
+		{
+			"codepoint": 62108,
+			"name": "dine_heart"
+		},
+		{
+			"codepoint": 62101,
+			"name": "dine_in"
+		},
+		{
+			"codepoint": 62107,
+			"name": "dine_lamp"
+		},
+		{
+			"codepoint": 61428,
+			"name": "dining"
+		},
+		{
+			"codepoint": 59991,
+			"name": "dinner_dining"
+		},
+		{
+			"codepoint": 58670,
+			"name": "directions"
+		},
+		{
+			"codepoint": 63616,
+			"name": "directions_alt"
+		},
+		{
+			"codepoint": 63617,
+			"name": "directions_alt_off"
+		},
+		{
+			"codepoint": 58671,
+			"name": "directions_bike"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat"
+		},
+		{
+			"codepoint": 61429,
+			"name": "directions_boat_filled"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus"
+		},
+		{
+			"codepoint": 61430,
+			"name": "directions_bus_filled"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car"
+		},
+		{
+			"codepoint": 61431,
+			"name": "directions_car_filled"
+		},
+		{
+			"codepoint": 61711,
+			"name": "directions_off"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway"
+		},
+		{
+			"codepoint": 62562,
+			"name": "directions_railway_2"
+		},
+		{
+			"codepoint": 61432,
+			"name": "directions_railway_filled"
+		},
+		{
+			"codepoint": 58726,
+			"name": "directions_run"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_subway_filled"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit"
+		},
+		{
+			"codepoint": 61434,
+			"name": "directions_transit_filled"
+		},
+		{
+			"codepoint": 58678,
+			"name": "directions_walk"
+		},
+		{
+			"codepoint": 58260,
+			"name": "directory_sync"
+		},
+		{
+			"codepoint": 61259,
+			"name": "dirty_lens"
+		},
+		{
+			"codepoint": 62000,
+			"name": "disabled_by_default"
+		},
+		{
+			"codepoint": 59246,
+			"name": "disabled_visible"
+		},
+		{
+			"codepoint": 58896,
+			"name": "disc_full"
+		},
+		{
+			"codepoint": 57368,
+			"name": "discover_tune"
+		},
+		{
+			"codepoint": 59808,
+			"name": "dishwasher"
+		},
+		{
+			"codepoint": 59442,
+			"name": "dishwasher_gen"
+		},
+		{
+			"codepoint": 63463,
+			"name": "display_external_input"
+		},
+		{
+			"codepoint": 60311,
+			"name": "display_settings"
+		},
+		{
+			"codepoint": 63210,
+			"name": "distance"
+		},
+		{
+			"codepoint": 63703,
+			"name": "diversity_1"
+		},
+		{
+			"codepoint": 63704,
+			"name": "diversity_2"
+		},
+		{
+			"codepoint": 63705,
+			"name": "diversity_3"
+		},
+		{
+			"codepoint": 63575,
+			"name": "diversity_4"
+		},
+		{
+			"codepoint": 59509,
+			"name": "dns"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_disturb"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_disturb_on"
+		},
+		{
+			"codepoint": 61581,
+			"name": "do_not_disturb"
+		},
+		{
+			"codepoint": 61580,
+			"name": "do_not_disturb_alt"
+		},
+		{
+			"codepoint": 61582,
+			"name": "do_not_disturb_off"
+		},
+		{
+			"codepoint": 61583,
+			"name": "do_not_disturb_on"
+		},
+		{
+			"codepoint": 61435,
+			"name": "do_not_disturb_on_total_silence"
+		},
+		{
+			"codepoint": 61855,
+			"name": "do_not_step"
+		},
+		{
+			"codepoint": 61872,
+			"name": "do_not_touch"
+		},
+		{
+			"codepoint": 62176,
+			"name": "dock"
+		},
+		{
+			"codepoint": 63462,
+			"name": "dock_to_bottom"
+		},
+		{
+			"codepoint": 63461,
+			"name": "dock_to_left"
+		},
+		{
+			"codepoint": 63460,
+			"name": "dock_to_right"
+		},
+		{
+			"codepoint": 60029,
+			"name": "docs"
+		},
+		{
+			"codepoint": 61634,
+			"name": "docs_add_on"
+		},
+		{
+			"codepoint": 61635,
+			"name": "docs_apps_script"
+		},
+		{
+			"codepoint": 58874,
+			"name": "document_scanner"
+		},
+		{
+			"codepoint": 62341,
+			"name": "document_search"
+		},
+		{
+			"codepoint": 59374,
+			"name": "domain"
+		},
+		{
+			"codepoint": 60258,
+			"name": "domain_add"
+		},
+		{
+			"codepoint": 57583,
+			"name": "domain_disabled"
+		},
+		{
+			"codepoint": 61260,
+			"name": "domain_verification"
+		},
+		{
+			"codepoint": 63408,
+			"name": "domain_verification_off"
+		},
+		{
+			"codepoint": 62948,
+			"name": "domino_mask"
+		},
+		{
+			"codepoint": 59510,
+			"name": "done"
+		},
+		{
+			"codepoint": 59511,
+			"name": "done_all"
+		},
+		{
+			"codepoint": 59695,
+			"name": "done_outline"
+		},
+		{
+			"codepoint": 59671,
+			"name": "donut_large"
+		},
+		{
+			"codepoint": 59672,
+			"name": "donut_small"
+		},
+		{
+			"codepoint": 61436,
+			"name": "door_back"
+		},
+		{
+			"codepoint": 61437,
+			"name": "door_front"
+		},
+		{
+			"codepoint": 59260,
+			"name": "door_open"
+		},
+		{
+			"codepoint": 57994,
+			"name": "door_sensor"
+		},
+		{
+			"codepoint": 61438,
+			"name": "door_sliding"
+		},
+		{
+			"codepoint": 61439,
+			"name": "doorbell"
+		},
+		{
+			"codepoint": 57831,
+			"name": "doorbell_3p"
+		},
+		{
+			"codepoint": 57843,
+			"name": "doorbell_chime"
+		},
+		{
+			"codepoint": 59984,
+			"name": "double_arrow"
+		},
+		{
+			"codepoint": 58633,
+			"name": "downhill_skiing"
+		},
+		{
+			"codepoint": 61584,
+			"name": "download"
+		},
+		{
+			"codepoint": 62755,
+			"name": "download_2"
+		},
+		{
+			"codepoint": 61585,
+			"name": "download_done"
+		},
+		{
+			"codepoint": 61440,
+			"name": "download_for_offline"
+		},
+		{
+			"codepoint": 61441,
+			"name": "downloading"
+		},
+		{
+			"codepoint": 58996,
+			"name": "draft"
+		},
+		{
+			"codepoint": 59315,
+			"name": "draft_orders"
+		},
+		{
+			"codepoint": 57681,
+			"name": "drafts"
+		},
+		{
+			"codepoint": 63263,
+			"name": "drag_click"
+		},
+		{
+			"codepoint": 57949,
+			"name": "drag_handle"
+		},
+		{
+			"codepoint": 59717,
+			"name": "drag_indicator"
+		},
+		{
+			"codepoint": 63262,
+			"name": "drag_pan"
+		},
+		{
+			"codepoint": 59206,
+			"name": "draw"
+		},
+		{
+			"codepoint": 63480,
+			"name": "draw_abstract"
+		},
+		{
+			"codepoint": 63479,
+			"name": "draw_collage"
+		},
+		{
+			"codepoint": 60160,
+			"name": "drawing_recognition"
+		},
+		{
+			"codepoint": 57872,
+			"name": "dresser"
+		},
+		{
+			"codepoint": 61431,
+			"name": "drive_eta"
+		},
+		{
+			"codepoint": 62493,
+			"name": "drive_export"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_outline"
+		},
+		{
+			"codepoint": 59809,
+			"name": "drive_file_move_rtl"
+		},
+		{
+			"codepoint": 58998,
+			"name": "drive_file_rename"
+		},
+		{
+			"codepoint": 59810,
+			"name": "drive_file_rename_outline"
+		},
+		{
+			"codepoint": 59811,
+			"name": "drive_folder_upload"
+		},
+		{
+			"codepoint": 59000,
+			"name": "drive_fusiontable"
+		},
+		{
+			"codepoint": 62042,
+			"name": "drone"
+		},
+		{
+			"codepoint": 62041,
+			"name": "drone_2"
+		},
+		{
+			"codepoint": 59812,
+			"name": "dropdown"
+		},
+		{
+			"codepoint": 1048304,
+			"name": "dropdown_menu"
+		},
+		{
+			"codepoint": 62289,
+			"name": "dropper_eye"
+		},
+		{
+			"codepoint": 61875,
+			"name": "dry"
+		},
+		{
+			"codepoint": 59992,
+			"name": "dry_cleaning"
+		},
+		{
+			"codepoint": 63183,
+			"name": "dual_screen"
+		},
+		{
+			"codepoint": 59813,
+			"name": "duo"
+		},
+		{
+			"codepoint": 57778,
+			"name": "dvr"
+		},
+		{
+			"codepoint": 59924,
+			"name": "dynamic_feed"
+		},
+		{
+			"codepoint": 61887,
+			"name": "dynamic_form"
+		},
+		{
+			"codepoint": 61722,
+			"name": "e911_avatar"
+		},
+		{
+			"codepoint": 61721,
+			"name": "e911_emergency"
+		},
+		{
+			"codepoint": 61442,
+			"name": "e_mobiledata"
+		},
+		{
+			"codepoint": 63459,
+			"name": "e_mobiledata_badge"
+		},
+		{
+			"codepoint": 62294,
+			"name": "ear_sound"
+		},
+		{
+			"codepoint": 62247,
+			"name": "earbud_case"
+		},
+		{
+			"codepoint": 62246,
+			"name": "earbud_left"
+		},
+		{
+			"codepoint": 62245,
+			"name": "earbud_right"
+		},
+		{
+			"codepoint": 61443,
+			"name": "earbuds"
+		},
+		{
+			"codepoint": 62244,
+			"name": "earbuds_2"
+		},
+		{
+			"codepoint": 61444,
+			"name": "earbuds_battery"
+		},
+		{
+			"codepoint": 58042,
+			"name": "early_on"
+		},
+		{
+			"codepoint": 63055,
+			"name": "earthquake"
+		},
+		{
+			"codepoint": 61919,
+			"name": "east"
+		},
+		{
+			"codepoint": 63503,
+			"name": "ecg"
+		},
+		{
+			"codepoint": 63209,
+			"name": "ecg_heart"
+		},
+		{
+			"codepoint": 59957,
+			"name": "eco"
+		},
+		{
+			"codepoint": 63208,
+			"name": "eda"
+		},
+		{
+			"codepoint": 62191,
+			"name": "edgesensor_high"
+		},
+		{
+			"codepoint": 62190,
+			"name": "edgesensor_low"
+		},
+		{
+			"codepoint": 61591,
+			"name": "edit"
+		},
+		{
+			"codepoint": 62336,
+			"name": "edit_arrow_down"
+		},
+		{
+			"codepoint": 62335,
+			"name": "edit_arrow_up"
+		},
+		{
+			"codepoint": 58744,
+			"name": "edit_attributes"
+		},
+		{
+			"codepoint": 62509,
+			"name": "edit_audio"
+		},
+		{
+			"codepoint": 59202,
+			"name": "edit_calendar"
+		},
+		{
+			"codepoint": 63628,
+			"name": "edit_document"
+		},
+		{
+			"codepoint": 58728,
+			"name": "edit_location"
+		},
+		{
+			"codepoint": 57797,
+			"name": "edit_location_alt"
+		},
+		{
+			"codepoint": 59205,
+			"name": "edit_note"
+		},
+		{
+			"codepoint": 58661,
+			"name": "edit_notifications"
+		},
+		{
+			"codepoint": 59728,
+			"name": "edit_off"
+		},
+		{
+			"codepoint": 61261,
+			"name": "edit_road"
+		},
+		{
+			"codepoint": 63629,
+			"name": "edit_square"
+		},
+		{
+			"codepoint": 62760,
+			"name": "editor_choice"
+		},
+		{
+			"codepoint": 60108,
+			"name": "egg"
+		},
+		{
+			"codepoint": 60104,
+			"name": "egg_alt"
+		},
+		{
+			"codepoint": 59643,
+			"name": "eject"
+		},
+		{
+			"codepoint": 61978,
+			"name": "elderly"
+		},
+		{
+			"codepoint": 60265,
+			"name": "elderly_woman"
+		},
+		{
+			"codepoint": 60187,
+			"name": "electric_bike"
+		},
+		{
+			"codepoint": 60444,
+			"name": "electric_bolt"
+		},
+		{
+			"codepoint": 60188,
+			"name": "electric_car"
+		},
+		{
+			"codepoint": 60443,
+			"name": "electric_meter"
+		},
+		{
+			"codepoint": 60189,
+			"name": "electric_moped"
+		},
+		{
+			"codepoint": 60190,
+			"name": "electric_rickshaw"
+		},
+		{
+			"codepoint": 60191,
+			"name": "electric_scooter"
+		},
+		{
+			"codepoint": 61698,
+			"name": "electrical_services"
+		},
+		{
+			"codepoint": 63207,
+			"name": "elevation"
+		},
+		{
+			"codepoint": 61856,
+			"name": "elevator"
+		},
+		{
+			"codepoint": 57689,
+			"name": "email"
+		},
+		{
+			"codepoint": 57835,
+			"name": "emergency"
+		},
+		{
+			"codepoint": 61789,
+			"name": "emergency_heat"
+		},
+		{
+			"codepoint": 62693,
+			"name": "emergency_heat_2"
+		},
+		{
+			"codepoint": 59434,
+			"name": "emergency_home"
+		},
+		{
+			"codepoint": 60404,
+			"name": "emergency_recording"
+		},
+		{
+			"codepoint": 60406,
+			"name": "emergency_share"
+		},
+		{
+			"codepoint": 62878,
+			"name": "emergency_share_off"
+		},
+		{
+			"codepoint": 59938,
+			"name": "emoji_emotions"
+		},
+		{
+			"codepoint": 59939,
+			"name": "emoji_events"
+		},
+		{
+			"codepoint": 61638,
+			"name": "emoji_flags"
+		},
+		{
+			"codepoint": 59931,
+			"name": "emoji_food_beverage"
+		},
+		{
+			"codepoint": 62669,
+			"name": "emoji_language"
+		},
+		{
+			"codepoint": 59932,
+			"name": "emoji_nature"
+		},
+		{
+			"codepoint": 59940,
+			"name": "emoji_objects"
+		},
+		{
+			"codepoint": 59933,
+			"name": "emoji_people"
+		},
+		{
+			"codepoint": 59934,
+			"name": "emoji_symbols"
+		},
+		{
+			"codepoint": 59935,
+			"name": "emoji_transportation"
+		},
+		{
+			"codepoint": 58867,
+			"name": "emoticon"
+		},
+		{
+			"codepoint": 63556,
+			"name": "empty_dashboard"
+		},
+		{
+			"codepoint": 61832,
+			"name": "enable"
+		},
+		{
+			"codepoint": 58771,
+			"name": "encrypted"
+		},
+		{
+			"codepoint": 62505,
+			"name": "encrypted_add"
+		},
+		{
+			"codepoint": 62506,
+			"name": "encrypted_add_circle"
+		},
+		{
+			"codepoint": 62504,
+			"name": "encrypted_minus_circle"
+		},
+		{
+			"codepoint": 62503,
+			"name": "encrypted_off"
+		},
+		{
+			"codepoint": 57513,
+			"name": "endocrinology"
+		},
+		{
+			"codepoint": 59814,
+			"name": "energy"
+		},
+		{
+			"codepoint": 61791,
+			"name": "energy_program_saving"
+		},
+		{
+			"codepoint": 61793,
+			"name": "energy_program_time_used"
+		},
+		{
+			"codepoint": 60442,
+			"name": "energy_savings_leaf"
+		},
+		{
+			"codepoint": 59965,
+			"name": "engineering"
+		},
+		{
+			"codepoint": 58943,
+			"name": "enhanced_encryption"
+		},
+		{
+			"codepoint": 57514,
+			"name": "ent"
+		},
+		{
+			"codepoint": 59150,
+			"name": "enterprise"
+		},
+		{
+			"codepoint": 60237,
+			"name": "enterprise_off"
+		},
+		{
+			"codepoint": 63355,
+			"name": "equal"
+		},
+		{
+			"codepoint": 57373,
+			"name": "equalizer"
+		},
+		{
+			"codepoint": 62460,
+			"name": "eraser_size_1"
+		},
+		{
+			"codepoint": 62459,
+			"name": "eraser_size_2"
+		},
+		{
+			"codepoint": 62458,
+			"name": "eraser_size_3"
+		},
+		{
+			"codepoint": 62457,
+			"name": "eraser_size_4"
+		},
+		{
+			"codepoint": 62456,
+			"name": "eraser_size_5"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_circle_rounded"
+		},
+		{
+			"codepoint": 58523,
+			"name": "error_med"
+		},
+		{
+			"codepoint": 63670,
+			"name": "error_outline"
+		},
+		{
+			"codepoint": 61857,
+			"name": "escalator"
+		},
+		{
+			"codepoint": 61868,
+			"name": "escalator_warning"
+		},
+		{
+			"codepoint": 59925,
+			"name": "euro"
+		},
+		{
+			"codepoint": 59686,
+			"name": "euro_symbol"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_charger"
+		},
+		{
+			"codepoint": 63458,
+			"name": "ev_mobiledata_badge"
+		},
+		{
+			"codepoint": 61327,
+			"name": "ev_shadow"
+		},
+		{
+			"codepoint": 62848,
+			"name": "ev_shadow_add"
+		},
+		{
+			"codepoint": 62847,
+			"name": "ev_shadow_minus"
+		},
+		{
+			"codepoint": 58733,
+			"name": "ev_station"
+		},
+		{
+			"codepoint": 59512,
+			"name": "event"
+		},
+		{
+			"codepoint": 58900,
+			"name": "event_available"
+		},
+		{
+			"codepoint": 58901,
+			"name": "event_busy"
+		},
+		{
+			"codepoint": 63107,
+			"name": "event_list"
+		},
+		{
+			"codepoint": 58902,
+			"name": "event_note"
+		},
+		{
+			"codepoint": 60283,
+			"name": "event_repeat"
+		},
+		{
+			"codepoint": 59651,
+			"name": "event_seat"
+		},
+		{
+			"codepoint": 62008,
+			"name": "event_upcoming"
+		},
+		{
+			"codepoint": 61999,
+			"name": "exclamation"
+		},
+		{
+			"codepoint": 63206,
+			"name": "exercise"
+		},
+		{
+			"codepoint": 59513,
+			"name": "exit_to_app"
+		},
+		{
+			"codepoint": 59727,
+			"name": "expand"
+		},
+		{
+			"codepoint": 59718,
+			"name": "expand_all"
+		},
+		{
+			"codepoint": 59341,
+			"name": "expand_circle_down"
+		},
+		{
+			"codepoint": 62865,
+			"name": "expand_circle_right"
+		},
+		{
+			"codepoint": 62930,
+			"name": "expand_circle_up"
+		},
+		{
+			"codepoint": 63536,
+			"name": "expand_content"
+		},
+		{
+			"codepoint": 58830,
+			"name": "expand_less"
+		},
+		{
+			"codepoint": 58831,
+			"name": "expand_more"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expansion_panels"
+		},
+		{
+			"codepoint": 61328,
+			"name": "expension_panels"
+		},
+		{
+			"codepoint": 59014,
+			"name": "experiment"
+		},
+		{
+			"codepoint": 57374,
+			"name": "explicit"
+		},
+		{
+			"codepoint": 59514,
+			"name": "explore"
+		},
+		{
+			"codepoint": 58680,
+			"name": "explore_nearby"
+		},
+		{
+			"codepoint": 59816,
+			"name": "explore_off"
+		},
+		{
+			"codepoint": 63109,
+			"name": "explosion"
+		},
+		{
+			"codepoint": 57516,
+			"name": "export_notes"
+		},
+		{
+			"codepoint": 58358,
+			"name": "exposure"
+		},
+		{
+			"codepoint": 58315,
+			"name": "exposure_neg_1"
+		},
+		{
+			"codepoint": 58316,
+			"name": "exposure_neg_2"
+		},
+		{
+			"codepoint": 59392,
+			"name": "exposure_plus_1"
+		},
+		{
+			"codepoint": 58318,
+			"name": "exposure_plus_2"
+		},
+		{
+			"codepoint": 58319,
+			"name": "exposure_zero"
+		},
+		{
+			"codepoint": 59515,
+			"name": "extension"
+		},
+		{
+			"codepoint": 58613,
+			"name": "extension_off"
+		},
+		{
+			"codepoint": 62665,
+			"name": "eye_tracking"
+		},
+		{
+			"codepoint": 61107,
+			"name": "eyebrow"
+		},
+		{
+			"codepoint": 63214,
+			"name": "eyeglasses"
+		},
+		{
+			"codepoint": 62151,
+			"name": "eyeglasses_2"
+		},
+		{
+			"codepoint": 62053,
+			"name": "eyeglasses_2_sound"
+		},
+		{
+			"codepoint": 1048305,
+			"name": "eyeglasses_3"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face"
+		},
+		{
+			"codepoint": 63706,
+			"name": "face_2"
+		},
+		{
+			"codepoint": 63707,
+			"name": "face_3"
+		},
+		{
+			"codepoint": 63708,
+			"name": "face_4"
+		},
+		{
+			"codepoint": 63709,
+			"name": "face_5"
+		},
+		{
+			"codepoint": 63710,
+			"name": "face_6"
+		},
+		{
+			"codepoint": 62466,
+			"name": "face_down"
+		},
+		{
+			"codepoint": 62465,
+			"name": "face_left"
+		},
+		{
+			"codepoint": 62464,
+			"name": "face_nod"
+		},
+		{
+			"codepoint": 61262,
+			"name": "face_retouching_natural"
+		},
+		{
+			"codepoint": 61447,
+			"name": "face_retouching_off"
+		},
+		{
+			"codepoint": 62463,
+			"name": "face_right"
+		},
+		{
+			"codepoint": 62462,
+			"name": "face_shake"
+		},
+		{
+			"codepoint": 61448,
+			"name": "face_unlock"
+		},
+		{
+			"codepoint": 62461,
+			"name": "face_up"
+		},
+		{
+			"codepoint": 61637,
+			"name": "fact_check"
+		},
+		{
+			"codepoint": 60348,
+			"name": "factory"
+		},
+		{
+			"codepoint": 62989,
+			"name": "falling"
+		},
+		{
+			"codepoint": 57884,
+			"name": "familiar_face_and_zone"
+		},
+		{
+			"codepoint": 61170,
+			"name": "family_group"
+		},
+		{
+			"codepoint": 57517,
+			"name": "family_history"
+		},
+		{
+			"codepoint": 60198,
+			"name": "family_home"
+		},
+		{
+			"codepoint": 60185,
+			"name": "family_link"
+		},
+		{
+			"codepoint": 61858,
+			"name": "family_restroom"
+		},
+		{
+			"codepoint": 62759,
+			"name": "family_star"
+		},
+		{
+			"codepoint": 62260,
+			"name": "fan_focus"
+		},
+		{
+			"codepoint": 62259,
+			"name": "fan_indirect"
+		},
+		{
+			"codepoint": 62809,
+			"name": "farsight_digital"
+		},
+		{
+			"codepoint": 57375,
+			"name": "fast_forward"
+		},
+		{
+			"codepoint": 57376,
+			"name": "fast_rewind"
+		},
+		{
+			"codepoint": 58746,
+			"name": "fastfood"
+		},
+		{
+			"codepoint": 57976,
+			"name": "faucet"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite"
+		},
+		{
+			"codepoint": 59518,
+			"name": "favorite_border"
+		},
+		{
+			"codepoint": 60120,
+			"name": "fax"
+		},
+		{
+			"codepoint": 59817,
+			"name": "feature_search"
+		},
+		{
+			"codepoint": 57453,
+			"name": "featured_play_list"
+		},
+		{
+			"codepoint": 61329,
+			"name": "featured_seasonal_and_gifts"
+		},
+		{
+			"codepoint": 57454,
+			"name": "featured_video"
+		},
+		{
+			"codepoint": 61449,
+			"name": "feed"
+		},
+		{
+			"codepoint": 59519,
+			"name": "feedback"
+		},
+		{
+			"codepoint": 58768,
+			"name": "female"
+		},
+		{
+			"codepoint": 63633,
+			"name": "femur"
+		},
+		{
+			"codepoint": 63634,
+			"name": "femur_alt"
+		},
+		{
+			"codepoint": 61942,
+			"name": "fence"
+		},
+		{
+			"codepoint": 63205,
+			"name": "fertile"
+		},
+		{
+			"codepoint": 60008,
+			"name": "festival"
+		},
+		{
+			"codepoint": 57437,
+			"name": "fiber_dvr"
+		},
+		{
+			"codepoint": 57441,
+			"name": "fiber_manual_record"
+		},
+		{
+			"codepoint": 57438,
+			"name": "fiber_new"
+		},
+		{
+			"codepoint": 57450,
+			"name": "fiber_pin"
+		},
+		{
+			"codepoint": 57442,
+			"name": "fiber_smart_record"
+		},
+		{
+			"codepoint": 57715,
+			"name": "file_copy"
+		},
+		{
+			"codepoint": 62680,
+			"name": "file_copy_off"
+		},
+		{
+			"codepoint": 61584,
+			"name": "file_download"
+		},
+		{
+			"codepoint": 61585,
+			"name": "file_download_done"
+		},
+		{
+			"codepoint": 58622,
+			"name": "file_download_off"
+		},
+		{
+			"codepoint": 62386,
+			"name": "file_export"
+		},
+		{
+			"codepoint": 62395,
+			"name": "file_json"
+		},
+		{
+			"codepoint": 58053,
+			"name": "file_map"
+		},
+		{
+			"codepoint": 62434,
+			"name": "file_map_stack"
+		},
+		{
+			"codepoint": 60147,
+			"name": "file_open"
+		},
+		{
+			"codepoint": 62396,
+			"name": "file_png"
+		},
+		{
+			"codepoint": 59918,
+			"name": "file_present"
+		},
+		{
+			"codepoint": 61823,
+			"name": "file_save"
+		},
+		{
+			"codepoint": 58629,
+			"name": "file_save_off"
+		},
+		{
+			"codepoint": 61595,
+			"name": "file_upload"
+		},
+		{
+			"codepoint": 63622,
+			"name": "file_upload_off"
+		},
+		{
+			"codepoint": 60037,
+			"name": "files"
+		},
+		{
+			"codepoint": 58323,
+			"name": "filter"
+		},
+		{
+			"codepoint": 58320,
+			"name": "filter_1"
+		},
+		{
+			"codepoint": 58321,
+			"name": "filter_2"
+		},
+		{
+			"codepoint": 58322,
+			"name": "filter_3"
+		},
+		{
+			"codepoint": 58324,
+			"name": "filter_4"
+		},
+		{
+			"codepoint": 58325,
+			"name": "filter_5"
+		},
+		{
+			"codepoint": 58326,
+			"name": "filter_6"
+		},
+		{
+			"codepoint": 58327,
+			"name": "filter_7"
+		},
+		{
+			"codepoint": 58328,
+			"name": "filter_8"
+		},
+		{
+			"codepoint": 58329,
+			"name": "filter_9"
+		},
+		{
+			"codepoint": 58330,
+			"name": "filter_9_plus"
+		},
+		{
+			"codepoint": 61263,
+			"name": "filter_alt"
+		},
+		{
+			"codepoint": 60210,
+			"name": "filter_alt_off"
+		},
+		{
+			"codepoint": 62417,
+			"name": "filter_arrow_right"
+		},
+		{
+			"codepoint": 58331,
+			"name": "filter_b_and_w"
+		},
+		{
+			"codepoint": 58332,
+			"name": "filter_center_focus"
+		},
+		{
+			"codepoint": 58333,
+			"name": "filter_drama"
+		},
+		{
+			"codepoint": 58334,
+			"name": "filter_frames"
+		},
+		{
+			"codepoint": 58335,
+			"name": "filter_hdr"
+		},
+		{
+			"codepoint": 57682,
+			"name": "filter_list"
+		},
+		{
+			"codepoint": 59726,
+			"name": "filter_list_alt"
+		},
+		{
+			"codepoint": 60247,
+			"name": "filter_list_off"
+		},
+		{
+			"codepoint": 58336,
+			"name": "filter_none"
+		},
+		{
+			"codepoint": 58337,
+			"name": "filter_retrolux"
+		},
+		{
+			"codepoint": 58338,
+			"name": "filter_tilt_shift"
+		},
+		{
+			"codepoint": 58339,
+			"name": "filter_vintage"
+		},
+		{
+			"codepoint": 59071,
+			"name": "finance"
+		},
+		{
+			"codepoint": 63566,
+			"name": "finance_chip"
+		},
+		{
+			"codepoint": 61330,
+			"name": "finance_mode"
+		},
+		{
+			"codepoint": 59520,
+			"name": "find_in_page"
+		},
+		{
+			"codepoint": 59521,
+			"name": "find_replace"
+		},
+		{
+			"codepoint": 59661,
+			"name": "fingerprint"
+		},
+		{
+			"codepoint": 62621,
+			"name": "fingerprint_off"
+		},
+		{
+			"codepoint": 1048488,
+			"name": "fire_check"
+		},
+		{
+			"codepoint": 61912,
+			"name": "fire_extinguisher"
+		},
+		{
+			"codepoint": 61859,
+			"name": "fire_hydrant"
+		},
+		{
+			"codepoint": 63730,
+			"name": "fire_truck"
+		},
+		{
+			"codepoint": 59971,
+			"name": "fireplace"
+		},
+		{
+			"codepoint": 58844,
+			"name": "first_page"
+		},
+		{
+			"codepoint": 63354,
+			"name": "fit_page"
+		},
+		{
+			"codepoint": 62359,
+			"name": "fit_page_height"
+		},
+		{
+			"codepoint": 62358,
+			"name": "fit_page_width"
+		},
+		{
+			"codepoint": 59920,
+			"name": "fit_screen"
+		},
+		{
+			"codepoint": 63353,
+			"name": "fit_width"
+		},
+		{
+			"codepoint": 60227,
+			"name": "fitness_center"
+		},
+		{
+			"codepoint": 62563,
+			"name": "fitness_tracker"
+		},
+		{
+			"codepoint": 61169,
+			"name": "fitness_trackers"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag"
+		},
+		{
+			"codepoint": 62479,
+			"name": "flag_2"
+		},
+		{
+			"codepoint": 62424,
+			"name": "flag_check"
+		},
+		{
+			"codepoint": 60152,
+			"name": "flag_circle"
+		},
+		{
+			"codepoint": 61638,
+			"name": "flag_filled"
+		},
+		{
+			"codepoint": 61264,
+			"name": "flaky"
+		},
+		{
+			"codepoint": 58340,
+			"name": "flare"
+		},
+		{
+			"codepoint": 58341,
+			"name": "flash_auto"
+		},
+		{
+			"codepoint": 58342,
+			"name": "flash_off"
+		},
+		{
+			"codepoint": 58343,
+			"name": "flash_on"
+		},
+		{
+			"codepoint": 61450,
+			"name": "flashlight_off"
+		},
+		{
+			"codepoint": 61451,
+			"name": "flashlight_on"
+		},
+		{
+			"codepoint": 61452,
+			"name": "flatware"
+		},
+		{
+			"codepoint": 63352,
+			"name": "flex_direction"
+		},
+		{
+			"codepoint": 63351,
+			"name": "flex_no_wrap"
+		},
+		{
+			"codepoint": 63350,
+			"name": "flex_wrap"
+		},
+		{
+			"codepoint": 58681,
+			"name": "flight"
+		},
+		{
+			"codepoint": 59339,
+			"name": "flight_class"
+		},
+		{
+			"codepoint": 59652,
+			"name": "flight_land"
+		},
+		{
+			"codepoint": 59653,
+			"name": "flight_takeoff"
+		},
+		{
+			"codepoint": 59819,
+			"name": "flights_and_hotels"
+		},
+		{
+			"codepoint": 61331,
+			"name": "flightsmode"
+		},
+		{
+			"codepoint": 58344,
+			"name": "flip"
+		},
+		{
+			"codepoint": 59959,
+			"name": "flip_camera_android"
+		},
+		{
+			"codepoint": 59960,
+			"name": "flip_camera_ios"
+		},
+		{
+			"codepoint": 59522,
+			"name": "flip_to_back"
+		},
+		{
+			"codepoint": 59523,
+			"name": "flip_to_front"
+		},
+		{
+			"codepoint": 62556,
+			"name": "float_landscape_2"
+		},
+		{
+			"codepoint": 62555,
+			"name": "float_portrait_2"
+		},
+		{
+			"codepoint": 60390,
+			"name": "flood"
+		},
+		{
+			"codepoint": 63204,
+			"name": "floor"
+		},
+		{
+			"codepoint": 57886,
+			"name": "floor_lamp"
+		},
+		{
+			"codepoint": 61565,
+			"name": "flourescent"
+		},
+		{
+			"codepoint": 62349,
+			"name": "flowchart"
+		},
+		{
+			"codepoint": 57518,
+			"name": "flowsheet"
+		},
+		{
+			"codepoint": 58499,
+			"name": "fluid"
+		},
+		{
+			"codepoint": 63501,
+			"name": "fluid_balance"
+		},
+		{
+			"codepoint": 63500,
+			"name": "fluid_med"
+		},
+		{
+			"codepoint": 61565,
+			"name": "fluorescent"
+		},
+		{
+			"codepoint": 61917,
+			"name": "flutter"
+		},
+		{
+			"codepoint": 57355,
+			"name": "flutter_dash"
+		},
+		{
+			"codepoint": 62584,
+			"name": "flyover"
+		},
+		{
+			"codepoint": 61454,
+			"name": "fmd_bad"
+		},
+		{
+			"codepoint": 61915,
+			"name": "fmd_good"
+		},
+		{
+			"codepoint": 59416,
+			"name": "foggy"
+		},
+		{
+			"codepoint": 62957,
+			"name": "folded_hands"
+		},
+		{
+			"codepoint": 58055,
+			"name": "folder"
+		},
+		{
+			"codepoint": 62423,
+			"name": "folder_check"
+		},
+		{
+			"codepoint": 62422,
+			"name": "folder_check_2"
+		},
+		{
+			"codepoint": 62408,
+			"name": "folder_code"
+		},
+		{
+			"codepoint": 60349,
+			"name": "folder_copy"
+		},
+		{
+			"codepoint": 62854,
+			"name": "folder_data"
+		},
+		{
+			"codepoint": 60212,
+			"name": "folder_delete"
+		},
+		{
+			"codepoint": 62421,
+			"name": "folder_eye"
+		},
+		{
+			"codepoint": 62357,
+			"name": "folder_info"
+		},
+		{
+			"codepoint": 62692,
+			"name": "folder_limited"
+		},
+		{
+			"codepoint": 63349,
+			"name": "folder_managed"
+		},
+		{
+			"codepoint": 62420,
+			"name": "folder_match"
+		},
+		{
+			"codepoint": 60291,
+			"name": "folder_off"
+		},
+		{
+			"codepoint": 58056,
+			"name": "folder_open"
+		},
+		{
+			"codepoint": 58057,
+			"name": "folder_shared"
+		},
+		{
+			"codepoint": 58903,
+			"name": "folder_special"
+		},
+		{
+			"codepoint": 63348,
+			"name": "folder_supervised"
+		},
+		{
+			"codepoint": 60204,
+			"name": "folder_zip"
+		},
+		{
+			"codepoint": 61986,
+			"name": "follow_the_signs"
+		},
+		{
+			"codepoint": 57703,
+			"name": "font_download"
+		},
+		{
+			"codepoint": 58617,
+			"name": "font_download_off"
+		},
+		{
+			"codepoint": 61938,
+			"name": "food_bank"
+		},
+		{
+			"codepoint": 63635,
+			"name": "foot_bones"
+		},
+		{
+			"codepoint": 63613,
+			"name": "footprint"
+		},
+		{
+			"codepoint": 59820,
+			"name": "for_you"
+		},
+		{
+			"codepoint": 60057,
+			"name": "forest"
+		},
+		{
+			"codepoint": 1048486,
+			"name": "fork_chart"
+		},
+		{
+			"codepoint": 60320,
+			"name": "fork_left"
+		},
+		{
+			"codepoint": 60332,
+			"name": "fork_right"
+		},
+		{
+			"codepoint": 62436,
+			"name": "fork_spoon"
+		},
+		{
+			"codepoint": 63592,
+			"name": "forklift"
+		},
+		{
+			"codepoint": 57908,
+			"name": "format_align_center"
+		},
+		{
+			"codepoint": 57909,
+			"name": "format_align_justify"
+		},
+		{
+			"codepoint": 57910,
+			"name": "format_align_left"
+		},
+		{
+			"codepoint": 57911,
+			"name": "format_align_right"
+		},
+		{
+			"codepoint": 57912,
+			"name": "format_bold"
+		},
+		{
+			"codepoint": 57913,
+			"name": "format_clear"
+		},
+		{
+			"codepoint": 57914,
+			"name": "format_color_fill"
+		},
+		{
+			"codepoint": 57915,
+			"name": "format_color_reset"
+		},
+		{
+			"codepoint": 57916,
+			"name": "format_color_text"
+		},
+		{
+			"codepoint": 63581,
+			"name": "format_h1"
+		},
+		{
+			"codepoint": 63582,
+			"name": "format_h2"
+		},
+		{
+			"codepoint": 63583,
+			"name": "format_h3"
+		},
+		{
+			"codepoint": 63584,
+			"name": "format_h4"
+		},
+		{
+			"codepoint": 63585,
+			"name": "format_h5"
+		},
+		{
+			"codepoint": 63586,
+			"name": "format_h6"
+		},
+		{
+			"codepoint": 61104,
+			"name": "format_image_back"
+		},
+		{
+			"codepoint": 61103,
+			"name": "format_image_break_left"
+		},
+		{
+			"codepoint": 61102,
+			"name": "format_image_break_right"
+		},
+		{
+			"codepoint": 61101,
+			"name": "format_image_front"
+		},
+		{
+			"codepoint": 61100,
+			"name": "format_image_inline_left"
+		},
+		{
+			"codepoint": 1048573,
+			"name": "format_image_inline_right"
+		},
+		{
+			"codepoint": 63587,
+			"name": "format_image_left"
+		},
+		{
+			"codepoint": 63588,
+			"name": "format_image_right"
+		},
+		{
+			"codepoint": 57917,
+			"name": "format_indent_decrease"
+		},
+		{
+			"codepoint": 57918,
+			"name": "format_indent_increase"
+		},
+		{
+			"codepoint": 63531,
+			"name": "format_ink_highlighter"
+		},
+		{
+			"codepoint": 57919,
+			"name": "format_italic"
+		},
+		{
+			"codepoint": 63347,
+			"name": "format_letter_spacing"
+		},
+		{
+			"codepoint": 63000,
+			"name": "format_letter_spacing_2"
+		},
+		{
+			"codepoint": 62999,
+			"name": "format_letter_spacing_standard"
+		},
+		{
+			"codepoint": 62998,
+			"name": "format_letter_spacing_wide"
+		},
+		{
+			"codepoint": 62997,
+			"name": "format_letter_spacing_wider"
+		},
+		{
+			"codepoint": 57920,
+			"name": "format_line_spacing"
+		},
+		{
+			"codepoint": 57921,
+			"name": "format_list_bulleted"
+		},
+		{
+			"codepoint": 63561,
+			"name": "format_list_bulleted_add"
+		},
+		{
+			"codepoint": 57922,
+			"name": "format_list_numbered"
+		},
+		{
+			"codepoint": 57959,
+			"name": "format_list_numbered_rtl"
+		},
+		{
+			"codepoint": 60261,
+			"name": "format_overline"
+		},
+		{
+			"codepoint": 57923,
+			"name": "format_paint"
+		},
+		{
+			"codepoint": 1048471,
+			"name": "format_paint_off"
+		},
+		{
+			"codepoint": 63589,
+			"name": "format_paragraph"
+		},
+		{
+			"codepoint": 57924,
+			"name": "format_quote"
+		},
+		{
+			"codepoint": 62483,
+			"name": "format_quote_off"
+		},
+		{
+			"codepoint": 57950,
+			"name": "format_shapes"
+		},
+		{
+			"codepoint": 57925,
+			"name": "format_size"
+		},
+		{
+			"codepoint": 57926,
+			"name": "format_strikethrough"
+		},
+		{
+			"codepoint": 63530,
+			"name": "format_text_clip"
+		},
+		{
+			"codepoint": 63529,
+			"name": "format_text_overflow"
+		},
+		{
+			"codepoint": 63528,
+			"name": "format_text_wrap"
+		},
+		{
+			"codepoint": 57927,
+			"name": "format_textdirection_l_to_r"
+		},
+		{
+			"codepoint": 57928,
+			"name": "format_textdirection_r_to_l"
+		},
+		{
+			"codepoint": 62648,
+			"name": "format_textdirection_vertical"
+		},
+		{
+			"codepoint": 57929,
+			"name": "format_underlined"
+		},
+		{
+			"codepoint": 63621,
+			"name": "format_underlined_squiggle"
+		},
+		{
+			"codepoint": 61639,
+			"name": "forms_add_on"
+		},
+		{
+			"codepoint": 61640,
+			"name": "forms_apps_script"
+		},
+		{
+			"codepoint": 60077,
+			"name": "fort"
+		},
+		{
+			"codepoint": 59567,
+			"name": "forum"
+		},
+		{
+			"codepoint": 62842,
+			"name": "forward"
+		},
+		{
+			"codepoint": 57430,
+			"name": "forward_10"
+		},
+		{
+			"codepoint": 57431,
+			"name": "forward_30"
+		},
+		{
+			"codepoint": 57432,
+			"name": "forward_5"
+		},
+		{
+			"codepoint": 63221,
+			"name": "forward_circle"
+		},
+		{
+			"codepoint": 63220,
+			"name": "forward_media"
+		},
+		{
+			"codepoint": 61831,
+			"name": "forward_to_inbox"
+		},
+		{
+			"codepoint": 61952,
+			"name": "foundation"
+		},
+		{
+			"codepoint": 62277,
+			"name": "fragrance"
+		},
+		{
+			"codepoint": 61167,
+			"name": "frame_bug"
+		},
+		{
+			"codepoint": 61166,
+			"name": "frame_exclamation"
+		},
+		{
+			"codepoint": 63346,
+			"name": "frame_inspect"
+		},
+		{
+			"codepoint": 63654,
+			"name": "frame_person"
+		},
+		{
+			"codepoint": 62677,
+			"name": "frame_person_mic"
+		},
+		{
+			"codepoint": 63441,
+			"name": "frame_person_off"
+		},
+		{
+			"codepoint": 63345,
+			"name": "frame_reload"
+		},
+		{
+			"codepoint": 63344,
+			"name": "frame_source"
+		},
+		{
+			"codepoint": 60228,
+			"name": "free_breakfast"
+		},
+		{
+			"codepoint": 59208,
+			"name": "free_cancellation"
+		},
+		{
+			"codepoint": 59241,
+			"name": "front_hand"
+		},
+		{
+			"codepoint": 63593,
+			"name": "front_loader"
+		},
+		{
+			"codepoint": 60178,
+			"name": "full_coverage"
+		},
+		{
+			"codepoint": 62859,
+			"name": "full_hd"
+		},
+		{
+			"codepoint": 61970,
+			"name": "full_stacked_bar_chart"
+		},
+		{
+			"codepoint": 58832,
+			"name": "fullscreen"
+		},
+		{
+			"codepoint": 58833,
+			"name": "fullscreen_exit"
+		},
+		{
+			"codepoint": 62554,
+			"name": "fullscreen_portrait"
+		},
+		{
+			"codepoint": 63590,
+			"name": "function"
+		},
+		{
+			"codepoint": 57930,
+			"name": "functions"
+		},
+		{
+			"codepoint": 62583,
+			"name": "funicular"
+		},
+		{
+			"codepoint": 61456,
+			"name": "g_mobiledata"
+		},
+		{
+			"codepoint": 63457,
+			"name": "g_mobiledata_badge"
+		},
+		{
+			"codepoint": 59687,
+			"name": "g_translate"
+		},
+		{
+			"codepoint": 63599,
+			"name": "gallery_thumbnail"
+		},
+		{
+			"codepoint": 61152,
+			"name": "game_bumper_left"
+		},
+		{
+			"codepoint": 61151,
+			"name": "game_bumper_right"
+		},
+		{
+			"codepoint": 61150,
+			"name": "game_button_l"
+		},
+		{
+			"codepoint": 61149,
+			"name": "game_button_l1"
+		},
+		{
+			"codepoint": 61148,
+			"name": "game_button_l2"
+		},
+		{
+			"codepoint": 61147,
+			"name": "game_button_r"
+		},
+		{
+			"codepoint": 61146,
+			"name": "game_button_r1"
+		},
+		{
+			"codepoint": 61145,
+			"name": "game_button_r2"
+		},
+		{
+			"codepoint": 61144,
+			"name": "game_button_zl"
+		},
+		{
+			"codepoint": 61143,
+			"name": "game_button_zr"
+		},
+		{
+			"codepoint": 61142,
+			"name": "game_stick_l3"
+		},
+		{
+			"codepoint": 61141,
+			"name": "game_stick_left"
+		},
+		{
+			"codepoint": 61140,
+			"name": "game_stick_r3"
+		},
+		{
+			"codepoint": 61139,
+			"name": "game_stick_right"
+		},
+		{
+			"codepoint": 61138,
+			"name": "game_trigger_left"
+		},
+		{
+			"codepoint": 61137,
+			"name": "game_trigger_right"
+		},
+		{
+			"codepoint": 58127,
+			"name": "gamepad"
+		},
+		{
+			"codepoint": 61136,
+			"name": "gamepad_circle_down"
+		},
+		{
+			"codepoint": 61135,
+			"name": "gamepad_circle_left"
+		},
+		{
+			"codepoint": 61134,
+			"name": "gamepad_circle_right"
+		},
+		{
+			"codepoint": 61133,
+			"name": "gamepad_circle_up"
+		},
+		{
+			"codepoint": 61132,
+			"name": "gamepad_down"
+		},
+		{
+			"codepoint": 61131,
+			"name": "gamepad_left"
+		},
+		{
+			"codepoint": 61130,
+			"name": "gamepad_right"
+		},
+		{
+			"codepoint": 61129,
+			"name": "gamepad_up"
+		},
+		{
+			"codepoint": 58127,
+			"name": "games"
+		},
+		{
+			"codepoint": 61457,
+			"name": "garage"
+		},
+		{
+			"codepoint": 62093,
+			"name": "garage_check"
+		},
+		{
+			"codepoint": 59156,
+			"name": "garage_door"
+		},
+		{
+			"codepoint": 1048439,
+			"name": "garage_door_open"
+		},
+		{
+			"codepoint": 59437,
+			"name": "garage_home"
+		},
+		{
+			"codepoint": 62092,
+			"name": "garage_money"
+		},
+		{
+			"codepoint": 63657,
+			"name": "garden_cart"
+		},
+		{
+			"codepoint": 60441,
+			"name": "gas_meter"
+		},
+		{
+			"codepoint": 57585,
+			"name": "gastroenterology"
+		},
+		{
+			"codepoint": 57975,
+			"name": "gate"
+		},
+		{
+			"codepoint": 59662,
+			"name": "gavel"
+		},
+		{
+			"codepoint": 59102,
+			"name": "general_device"
+		},
+		{
+			"codepoint": 59209,
+			"name": "generating_tokens"
+		},
+		{
+			"codepoint": 57587,
+			"name": "genetics"
+		},
+		{
+			"codepoint": 59118,
+			"name": "genres"
+		},
+		{
+			"codepoint": 57685,
+			"name": "gesture"
+		},
+		{
+			"codepoint": 63063,
+			"name": "gesture_select"
+		},
+		{
+			"codepoint": 61584,
+			"name": "get_app"
+		},
+		{
+			"codepoint": 59656,
+			"name": "gif"
+		},
+		{
+			"codepoint": 62478,
+			"name": "gif_2"
+		},
+		{
+			"codepoint": 59299,
+			"name": "gif_box"
+		},
+		{
+			"codepoint": 60264,
+			"name": "girl"
+		},
+		{
+			"codepoint": 58763,
+			"name": "gite"
+		},
+		{
+			"codepoint": 63203,
+			"name": "glass_cup"
+		},
+		{
+			"codepoint": 58956,
+			"name": "globe"
+		},
+		{
+			"codepoint": 1048503,
+			"name": "globe_2_cancel"
+		},
+		{
+			"codepoint": 1048502,
+			"name": "globe_2_question"
+		},
+		{
+			"codepoint": 63385,
+			"name": "globe_asia"
+		},
+		{
+			"codepoint": 62409,
+			"name": "globe_book"
+		},
+		{
+			"codepoint": 62301,
+			"name": "globe_location_pin"
+		},
+		{
+			"codepoint": 63384,
+			"name": "globe_uk"
+		},
+		{
+			"codepoint": 58528,
+			"name": "glucose"
+		},
+		{
+			"codepoint": 63651,
+			"name": "glyphs"
+		},
+		{
+			"codepoint": 63261,
+			"name": "go_to_line"
+		},
+		{
+			"codepoint": 60229,
+			"name": "golf_course"
+		},
+		{
+			"codepoint": 62582,
+			"name": "gondola_lift"
+		},
+		{
+			"codepoint": 59157,
+			"name": "google_home_devices"
+		},
+		{
+			"codepoint": 62842,
+			"name": "google_plus_reshare"
+		},
+		{
+			"codepoint": 62939,
+			"name": "google_tv_remote"
+		},
+		{
+			"codepoint": 62841,
+			"name": "google_wifi"
+		},
+		{
+			"codepoint": 61458,
+			"name": "gpp_bad"
+		},
+		{
+			"codepoint": 61459,
+			"name": "gpp_good"
+		},
+		{
+			"codepoint": 61460,
+			"name": "gpp_maybe"
+		},
+		{
+			"codepoint": 58716,
+			"name": "gps_fixed"
+		},
+		{
+			"codepoint": 57783,
+			"name": "gps_not_fixed"
+		},
+		{
+			"codepoint": 57782,
+			"name": "gps_off"
+		},
+		{
+			"codepoint": 61594,
+			"name": "grade"
+		},
+		{
+			"codepoint": 58345,
+			"name": "gradient"
+		},
+		{
+			"codepoint": 59983,
+			"name": "grading"
+		},
+		{
+			"codepoint": 58346,
+			"name": "grain"
+		},
+		{
+			"codepoint": 62368,
+			"name": "graph_1"
+		},
+		{
+			"codepoint": 62367,
+			"name": "graph_2"
+		},
+		{
+			"codepoint": 62366,
+			"name": "graph_3"
+		},
+		{
+			"codepoint": 62365,
+			"name": "graph_4"
+		},
+		{
+			"codepoint": 62364,
+			"name": "graph_5"
+		},
+		{
+			"codepoint": 62363,
+			"name": "graph_6"
+		},
+		{
+			"codepoint": 62278,
+			"name": "graph_7"
+		},
+		{
+			"codepoint": 1048556,
+			"name": "graph_8"
+		},
+		{
+			"codepoint": 57784,
+			"name": "graphic_eq"
+		},
+		{
+			"codepoint": 1048472,
+			"name": "graphic_eq_off"
+		},
+		{
+			"codepoint": 61957,
+			"name": "grass"
+		},
+		{
+			"codepoint": 61461,
+			"name": "grid_3x3"
+		},
+		{
+			"codepoint": 63100,
+			"name": "grid_3x3_off"
+		},
+		{
+			"codepoint": 61462,
+			"name": "grid_4x4"
+		},
+		{
+			"codepoint": 61463,
+			"name": "grid_goldenratio"
+		},
+		{
+			"codepoint": 63343,
+			"name": "grid_guides"
+		},
+		{
+			"codepoint": 1048461,
+			"name": "grid_layout_side"
+		},
+		{
+			"codepoint": 58347,
+			"name": "grid_off"
+		},
+		{
+			"codepoint": 58348,
+			"name": "grid_on"
+		},
+		{
+			"codepoint": 59824,
+			"name": "grid_view"
+		},
+		{
+			"codepoint": 61335,
+			"name": "grocery"
+		},
+		{
+			"codepoint": 59937,
+			"name": "group"
+		},
+		{
+			"codepoint": 59376,
+			"name": "group_add"
+		},
+		{
+			"codepoint": 59207,
+			"name": "group_off"
+		},
+		{
+			"codepoint": 59309,
+			"name": "group_remove"
+		},
+		{
+			"codepoint": 62414,
+			"name": "group_search"
+		},
+		{
+			"codepoint": 59526,
+			"name": "group_work"
+		},
+		{
+			"codepoint": 61969,
+			"name": "grouped_bar_chart"
+		},
+		{
+			"codepoint": 62003,
+			"name": "groups"
+		},
+		{
+			"codepoint": 63711,
+			"name": "groups_2"
+		},
+		{
+			"codepoint": 63712,
+			"name": "groups_3"
+		},
+		{
+			"codepoint": 62657,
+			"name": "guardian"
+		},
+		{
+			"codepoint": 57588,
+			"name": "gynecology"
+		},
+		{
+			"codepoint": 61464,
+			"name": "h_mobiledata"
+		},
+		{
+			"codepoint": 63456,
+			"name": "h_mobiledata_badge"
+		},
+		{
+			"codepoint": 61465,
+			"name": "h_plus_mobiledata"
+		},
+		{
+			"codepoint": 63455,
+			"name": "h_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 59825,
+			"name": "hail"
+		},
+		{
+			"codepoint": 59128,
+			"name": "hallway"
+		},
+		{
+			"codepoint": 62015,
+			"name": "hanami_dango"
+		},
+		{
+			"codepoint": 63636,
+			"name": "hand_bones"
+		},
+		{
+			"codepoint": 61340,
+			"name": "hand_gesture"
+		},
+		{
+			"codepoint": 62451,
+			"name": "hand_gesture_off"
+		},
+		{
+			"codepoint": 62100,
+			"name": "hand_meal"
+		},
+		{
+			"codepoint": 62099,
+			"name": "hand_package"
+		},
+		{
+			"codepoint": 62662,
+			"name": "handheld_controller"
+		},
+		{
+			"codepoint": 60363,
+			"name": "handshake"
+		},
+		{
+			"codepoint": 60162,
+			"name": "handwriting_recognition"
+		},
+		{
+			"codepoint": 61707,
+			"name": "handyman"
+		},
+		{
+			"codepoint": 57537,
+			"name": "hangout_video"
+		},
+		{
+			"codepoint": 57538,
+			"name": "hangout_video_off"
+		},
+		{
+			"codepoint": 62426,
+			"name": "hard_disk"
+		},
+		{
+			"codepoint": 63502,
+			"name": "hard_drive"
+		},
+		{
+			"codepoint": 63396,
+			"name": "hard_drive_2"
+		},
+		{
+			"codepoint": 59993,
+			"name": "hardware"
+		},
+		{
+			"codepoint": 57426,
+			"name": "hd"
+		},
+		{
+			"codepoint": 61466,
+			"name": "hdr_auto"
+		},
+		{
+			"codepoint": 61467,
+			"name": "hdr_auto_select"
+		},
+		{
+			"codepoint": 61265,
+			"name": "hdr_enhanced_select"
+		},
+		{
+			"codepoint": 58349,
+			"name": "hdr_off"
+		},
+		{
+			"codepoint": 61468,
+			"name": "hdr_off_select"
+		},
+		{
+			"codepoint": 58350,
+			"name": "hdr_on"
+		},
+		{
+			"codepoint": 61469,
+			"name": "hdr_on_select"
+		},
+		{
+			"codepoint": 61470,
+			"name": "hdr_plus"
+		},
+		{
+			"codepoint": 58351,
+			"name": "hdr_plus_off"
+		},
+		{
+			"codepoint": 58353,
+			"name": "hdr_strong"
+		},
+		{
+			"codepoint": 58354,
+			"name": "hdr_weak"
+		},
+		{
+			"codepoint": 62661,
+			"name": "head_mounted_device"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headphones"
+		},
+		{
+			"codepoint": 61472,
+			"name": "headphones_battery"
+		},
+		{
+			"codepoint": 61471,
+			"name": "headset"
+		},
+		{
+			"codepoint": 58129,
+			"name": "headset_mic"
+		},
+		{
+			"codepoint": 58170,
+			"name": "headset_off"
+		},
+		{
+			"codepoint": 58355,
+			"name": "healing"
+		},
+		{
+			"codepoint": 61341,
+			"name": "health_and_beauty"
+		},
+		{
+			"codepoint": 57813,
+			"name": "health_and_safety"
+		},
+		{
+			"codepoint": 62147,
+			"name": "health_cross"
+		},
+		{
+			"codepoint": 63202,
+			"name": "health_metrics"
+		},
+		{
+			"codepoint": 63342,
+			"name": "heap_snapshot_large"
+		},
+		{
+			"codepoint": 63341,
+			"name": "heap_snapshot_multiple"
+		},
+		{
+			"codepoint": 63340,
+			"name": "heap_snapshot_thumbnail"
+		},
+		{
+			"codepoint": 57379,
+			"name": "hearing"
+		},
+		{
+			"codepoint": 62564,
+			"name": "hearing_aid"
+		},
+		{
+			"codepoint": 62384,
+			"name": "hearing_aid_disabled"
+		},
+		{
+			"codepoint": 62188,
+			"name": "hearing_aid_disabled_left"
+		},
+		{
+			"codepoint": 62189,
+			"name": "hearing_aid_left"
+		},
+		{
+			"codepoint": 61700,
+			"name": "hearing_disabled"
+		},
+		{
+			"codepoint": 60098,
+			"name": "heart_broken"
+		},
+		{
+			"codepoint": 62986,
+			"name": "heart_check"
+		},
+		{
+			"codepoint": 63619,
+			"name": "heart_minus"
+		},
+		{
+			"codepoint": 63620,
+			"name": "heart_plus"
+		},
+		{
+			"codepoint": 62098,
+			"name": "heart_smile"
+		},
+		{
+			"codepoint": 62775,
+			"name": "heat"
+		},
+		{
+			"codepoint": 60440,
+			"name": "heat_pump"
+		},
+		{
+			"codepoint": 57982,
+			"name": "heat_pump_balance"
+		},
+		{
+			"codepoint": 59926,
+			"name": "height"
+		},
+		{
+			"codepoint": 62988,
+			"name": "helicopter"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help"
+		},
+		{
+			"codepoint": 61888,
+			"name": "help_center"
+		},
+		{
+			"codepoint": 63504,
+			"name": "help_clinic"
+		},
+		{
+			"codepoint": 59645,
+			"name": "help_outline"
+		},
+		{
+			"codepoint": 57590,
+			"name": "hematology"
+		},
+		{
+			"codepoint": 61473,
+			"name": "hevc"
+		},
+		{
+			"codepoint": 60217,
+			"name": "hexagon"
+		},
+		{
+			"codepoint": 61342,
+			"name": "hide"
+		},
+		{
+			"codepoint": 61474,
+			"name": "hide_image"
+		},
+		{
+			"codepoint": 61475,
+			"name": "hide_source"
+		},
+		{
+			"codepoint": 62106,
+			"name": "high_chair"
+		},
+		{
+			"codepoint": 63388,
+			"name": "high_density"
+		},
+		{
+			"codepoint": 57380,
+			"name": "high_quality"
+		},
+		{
+			"codepoint": 62795,
+			"name": "high_res"
+		},
+		{
+			"codepoint": 57951,
+			"name": "highlight"
+		},
+		{
+			"codepoint": 61266,
+			"name": "highlight_alt"
+		},
+		{
+			"codepoint": 62736,
+			"name": "highlight_keyboard_focus"
+		},
+		{
+			"codepoint": 62737,
+			"name": "highlight_mouse_cursor"
+		},
+		{
+			"codepoint": 59528,
+			"name": "highlight_off"
+		},
+		{
+			"codepoint": 62738,
+			"name": "highlight_text_cursor"
+		},
+		{
+			"codepoint": 63339,
+			"name": "highlighter_size_1"
+		},
+		{
+			"codepoint": 63338,
+			"name": "highlighter_size_2"
+		},
+		{
+			"codepoint": 63337,
+			"name": "highlighter_size_3"
+		},
+		{
+			"codepoint": 63336,
+			"name": "highlighter_size_4"
+		},
+		{
+			"codepoint": 63335,
+			"name": "highlighter_size_5"
+		},
+		{
+			"codepoint": 58634,
+			"name": "hiking"
+		},
+		{
+			"codepoint": 59571,
+			"name": "history"
+		},
+		{
+			"codepoint": 62438,
+			"name": "history_2"
+		},
+		{
+			"codepoint": 59966,
+			"name": "history_edu"
+		},
+		{
+			"codepoint": 62682,
+			"name": "history_off"
+		},
+		{
+			"codepoint": 61821,
+			"name": "history_toggle_off"
+		},
+		{
+			"codepoint": 60070,
+			"name": "hive"
+		},
+		{
+			"codepoint": 60298,
+			"name": "hls"
+		},
+		{
+			"codepoint": 60300,
+			"name": "hls_off"
+		},
+		{
+			"codepoint": 58762,
+			"name": "holiday_village"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home"
+		},
+		{
+			"codepoint": 61343,
+			"name": "home_and_garden"
+		},
+		{
+			"codepoint": 58005,
+			"name": "home_app_logo"
+		},
+		{
+			"codepoint": 59826,
+			"name": "home_filled"
+		},
+		{
+			"codepoint": 58553,
+			"name": "home_health"
+		},
+		{
+			"codepoint": 61344,
+			"name": "home_improvement_and_tools"
+		},
+		{
+			"codepoint": 57987,
+			"name": "home_iot_device"
+		},
+		{
+			"codepoint": 61476,
+			"name": "home_max"
+		},
+		{
+			"codepoint": 59465,
+			"name": "home_max_dots"
+		},
+		{
+			"codepoint": 61477,
+			"name": "home_mini"
+		},
+		{
+			"codepoint": 61773,
+			"name": "home_pin"
+		},
+		{
+			"codepoint": 61696,
+			"name": "home_repair_service"
+		},
+		{
+			"codepoint": 61724,
+			"name": "home_speaker"
+		},
+		{
+			"codepoint": 63596,
+			"name": "home_storage"
+		},
+		{
+			"codepoint": 1048446,
+			"name": "home_storage_gear"
+		},
+		{
+			"codepoint": 61488,
+			"name": "home_work"
+		},
+		{
+			"codepoint": 1048476,
+			"name": "horizontal_align_center"
+		},
+		{
+			"codepoint": 1048475,
+			"name": "horizontal_align_left"
+		},
+		{
+			"codepoint": 1048474,
+			"name": "horizontal_align_right"
+		},
+		{
+			"codepoint": 57364,
+			"name": "horizontal_distribute"
+		},
+		{
+			"codepoint": 61704,
+			"name": "horizontal_rule"
+		},
+		{
+			"codepoint": 59719,
+			"name": "horizontal_split"
+		},
+		{
+			"codepoint": 62425,
+			"name": "host"
+		},
+		{
+			"codepoint": 60230,
+			"name": "hot_tub"
+		},
+		{
+			"codepoint": 58697,
+			"name": "hotel"
+		},
+		{
+			"codepoint": 59203,
+			"name": "hotel_class"
+		},
+		{
+			"codepoint": 60415,
+			"name": "hourglass"
+		},
+		{
+			"codepoint": 62334,
+			"name": "hourglass_arrow_down"
+		},
+		{
+			"codepoint": 62333,
+			"name": "hourglass_arrow_up"
+		},
+		{
+			"codepoint": 59996,
+			"name": "hourglass_bottom"
+		},
+		{
+			"codepoint": 1048557,
+			"name": "hourglass_check"
+		},
+		{
+			"codepoint": 61267,
+			"name": "hourglass_disabled"
+		},
+		{
+			"codepoint": 59531,
+			"name": "hourglass_empty"
+		},
+		{
+			"codepoint": 59532,
+			"name": "hourglass_full"
+		},
+		{
+			"codepoint": 62348,
+			"name": "hourglass_pause"
+		},
+		{
+			"codepoint": 59995,
+			"name": "hourglass_top"
+		},
+		{
+			"codepoint": 59972,
+			"name": "house"
+		},
+		{
+			"codepoint": 61954,
+			"name": "house_siding"
+		},
+		{
+			"codepoint": 59270,
+			"name": "house_with_shield"
+		},
+		{
+			"codepoint": 58756,
+			"name": "houseboat"
+		},
+		{
+			"codepoint": 61345,
+			"name": "household_supplies"
+		},
+		{
+			"codepoint": 62581,
+			"name": "hov"
+		},
+		{
+			"codepoint": 57716,
+			"name": "how_to_reg"
+		},
+		{
+			"codepoint": 57717,
+			"name": "how_to_vote"
+		},
+		{
+			"codepoint": 63162,
+			"name": "hr_resting"
+		},
+		{
+			"codepoint": 60286,
+			"name": "html"
+		},
+		{
+			"codepoint": 59650,
+			"name": "http"
+		},
+		{
+			"codepoint": 59545,
+			"name": "https"
+		},
+		{
+			"codepoint": 59892,
+			"name": "hub"
+		},
+		{
+			"codepoint": 63637,
+			"name": "humerus"
+		},
+		{
+			"codepoint": 63638,
+			"name": "humerus_alt"
+		},
+		{
+			"codepoint": 61795,
+			"name": "humidity_high"
+		},
+		{
+			"codepoint": 62808,
+			"name": "humidity_indoor"
+		},
+		{
+			"codepoint": 61796,
+			"name": "humidity_low"
+		},
+		{
+			"codepoint": 61797,
+			"name": "humidity_mid"
+		},
+		{
+			"codepoint": 63614,
+			"name": "humidity_percentage"
+		},
+		{
+			"codepoint": 61710,
+			"name": "hvac"
+		},
+		{
+			"codepoint": 62258,
+			"name": "hvac_max_defrost"
+		},
+		{
+			"codepoint": 58635,
+			"name": "ice_skating"
+		},
+		{
+			"codepoint": 60009,
+			"name": "icecream"
+		},
+		{
+			"codepoint": 62666,
+			"name": "id_card"
+		},
+		{
+			"codepoint": 1048298,
+			"name": "id_card_2"
+		},
+		{
+			"codepoint": 58077,
+			"name": "identity_aware_proxy"
+		},
+		{
+			"codepoint": 60343,
+			"name": "identity_platform"
+		},
+		{
+			"codepoint": 57381,
+			"name": "ifl"
+		},
+		{
+			"codepoint": 63259,
+			"name": "iframe"
+		},
+		{
+			"codepoint": 63260,
+			"name": "iframe_off"
+		},
+		{
+			"codepoint": 58356,
+			"name": "image"
+		},
+		{
+			"codepoint": 62231,
+			"name": "image_arrow_up"
+		},
+		{
+			"codepoint": 59046,
+			"name": "image_aspect_ratio"
+		},
+		{
+			"codepoint": 62023,
+			"name": "image_inset"
+		},
+		{
+			"codepoint": 61718,
+			"name": "image_not_supported"
+		},
+		{
+			"codepoint": 58431,
+			"name": "image_search"
+		},
+		{
+			"codepoint": 59828,
+			"name": "imagesearch_roller"
+		},
+		{
+			"codepoint": 61346,
+			"name": "imagesmode"
+		},
+		{
+			"codepoint": 57595,
+			"name": "immunology"
+		},
+		{
+			"codepoint": 57568,
+			"name": "import_contacts"
+		},
+		{
+			"codepoint": 59605,
+			"name": "import_export"
+		},
+		{
+			"codepoint": 59666,
+			"name": "important_devices"
+		},
+		{
+			"codepoint": 59443,
+			"name": "in_home_mode"
+		},
+		{
+			"codepoint": 57596,
+			"name": "inactive_order"
+		},
+		{
+			"codepoint": 57686,
+			"name": "inbox"
+		},
+		{
+			"codepoint": 63577,
+			"name": "inbox_customize"
+		},
+		{
+			"codepoint": 62361,
+			"name": "inbox_text"
+		},
+		{
+			"codepoint": 62304,
+			"name": "inbox_text_asterisk"
+		},
+		{
+			"codepoint": 62302,
+			"name": "inbox_text_person"
+		},
+		{
+			"codepoint": 62300,
+			"name": "inbox_text_share"
+		},
+		{
+			"codepoint": 59291,
+			"name": "incomplete_circle"
+		},
+		{
+			"codepoint": 59657,
+			"name": "indeterminate_check_box"
+		},
+		{
+			"codepoint": 62829,
+			"name": "indeterminate_question_box"
+		},
+		{
+			"codepoint": 59534,
+			"name": "info"
+		},
+		{
+			"codepoint": 62875,
+			"name": "info_i"
+		},
+		{
+			"codepoint": 63612,
+			"name": "infrared"
+		},
+		{
+			"codepoint": 59088,
+			"name": "ink_eraser"
+		},
+		{
+			"codepoint": 59363,
+			"name": "ink_eraser_off"
+		},
+		{
+			"codepoint": 59089,
+			"name": "ink_highlighter"
+		},
+		{
+			"codepoint": 62756,
+			"name": "ink_highlighter_move"
+		},
+		{
+			"codepoint": 1048340,
+			"name": "ink_highlighter_off"
+		},
+		{
+			"codepoint": 59090,
+			"name": "ink_marker"
+		},
+		{
+			"codepoint": 59091,
+			"name": "ink_pen"
+		},
+		{
+			"codepoint": 61266,
+			"name": "ink_selection"
+		},
+		{
+			"codepoint": 57598,
+			"name": "inpatient"
+		},
+		{
+			"codepoint": 59536,
+			"name": "input"
+		},
+		{
+			"codepoint": 63258,
+			"name": "input_circle"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_filled"
+		},
+		{
+			"codepoint": 61644,
+			"name": "insert_chart_outlined"
+		},
+		{
+			"codepoint": 57932,
+			"name": "insert_comment"
+		},
+		{
+			"codepoint": 58996,
+			"name": "insert_drive_file"
+		},
+		{
+			"codepoint": 59938,
+			"name": "insert_emoticon"
+		},
+		{
+			"codepoint": 59512,
+			"name": "insert_invitation"
+		},
+		{
+			"codepoint": 57936,
+			"name": "insert_link"
+		},
+		{
+			"codepoint": 60106,
+			"name": "insert_page_break"
+		},
+		{
+			"codepoint": 58356,
+			"name": "insert_photo"
+		},
+		{
+			"codepoint": 63527,
+			"name": "insert_text"
+		},
+		{
+			"codepoint": 61586,
+			"name": "insights"
+		},
+		{
+			"codepoint": 60273,
+			"name": "install_desktop"
+		},
+		{
+			"codepoint": 62157,
+			"name": "install_mobile"
+		},
+		{
+			"codepoint": 57382,
+			"name": "instant_mix"
+		},
+		{
+			"codepoint": 61268,
+			"name": "integration_instructions"
+		},
+		{
+			"codepoint": 63487,
+			"name": "interactive_space"
+		},
+		{
+			"codepoint": 59336,
+			"name": "interests"
+		},
+		{
+			"codepoint": 59451,
+			"name": "interpreter_mode"
+		},
+		{
+			"codepoint": 57721,
+			"name": "inventory"
+		},
+		{
+			"codepoint": 57761,
+			"name": "inventory_2"
+		},
+		{
+			"codepoint": 59537,
+			"name": "invert_colors"
+		},
+		{
+			"codepoint": 57540,
+			"name": "invert_colors_off"
+		},
+		{
+			"codepoint": 57383,
+			"name": "ios"
+		},
+		{
+			"codepoint": 59064,
+			"name": "ios_share"
+		},
+		{
+			"codepoint": 58755,
+			"name": "iron"
+		},
+		{
+			"codepoint": 58358,
+			"name": "iso"
+		},
+		{
+			"codepoint": 59829,
+			"name": "jamboard_kiosk"
+		},
+		{
+			"codepoint": 62084,
+			"name": "japanese_curry"
+		},
+		{
+			"codepoint": 62083,
+			"name": "japanese_flag"
+		},
+		{
+			"codepoint": 60284,
+			"name": "javascript"
+		},
+		{
+			"codepoint": 1048283,
+			"name": "jewelry"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join"
+		},
+		{
+			"codepoint": 63567,
+			"name": "join_full"
+		},
+		{
+			"codepoint": 60148,
+			"name": "join_inner"
+		},
+		{
+			"codepoint": 60146,
+			"name": "join_left"
+		},
+		{
+			"codepoint": 60138,
+			"name": "join_right"
+		},
+		{
+			"codepoint": 62958,
+			"name": "joystick"
+		},
+		{
+			"codepoint": 63257,
+			"name": "jump_to_element"
+		},
+		{
+			"codepoint": 62014,
+			"name": "kanji_alcohol"
+		},
+		{
+			"codepoint": 58636,
+			"name": "kayaking"
+		},
+		{
+			"codepoint": 59458,
+			"name": "kebab_dining"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep"
+		},
+		{
+			"codepoint": 59129,
+			"name": "keep_off"
+		},
+		{
+			"codepoint": 61479,
+			"name": "keep_pin"
+		},
+		{
+			"codepoint": 62831,
+			"name": "keep_public"
+		},
+		{
+			"codepoint": 58041,
+			"name": "kettle"
+		},
+		{
+			"codepoint": 59196,
+			"name": "key"
+		},
+		{
+			"codepoint": 60292,
+			"name": "key_off"
+		},
+		{
+			"codepoint": 62746,
+			"name": "key_vertical"
+		},
+		{
+			"codepoint": 61849,
+			"name": "key_visualizer"
+		},
+		{
+			"codepoint": 58130,
+			"name": "keyboard"
+		},
+		{
+			"codepoint": 61480,
+			"name": "keyboard_alt"
+		},
+		{
+			"codepoint": 58131,
+			"name": "keyboard_arrow_down"
+		},
+		{
+			"codepoint": 58132,
+			"name": "keyboard_arrow_left"
+		},
+		{
+			"codepoint": 58133,
+			"name": "keyboard_arrow_right"
+		},
+		{
+			"codepoint": 58134,
+			"name": "keyboard_arrow_up"
+		},
+		{
+			"codepoint": 58135,
+			"name": "keyboard_backspace"
+		},
+		{
+			"codepoint": 58136,
+			"name": "keyboard_capslock"
+		},
+		{
+			"codepoint": 63454,
+			"name": "keyboard_capslock_badge"
+		},
+		{
+			"codepoint": 60135,
+			"name": "keyboard_command_key"
+		},
+		{
+			"codepoint": 60134,
+			"name": "keyboard_control_key"
+		},
+		{
+			"codepoint": 60112,
+			"name": "keyboard_double_arrow_down"
+		},
+		{
+			"codepoint": 60099,
+			"name": "keyboard_double_arrow_left"
+		},
+		{
+			"codepoint": 60105,
+			"name": "keyboard_double_arrow_right"
+		},
+		{
+			"codepoint": 60111,
+			"name": "keyboard_double_arrow_up"
+		},
+		{
+			"codepoint": 63453,
+			"name": "keyboard_external_input"
+		},
+		{
+			"codepoint": 63452,
+			"name": "keyboard_full"
+		},
+		{
+			"codepoint": 58138,
+			"name": "keyboard_hide"
+		},
+		{
+			"codepoint": 63099,
+			"name": "keyboard_keys"
+		},
+		{
+			"codepoint": 62610,
+			"name": "keyboard_lock"
+		},
+		{
+			"codepoint": 62609,
+			"name": "keyboard_lock_off"
+		},
+		{
+			"codepoint": 63098,
+			"name": "keyboard_off"
+		},
+		{
+			"codepoint": 63451,
+			"name": "keyboard_onscreen"
+		},
+		{
+			"codepoint": 60136,
+			"name": "keyboard_option_key"
+		},
+		{
+			"codepoint": 63450,
+			"name": "keyboard_previous_language"
+		},
+		{
+			"codepoint": 58139,
+			"name": "keyboard_return"
+		},
+		{
+			"codepoint": 58140,
+			"name": "keyboard_tab"
+		},
+		{
+			"codepoint": 60531,
+			"name": "keyboard_tab_rtl"
+		},
+		{
+			"codepoint": 58141,
+			"name": "keyboard_voice"
+		},
+		{
+			"codepoint": 62758,
+			"name": "kid_star"
+		},
+		{
+			"codepoint": 59973,
+			"name": "king_bed"
+		},
+		{
+			"codepoint": 60231,
+			"name": "kitchen"
+		},
+		{
+			"codepoint": 58637,
+			"name": "kitesurfing"
+		},
+		{
+			"codepoint": 57603,
+			"name": "lab_panel"
+		},
+		{
+			"codepoint": 57604,
+			"name": "lab_profile"
+		},
+		{
+			"codepoint": 63499,
+			"name": "lab_research"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important"
+		},
+		{
+			"codepoint": 59720,
+			"name": "label_important_outline"
+		},
+		{
+			"codepoint": 59830,
+			"name": "label_off"
+		},
+		{
+			"codepoint": 59539,
+			"name": "label_outline"
+		},
+		{
+			"codepoint": 57605,
+			"name": "labs"
+		},
+		{
+			"codepoint": 60207,
+			"name": "lan"
+		},
+		{
+			"codepoint": 58724,
+			"name": "landscape"
+		},
+		{
+			"codepoint": 62660,
+			"name": "landscape_2"
+		},
+		{
+			"codepoint": 62224,
+			"name": "landscape_2_edit"
+		},
+		{
+			"codepoint": 62659,
+			"name": "landscape_2_off"
+		},
+		{
+			"codepoint": 60375,
+			"name": "landslide"
+		},
+		{
+			"codepoint": 59911,
+			"name": "language"
+		},
+		{
+			"codepoint": 63334,
+			"name": "language_chinese_array"
+		},
+		{
+			"codepoint": 63333,
+			"name": "language_chinese_cangjie"
+		},
+		{
+			"codepoint": 63332,
+			"name": "language_chinese_dayi"
+		},
+		{
+			"codepoint": 63331,
+			"name": "language_chinese_pinyin"
+		},
+		{
+			"codepoint": 63330,
+			"name": "language_chinese_quick"
+		},
+		{
+			"codepoint": 63329,
+			"name": "language_chinese_wubi"
+		},
+		{
+			"codepoint": 63328,
+			"name": "language_french"
+		},
+		{
+			"codepoint": 63327,
+			"name": "language_gb_english"
+		},
+		{
+			"codepoint": 63326,
+			"name": "language_international"
+		},
+		{
+			"codepoint": 62739,
+			"name": "language_japanese_kana"
+		},
+		{
+			"codepoint": 63325,
+			"name": "language_korean_latin"
+		},
+		{
+			"codepoint": 63324,
+			"name": "language_pinyin"
+		},
+		{
+			"codepoint": 62953,
+			"name": "language_spanish"
+		},
+		{
+			"codepoint": 63321,
+			"name": "language_us"
+		},
+		{
+			"codepoint": 63323,
+			"name": "language_us_colemak"
+		},
+		{
+			"codepoint": 63322,
+			"name": "language_us_dvorak"
+		},
+		{
+			"codepoint": 63161,
+			"name": "laps"
+		},
+		{
+			"codepoint": 58142,
+			"name": "laptop"
+		},
+		{
+			"codepoint": 62413,
+			"name": "laptop_car"
+		},
+		{
+			"codepoint": 58143,
+			"name": "laptop_chromebook"
+		},
+		{
+			"codepoint": 58144,
+			"name": "laptop_mac"
+		},
+		{
+			"codepoint": 58145,
+			"name": "laptop_windows"
+		},
+		{
+			"codepoint": 60163,
+			"name": "lasso_select"
+		},
+		{
+			"codepoint": 58845,
+			"name": "last_page"
+		},
+		{
+			"codepoint": 59550,
+			"name": "launch"
+		},
+		{
+			"codepoint": 58024,
+			"name": "laundry"
+		},
+		{
+			"codepoint": 58683,
+			"name": "layers"
+		},
+		{
+			"codepoint": 58684,
+			"name": "layers_clear"
+		},
+		{
+			"codepoint": 57606,
+			"name": "lda"
+		},
+		{
+			"codepoint": 61964,
+			"name": "leaderboard"
+		},
+		{
+			"codepoint": 58360,
+			"name": "leak_add"
+		},
+		{
+			"codepoint": 58361,
+			"name": "leak_remove"
+		},
+		{
+			"codepoint": 63256,
+			"name": "left_click"
+		},
+		{
+			"codepoint": 63255,
+			"name": "left_panel_close"
+		},
+		{
+			"codepoint": 63254,
+			"name": "left_panel_open"
+		},
+		{
+			"codepoint": 61723,
+			"name": "legend_toggle"
+		},
+		{
+			"codepoint": 58362,
+			"name": "lens"
+		},
+		{
+			"codepoint": 61481,
+			"name": "lens_blur"
+		},
+		{
+			"codepoint": 63320,
+			"name": "letter_switch"
+		},
+		{
+			"codepoint": 57404,
+			"name": "library_add"
+		},
+		{
+			"codepoint": 59831,
+			"name": "library_add_check"
+		},
+		{
+			"codepoint": 57391,
+			"name": "library_books"
+		},
+		{
+			"codepoint": 57392,
+			"name": "library_music"
+		},
+		{
+			"codepoint": 60164,
+			"name": "license"
+		},
+		{
+			"codepoint": 61347,
+			"name": "lift_to_talk"
+		},
+		{
+			"codepoint": 61482,
+			"name": "light"
+		},
+		{
+			"codepoint": 57995,
+			"name": "light_group"
+		},
+		{
+			"codepoint": 1048438,
+			"name": "light_group_2"
+		},
+		{
+			"codepoint": 58648,
+			"name": "light_mode"
+		},
+		{
+			"codepoint": 1048320,
+			"name": "light_mode_auto"
+		},
+		{
+			"codepoint": 59832,
+			"name": "light_off"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb"
+		},
+		{
+			"codepoint": 62435,
+			"name": "lightbulb_2"
+		},
+		{
+			"codepoint": 60414,
+			"name": "lightbulb_circle"
+		},
+		{
+			"codepoint": 59663,
+			"name": "lightbulb_outline"
+		},
+		{
+			"codepoint": 61348,
+			"name": "lightning_stand"
+		},
+		{
+			"codepoint": 1048437,
+			"name": "lightstrip"
+		},
+		{
+			"codepoint": 60058,
+			"name": "line_axis"
+		},
+		{
+			"codepoint": 63319,
+			"name": "line_curve"
+		},
+		{
+			"codepoint": 63526,
+			"name": "line_end"
+		},
+		{
+			"codepoint": 63517,
+			"name": "line_end_arrow"
+		},
+		{
+			"codepoint": 63516,
+			"name": "line_end_arrow_notch"
+		},
+		{
+			"codepoint": 63515,
+			"name": "line_end_circle"
+		},
+		{
+			"codepoint": 63514,
+			"name": "line_end_diamond"
+		},
+		{
+			"codepoint": 63513,
+			"name": "line_end_square"
+		},
+		{
+			"codepoint": 63525,
+			"name": "line_start"
+		},
+		{
+			"codepoint": 63512,
+			"name": "line_start_arrow"
+		},
+		{
+			"codepoint": 63511,
+			"name": "line_start_arrow_notch"
+		},
+		{
+			"codepoint": 63510,
+			"name": "line_start_circle"
+		},
+		{
+			"codepoint": 63509,
+			"name": "line_start_diamond"
+		},
+		{
+			"codepoint": 63508,
+			"name": "line_start_square"
+		},
+		{
+			"codepoint": 59673,
+			"name": "line_style"
+		},
+		{
+			"codepoint": 59674,
+			"name": "line_weight"
+		},
+		{
+			"codepoint": 57952,
+			"name": "linear_scale"
+		},
+		{
+			"codepoint": 57936,
+			"name": "link"
+		},
+		{
+			"codepoint": 1048501,
+			"name": "link_2"
+		},
+		{
+			"codepoint": 57711,
+			"name": "link_off"
+		},
+		{
+			"codepoint": 58424,
+			"name": "linked_camera"
+		},
+		{
+			"codepoint": 62773,
+			"name": "linked_services"
+		},
+		{
+			"codepoint": 61106,
+			"name": "lips"
+		},
+		{
+			"codepoint": 60000,
+			"name": "liquor"
+		},
+		{
+			"codepoint": 59542,
+			"name": "list"
+		},
+		{
+			"codepoint": 58999,
+			"name": "list_alt"
+		},
+		{
+			"codepoint": 63318,
+			"name": "list_alt_add"
+		},
+		{
+			"codepoint": 62430,
+			"name": "list_alt_check"
+		},
+		{
+			"codepoint": 1048371,
+			"name": "list_arrow"
+		},
+		{
+			"codepoint": 59833,
+			"name": "lists"
+		},
+		{
+			"codepoint": 57542,
+			"name": "live_help"
+		},
+		{
+			"codepoint": 58938,
+			"name": "live_tv"
+		},
+		{
+			"codepoint": 61483,
+			"name": "living"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_activity"
+		},
+		{
+			"codepoint": 58685,
+			"name": "local_airport"
+		},
+		{
+			"codepoint": 58686,
+			"name": "local_atm"
+		},
+		{
+			"codepoint": 58688,
+			"name": "local_bar"
+		},
+		{
+			"codepoint": 60228,
+			"name": "local_cafe"
+		},
+		{
+			"codepoint": 58690,
+			"name": "local_car_wash"
+		},
+		{
+			"codepoint": 58691,
+			"name": "local_convenience_store"
+		},
+		{
+			"codepoint": 58721,
+			"name": "local_dining"
+		},
+		{
+			"codepoint": 58692,
+			"name": "local_drink"
+		},
+		{
+			"codepoint": 61269,
+			"name": "local_fire_department"
+		},
+		{
+			"codepoint": 58693,
+			"name": "local_florist"
+		},
+		{
+			"codepoint": 58694,
+			"name": "local_gas_station"
+		},
+		{
+			"codepoint": 59596,
+			"name": "local_grocery_store"
+		},
+		{
+			"codepoint": 58696,
+			"name": "local_hospital"
+		},
+		{
+			"codepoint": 58697,
+			"name": "local_hotel"
+		},
+		{
+			"codepoint": 58698,
+			"name": "local_laundry_service"
+		},
+		{
+			"codepoint": 58699,
+			"name": "local_library"
+		},
+		{
+			"codepoint": 58700,
+			"name": "local_mall"
+		},
+		{
+			"codepoint": 59610,
+			"name": "local_movies"
+		},
+		{
+			"codepoint": 61531,
+			"name": "local_offer"
+		},
+		{
+			"codepoint": 58703,
+			"name": "local_parking"
+		},
+		{
+			"codepoint": 58704,
+			"name": "local_pharmacy"
+		},
+		{
+			"codepoint": 61652,
+			"name": "local_phone"
+		},
+		{
+			"codepoint": 58706,
+			"name": "local_pizza"
+		},
+		{
+			"codepoint": 58707,
+			"name": "local_play"
+		},
+		{
+			"codepoint": 61270,
+			"name": "local_police"
+		},
+		{
+			"codepoint": 58708,
+			"name": "local_post_office"
+		},
+		{
+			"codepoint": 59565,
+			"name": "local_printshop"
+		},
+		{
+			"codepoint": 58711,
+			"name": "local_see"
+		},
+		{
+			"codepoint": 58712,
+			"name": "local_shipping"
+		},
+		{
+			"codepoint": 58713,
+			"name": "local_taxi"
+		},
+		{
+			"codepoint": 61775,
+			"name": "location_automation"
+		},
+		{
+			"codepoint": 61776,
+			"name": "location_away"
+		},
+		{
+			"codepoint": 63568,
+			"name": "location_chip"
+		},
+		{
+			"codepoint": 59377,
+			"name": "location_city"
+		},
+		{
+			"codepoint": 57782,
+			"name": "location_disabled"
+		},
+		{
+			"codepoint": 61778,
+			"name": "location_home"
+		},
+		{
+			"codepoint": 57543,
+			"name": "location_off"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_on"
+		},
+		{
+			"codepoint": 61915,
+			"name": "location_pin"
+		},
+		{
+			"codepoint": 57783,
+			"name": "location_searching"
+		},
+		{
+			"codepoint": 63681,
+			"name": "locator_tag"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock"
+		},
+		{
+			"codepoint": 61271,
+			"name": "lock_clock"
+		},
+		{
+			"codepoint": 59544,
+			"name": "lock_open"
+		},
+		{
+			"codepoint": 62305,
+			"name": "lock_open_circle"
+		},
+		{
+			"codepoint": 63062,
+			"name": "lock_open_right"
+		},
+		{
+			"codepoint": 59545,
+			"name": "lock_outline"
+		},
+		{
+			"codepoint": 63731,
+			"name": "lock_person"
+		},
+		{
+			"codepoint": 60126,
+			"name": "lock_reset"
+		},
+		{
+			"codepoint": 60023,
+			"name": "login"
+		},
+		{
+			"codepoint": 60118,
+			"name": "logo_dev"
+		},
+		{
+			"codepoint": 59834,
+			"name": "logout"
+		},
+		{
+			"codepoint": 58364,
+			"name": "looks"
+		},
+		{
+			"codepoint": 58363,
+			"name": "looks_3"
+		},
+		{
+			"codepoint": 58365,
+			"name": "looks_4"
+		},
+		{
+			"codepoint": 58366,
+			"name": "looks_5"
+		},
+		{
+			"codepoint": 58367,
+			"name": "looks_6"
+		},
+		{
+			"codepoint": 58368,
+			"name": "looks_one"
+		},
+		{
+			"codepoint": 58369,
+			"name": "looks_two"
+		},
+		{
+			"codepoint": 59491,
+			"name": "loop"
+		},
+		{
+			"codepoint": 58370,
+			"name": "loupe"
+		},
+		{
+			"codepoint": 63387,
+			"name": "low_density"
+		},
+		{
+			"codepoint": 57709,
+			"name": "low_priority"
+		},
+		{
+			"codepoint": 62602,
+			"name": "lowercase"
+		},
+		{
+			"codepoint": 59546,
+			"name": "loyalty"
+		},
+		{
+			"codepoint": 61484,
+			"name": "lte_mobiledata"
+		},
+		{
+			"codepoint": 63449,
+			"name": "lte_mobiledata_badge"
+		},
+		{
+			"codepoint": 61485,
+			"name": "lte_plus_mobiledata"
+		},
+		{
+			"codepoint": 63448,
+			"name": "lte_plus_mobiledata_badge"
+		},
+		{
+			"codepoint": 62005,
+			"name": "luggage"
+		},
+		{
+			"codepoint": 60001,
+			"name": "lunch_dining"
+		},
+		{
+			"codepoint": 60427,
+			"name": "lyrics"
+		},
+		{
+			"codepoint": 63218,
+			"name": "macro_auto"
+		},
+		{
+			"codepoint": 63698,
+			"name": "macro_off"
+		},
+		{
+			"codepoint": 61750,
+			"name": "magic_button"
+		},
+		{
+			"codepoint": 63476,
+			"name": "magic_exchange"
+		},
+		{
+			"codepoint": 63447,
+			"name": "magic_tether"
+		},
+		{
+			"codepoint": 63549,
+			"name": "magnification_large"
+		},
+		{
+			"codepoint": 63548,
+			"name": "magnification_small"
+		},
+		{
+			"codepoint": 63446,
+			"name": "magnify_docked"
+		},
+		{
+			"codepoint": 63445,
+			"name": "magnify_fullscreen"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail"
+		},
+		{
+			"codepoint": 61172,
+			"name": "mail_asterisk"
+		},
+		{
+			"codepoint": 60426,
+			"name": "mail_lock"
+		},
+		{
+			"codepoint": 62603,
+			"name": "mail_off"
+		},
+		{
+			"codepoint": 57689,
+			"name": "mail_outline"
+		},
+		{
+			"codepoint": 62025,
+			"name": "mail_shield"
+		},
+		{
+			"codepoint": 58766,
+			"name": "male"
+		},
+		{
+			"codepoint": 58603,
+			"name": "man"
+		},
+		{
+			"codepoint": 63713,
+			"name": "man_2"
+		},
+		{
+			"codepoint": 63714,
+			"name": "man_3"
+		},
+		{
+			"codepoint": 63715,
+			"name": "man_4"
+		},
+		{
+			"codepoint": 61486,
+			"name": "manage_accounts"
+		},
+		{
+			"codepoint": 60391,
+			"name": "manage_history"
+		},
+		{
+			"codepoint": 61487,
+			"name": "manage_search"
+		},
+		{
+			"codepoint": 62947,
+			"name": "manga"
+		},
+		{
+			"codepoint": 59174,
+			"name": "manufacturing"
+		},
+		{
+			"codepoint": 58715,
+			"name": "map"
+		},
+		{
+			"codepoint": 62104,
+			"name": "map_pin_heart"
+		},
+		{
+			"codepoint": 62103,
+			"name": "map_pin_review"
+		},
+		{
+			"codepoint": 62410,
+			"name": "map_search"
+		},
+		{
+			"codepoint": 61488,
+			"name": "maps_home_work"
+		},
+		{
+			"codepoint": 61272,
+			"name": "maps_ugc"
+		},
+		{
+			"codepoint": 59835,
+			"name": "margin"
+		},
+		{
+			"codepoint": 59836,
+			"name": "mark_as_unread"
+		},
+		{
+			"codepoint": 61835,
+			"name": "mark_chat_read"
+		},
+		{
+			"codepoint": 61833,
+			"name": "mark_chat_unread"
+		},
+		{
+			"codepoint": 61836,
+			"name": "mark_email_read"
+		},
+		{
+			"codepoint": 61834,
+			"name": "mark_email_unread"
+		},
+		{
+			"codepoint": 60317,
+			"name": "mark_unread_chat_alt"
+		},
+		{
+			"codepoint": 62802,
+			"name": "markdown"
+		},
+		{
+			"codepoint": 62803,
+			"name": "markdown_copy"
+		},
+		{
+			"codepoint": 62804,
+			"name": "markdown_paste"
+		},
+		{
+			"codepoint": 57689,
+			"name": "markunread"
+		},
+		{
+			"codepoint": 59547,
+			"name": "markunread_mailbox"
+		},
+		{
+			"codepoint": 59182,
+			"name": "masked_transitions"
+		},
+		{
+			"codepoint": 62507,
+			"name": "masked_transitions_add"
+		},
+		{
+			"codepoint": 61976,
+			"name": "masks"
+		},
+		{
+			"codepoint": 62146,
+			"name": "massage"
+		},
+		{
+			"codepoint": 63217,
+			"name": "match_case"
+		},
+		{
+			"codepoint": 62319,
+			"name": "match_case_off"
+		},
+		{
+			"codepoint": 63216,
+			"name": "match_word"
+		},
+		{
+			"codepoint": 59655,
+			"name": "matter"
+		},
+		{
+			"codepoint": 59696,
+			"name": "maximize"
+		},
+		{
+			"codepoint": 62013,
+			"name": "meal_dinner"
+		},
+		{
+			"codepoint": 62012,
+			"name": "meal_lunch"
+		},
+		{
+			"codepoint": 63151,
+			"name": "measuring_tape"
+		},
+		{
+			"codepoint": 61489,
+			"name": "media_bluetooth_off"
+		},
+		{
+			"codepoint": 61490,
+			"name": "media_bluetooth_on"
+		},
+		{
+			"codepoint": 63551,
+			"name": "media_link"
+		},
+		{
+			"codepoint": 62706,
+			"name": "media_output"
+		},
+		{
+			"codepoint": 62707,
+			"name": "media_output_off"
+		},
+		{
+			"codepoint": 61351,
+			"name": "mediation"
+		},
+		{
+			"codepoint": 60397,
+			"name": "medical_information"
+		},
+		{
+			"codepoint": 63498,
+			"name": "medical_mask"
+		},
+		{
+			"codepoint": 61705,
+			"name": "medical_services"
+		},
+		{
+			"codepoint": 61491,
+			"name": "medication"
+		},
+		{
+			"codepoint": 60039,
+			"name": "medication_liquid"
+		},
+		{
+			"codepoint": 60239,
+			"name": "meeting_room"
+		},
+		{
+			"codepoint": 58146,
+			"name": "memory"
+		},
+		{
+			"codepoint": 63395,
+			"name": "memory_alt"
+		},
+		{
+			"codepoint": 63201,
+			"name": "menstrual_health"
+		},
+		{
+			"codepoint": 58834,
+			"name": "menu"
+		},
+		{
+			"codepoint": 59929,
+			"name": "menu_book"
+		},
+		{
+			"codepoint": 62097,
+			"name": "menu_book_2"
+		},
+		{
+			"codepoint": 59837,
+			"name": "menu_open"
+		},
+		{
+			"codepoint": 60312,
+			"name": "merge"
+		},
+		{
+			"codepoint": 57938,
+			"name": "merge_type"
+		},
+		{
+			"codepoint": 57545,
+			"name": "message"
+		},
+		{
+			"codepoint": 57611,
+			"name": "metabolism"
+		},
+		{
+			"codepoint": 62580,
+			"name": "metro"
+		},
+		{
+			"codepoint": 61725,
+			"name": "mfg_nest_yale_lock"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic"
+		},
+		{
+			"codepoint": 62354,
+			"name": "mic_alert"
+		},
+		{
+			"codepoint": 62929,
+			"name": "mic_double"
+		},
+		{
+			"codepoint": 61273,
+			"name": "mic_external_off"
+		},
+		{
+			"codepoint": 61274,
+			"name": "mic_external_on"
+		},
+		{
+			"codepoint": 61114,
+			"name": "mic_gear"
+		},
+		{
+			"codepoint": 58141,
+			"name": "mic_none"
+		},
+		{
+			"codepoint": 57387,
+			"name": "mic_off"
+		},
+		{
+			"codepoint": 57612,
+			"name": "microbiology"
+		},
+		{
+			"codepoint": 61956,
+			"name": "microwave"
+		},
+		{
+			"codepoint": 59463,
+			"name": "microwave_gen"
+		},
+		{
+			"codepoint": 59967,
+			"name": "military_tech"
+		},
+		{
+			"codepoint": 59838,
+			"name": "mimo"
+		},
+		{
+			"codepoint": 59839,
+			"name": "mimo_disconnect"
+		},
+		{
+			"codepoint": 63200,
+			"name": "mindfulness"
+		},
+		{
+			"codepoint": 59697,
+			"name": "minimize"
+		},
+		{
+			"codepoint": 60401,
+			"name": "minor_crash"
+		},
+		{
+			"codepoint": 61353,
+			"name": "mintmark"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call"
+		},
+		{
+			"codepoint": 61646,
+			"name": "missed_video_call_filled"
+		},
+		{
+			"codepoint": 59137,
+			"name": "missing_controller"
+		},
+		{
+			"codepoint": 57736,
+			"name": "mist"
+		},
+		{
+			"codepoint": 62791,
+			"name": "mitre"
+		},
+		{
+			"codepoint": 58568,
+			"name": "mixture_med"
+		},
+		{
+			"codepoint": 58904,
+			"name": "mms"
+		},
+		{
+			"codepoint": 59322,
+			"name": "mobile"
+		},
+		{
+			"codepoint": 62171,
+			"name": "mobile_2"
+		},
+		{
+			"codepoint": 62170,
+			"name": "mobile_3"
+		},
+		{
+			"codepoint": 62163,
+			"name": "mobile_alert"
+		},
+		{
+			"codepoint": 62157,
+			"name": "mobile_arrow_down"
+		},
+		{
+			"codepoint": 62162,
+			"name": "mobile_arrow_right"
+		},
+		{
+			"codepoint": 62137,
+			"name": "mobile_arrow_up_right"
+		},
+		{
+			"codepoint": 62181,
+			"name": "mobile_block"
+		},
+		{
+			"codepoint": 62542,
+			"name": "mobile_camera"
+		},
+		{
+			"codepoint": 62153,
+			"name": "mobile_camera_front"
+		},
+		{
+			"codepoint": 62152,
+			"name": "mobile_camera_rear"
+		},
+		{
+			"codepoint": 62186,
+			"name": "mobile_cancel"
+		},
+		{
+			"codepoint": 62156,
+			"name": "mobile_cast"
+		},
+		{
+			"codepoint": 62179,
+			"name": "mobile_charge"
+		},
+		{
+			"codepoint": 63391,
+			"name": "mobile_chat"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_check"
+		},
+		{
+			"codepoint": 62178,
+			"name": "mobile_code"
+		},
+		{
+			"codepoint": 62176,
+			"name": "mobile_dock"
+		},
+		{
+			"codepoint": 62160,
+			"name": "mobile_dots"
+		},
+		{
+			"codepoint": 61555,
+			"name": "mobile_friendly"
+		},
+		{
+			"codepoint": 62169,
+			"name": "mobile_gear"
+		},
+		{
+			"codepoint": 62243,
+			"name": "mobile_hand"
+		},
+		{
+			"codepoint": 62227,
+			"name": "mobile_hand_left"
+		},
+		{
+			"codepoint": 62226,
+			"name": "mobile_hand_left_off"
+		},
+		{
+			"codepoint": 62228,
+			"name": "mobile_hand_off"
+		},
+		{
+			"codepoint": 62172,
+			"name": "mobile_info"
+		},
+		{
+			"codepoint": 60734,
+			"name": "mobile_landscape"
+		},
+		{
+			"codepoint": 62143,
+			"name": "mobile_layout"
+		},
+		{
+			"codepoint": 62168,
+			"name": "mobile_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "mobile_lock_portrait"
+		},
+		{
+			"codepoint": 62242,
+			"name": "mobile_loupe"
+		},
+		{
+			"codepoint": 62161,
+			"name": "mobile_menu"
+		},
+		{
+			"codepoint": 57857,
+			"name": "mobile_off"
+		},
+		{
+			"codepoint": 62177,
+			"name": "mobile_question"
+		},
+		{
+			"codepoint": 62165,
+			"name": "mobile_rotate"
+		},
+		{
+			"codepoint": 62166,
+			"name": "mobile_rotate_lock"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_screen_share"
+		},
+		{
+			"codepoint": 62241,
+			"name": "mobile_screensaver"
+		},
+		{
+			"codepoint": 62191,
+			"name": "mobile_sensor_hi"
+		},
+		{
+			"codepoint": 62190,
+			"name": "mobile_sensor_lo"
+		},
+		{
+			"codepoint": 62175,
+			"name": "mobile_share"
+		},
+		{
+			"codepoint": 62174,
+			"name": "mobile_share_stack"
+		},
+		{
+			"codepoint": 62184,
+			"name": "mobile_sound"
+		},
+		{
+			"codepoint": 62232,
+			"name": "mobile_sound_2"
+		},
+		{
+			"codepoint": 63402,
+			"name": "mobile_sound_off"
+		},
+		{
+			"codepoint": 62240,
+			"name": "mobile_speaker"
+		},
+		{
+			"codepoint": 62187,
+			"name": "mobile_text"
+		},
+		{
+			"codepoint": 62182,
+			"name": "mobile_text_2"
+		},
+		{
+			"codepoint": 62121,
+			"name": "mobile_theft"
+		},
+		{
+			"codepoint": 62180,
+			"name": "mobile_ticket"
+		},
+		{
+			"codepoint": 61162,
+			"name": "mobile_unlock"
+		},
+		{
+			"codepoint": 62155,
+			"name": "mobile_vibrate"
+		},
+		{
+			"codepoint": 62128,
+			"name": "mobile_wrench"
+		},
+		{
+			"codepoint": 1048483,
+			"name": "mobiledata_arrows"
+		},
+		{
+			"codepoint": 61492,
+			"name": "mobiledata_off"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode"
+		},
+		{
+			"codepoint": 57939,
+			"name": "mode_comment"
+		},
+		{
+			"codepoint": 61798,
+			"name": "mode_cool"
+		},
+		{
+			"codepoint": 61799,
+			"name": "mode_cool_off"
+		},
+		{
+			"codepoint": 62807,
+			"name": "mode_dual"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit"
+		},
+		{
+			"codepoint": 61591,
+			"name": "mode_edit_outline"
+		},
+		{
+			"codepoint": 61800,
+			"name": "mode_fan"
+		},
+		{
+			"codepoint": 1048528,
+			"name": "mode_fan_2"
+		},
+		{
+			"codepoint": 60439,
+			"name": "mode_fan_off"
+		},
+		{
+			"codepoint": 61802,
+			"name": "mode_heat"
+		},
+		{
+			"codepoint": 61803,
+			"name": "mode_heat_cool"
+		},
+		{
+			"codepoint": 61805,
+			"name": "mode_heat_off"
+		},
+		{
+			"codepoint": 61494,
+			"name": "mode_night"
+		},
+		{
+			"codepoint": 59342,
+			"name": "mode_of_travel"
+		},
+		{
+			"codepoint": 61807,
+			"name": "mode_off_on"
+		},
+		{
+			"codepoint": 61495,
+			"name": "mode_standby"
+		},
+		{
+			"codepoint": 61647,
+			"name": "model_training"
+		},
+		{
+			"codepoint": 62378,
+			"name": "modeling"
+		},
+		{
+			"codepoint": 57955,
+			"name": "monetization_on"
+		},
+		{
+			"codepoint": 58749,
+			"name": "money"
+		},
+		{
+			"codepoint": 62446,
+			"name": "money_bag"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off"
+		},
+		{
+			"codepoint": 61496,
+			"name": "money_off_csred"
+		},
+		{
+			"codepoint": 62021,
+			"name": "money_range"
+		},
+		{
+			"codepoint": 61275,
+			"name": "monitor"
+		},
+		{
+			"codepoint": 60066,
+			"name": "monitor_heart"
+		},
+		{
+			"codepoint": 61497,
+			"name": "monitor_weight"
+		},
+		{
+			"codepoint": 63199,
+			"name": "monitor_weight_gain"
+		},
+		{
+			"codepoint": 63198,
+			"name": "monitor_weight_loss"
+		},
+		{
+			"codepoint": 61840,
+			"name": "monitoring"
+		},
+		{
+			"codepoint": 58371,
+			"name": "monochrome_photos"
+		},
+		{
+			"codepoint": 62579,
+			"name": "monorail"
+		},
+		{
+			"codepoint": 59938,
+			"name": "mood"
+		},
+		{
+			"codepoint": 59379,
+			"name": "mood_bad"
+		},
+		{
+			"codepoint": 1048500,
+			"name": "mood_heart"
+		},
+		{
+			"codepoint": 62287,
+			"name": "moon_stars"
+		},
+		{
+			"codepoint": 57997,
+			"name": "mop"
+		},
+		{
+			"codepoint": 60200,
+			"name": "moped"
+		},
+		{
+			"codepoint": 62091,
+			"name": "moped_package"
+		},
+		{
+			"codepoint": 58905,
+			"name": "more"
+		},
+		{
+			"codepoint": 61846,
+			"name": "more_down"
+		},
+		{
+			"codepoint": 58835,
+			"name": "more_horiz"
+		},
+		{
+			"codepoint": 59997,
+			"name": "more_time"
+		},
+		{
+			"codepoint": 61847,
+			"name": "more_up"
+		},
+		{
+			"codepoint": 58836,
+			"name": "more_vert"
+		},
+		{
+			"codepoint": 60082,
+			"name": "mosque"
+		},
+		{
+			"codepoint": 61648,
+			"name": "motion_blur"
+		},
+		{
+			"codepoint": 63554,
+			"name": "motion_mode"
+		},
+		{
+			"codepoint": 61498,
+			"name": "motion_photos_auto"
+		},
+		{
+			"codepoint": 59840,
+			"name": "motion_photos_off"
+		},
+		{
+			"codepoint": 59841,
+			"name": "motion_photos_on"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_pause"
+		},
+		{
+			"codepoint": 61991,
+			"name": "motion_photos_paused"
+		},
+		{
+			"codepoint": 62475,
+			"name": "motion_play"
+		},
+		{
+			"codepoint": 59282,
+			"name": "motion_sensor_active"
+		},
+		{
+			"codepoint": 59268,
+			"name": "motion_sensor_alert"
+		},
+		{
+			"codepoint": 59267,
+			"name": "motion_sensor_idle"
+		},
+		{
+			"codepoint": 59278,
+			"name": "motion_sensor_urgent"
+		},
+		{
+			"codepoint": 59675,
+			"name": "motorcycle"
+		},
+		{
+			"codepoint": 62946,
+			"name": "mountain_flag"
+		},
+		{
+			"codepoint": 62082,
+			"name": "mountain_steam"
+		},
+		{
+			"codepoint": 58147,
+			"name": "mouse"
+		},
+		{
+			"codepoint": 62608,
+			"name": "mouse_lock"
+		},
+		{
+			"codepoint": 62607,
+			"name": "mouse_lock_off"
+		},
+		{
+			"codepoint": 59200,
+			"name": "move"
+		},
+		{
+			"codepoint": 60257,
+			"name": "move_down"
+		},
+		{
+			"codepoint": 63253,
+			"name": "move_group"
+		},
+		{
+			"codepoint": 61951,
+			"name": "move_item"
+		},
+		{
+			"codepoint": 59201,
+			"name": "move_location"
+		},
+		{
+			"codepoint": 63252,
+			"name": "move_selection_down"
+		},
+		{
+			"codepoint": 63251,
+			"name": "move_selection_left"
+		},
+		{
+			"codepoint": 63250,
+			"name": "move_selection_right"
+		},
+		{
+			"codepoint": 63249,
+			"name": "move_selection_up"
+		},
+		{
+			"codepoint": 57704,
+			"name": "move_to_inbox"
+		},
+		{
+			"codepoint": 60260,
+			"name": "move_up"
+		},
+		{
+			"codepoint": 58772,
+			"name": "moved_location"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie"
+		},
+		{
+			"codepoint": 59012,
+			"name": "movie_creation"
+		},
+		{
+			"codepoint": 63552,
+			"name": "movie_edit"
+		},
+		{
+			"codepoint": 1048445,
+			"name": "movie_edit_off"
+		},
+		{
+			"codepoint": 58426,
+			"name": "movie_filter"
+		},
+		{
+			"codepoint": 57389,
+			"name": "movie_info"
+		},
+		{
+			"codepoint": 62617,
+			"name": "movie_off"
+		},
+		{
+			"codepoint": 62115,
+			"name": "movie_speaker"
+		},
+		{
+			"codepoint": 58625,
+			"name": "moving"
+		},
+		{
+			"codepoint": 59197,
+			"name": "moving_beds"
+		},
+		{
+			"codepoint": 59198,
+			"name": "moving_ministry"
+		},
+		{
+			"codepoint": 59843,
+			"name": "mp"
+		},
+		{
+			"codepoint": 58003,
+			"name": "multicooker"
+		},
+		{
+			"codepoint": 59103,
+			"name": "multiline_chart"
+		},
+		{
+			"codepoint": 62491,
+			"name": "multimodal_hand_eye"
+		},
+		{
+			"codepoint": 61355,
+			"name": "multiple_airports"
+		},
+		{
+			"codepoint": 61881,
+			"name": "multiple_stop"
+		},
+		{
+			"codepoint": 59958,
+			"name": "museum"
+		},
+		{
+			"codepoint": 60186,
+			"name": "music_cast"
+		},
+		{
+			"codepoint": 62145,
+			"name": "music_history"
+		},
+		{
+			"codepoint": 58373,
+			"name": "music_note"
+		},
+		{
+			"codepoint": 1048536,
+			"name": "music_note_2"
+		},
+		{
+			"codepoint": 62353,
+			"name": "music_note_add"
+		},
+		{
+			"codepoint": 58432,
+			"name": "music_off"
+		},
+		{
+			"codepoint": 57443,
+			"name": "music_video"
+		},
+		{
+			"codepoint": 58716,
+			"name": "my_location"
+		},
+		{
+			"codepoint": 62945,
+			"name": "mystery"
+		},
+		{
+			"codepoint": 61276,
+			"name": "nat"
+		},
+		{
+			"codepoint": 58374,
+			"name": "nature"
+		},
+		{
+			"codepoint": 58375,
+			"name": "nature_people"
+		},
+		{
+			"codepoint": 58827,
+			"name": "navigate_before"
+		},
+		{
+			"codepoint": 58828,
+			"name": "navigate_next"
+		},
+		{
+			"codepoint": 58717,
+			"name": "navigation"
+		},
+		{
+			"codepoint": 58729,
+			"name": "near_me"
+		},
+		{
+			"codepoint": 61935,
+			"name": "near_me_disabled"
+		},
+		{
+			"codepoint": 59063,
+			"name": "nearby"
+		},
+		{
+			"codepoint": 61499,
+			"name": "nearby_error"
+		},
+		{
+			"codepoint": 61500,
+			"name": "nearby_off"
+		},
+		{
+			"codepoint": 57613,
+			"name": "nephrology"
+		},
+		{
+			"codepoint": 60351,
+			"name": "nest_audio"
+		},
+		{
+			"codepoint": 63671,
+			"name": "nest_cam_floodlight"
+		},
+		{
+			"codepoint": 61726,
+			"name": "nest_cam_indoor"
+		},
+		{
+			"codepoint": 61727,
+			"name": "nest_cam_iq"
+		},
+		{
+			"codepoint": 61728,
+			"name": "nest_cam_iq_outdoor"
+		},
+		{
+			"codepoint": 63672,
+			"name": "nest_cam_magnet_mount"
+		},
+		{
+			"codepoint": 61729,
+			"name": "nest_cam_outdoor"
+		},
+		{
+			"codepoint": 63673,
+			"name": "nest_cam_stand"
+		},
+		{
+			"codepoint": 63674,
+			"name": "nest_cam_wall_mount"
+		},
+		{
+			"codepoint": 60438,
+			"name": "nest_cam_wired_stand"
+		},
+		{
+			"codepoint": 63675,
+			"name": "nest_clock_farsight_analog"
+		},
+		{
+			"codepoint": 63676,
+			"name": "nest_clock_farsight_digital"
+		},
+		{
+			"codepoint": 61730,
+			"name": "nest_connect"
+		},
+		{
+			"codepoint": 61731,
+			"name": "nest_detect"
+		},
+		{
+			"codepoint": 61732,
+			"name": "nest_display"
+		},
+		{
+			"codepoint": 61733,
+			"name": "nest_display_max"
+		},
+		{
+			"codepoint": 63677,
+			"name": "nest_doorbell_visitor"
+		},
+		{
+			"codepoint": 63678,
+			"name": "nest_eco_leaf"
+		},
+		{
+			"codepoint": 62077,
+			"name": "nest_farsight_cool"
+		},
+		{
+			"codepoint": 62076,
+			"name": "nest_farsight_dual"
+		},
+		{
+			"codepoint": 62075,
+			"name": "nest_farsight_eco"
+		},
+		{
+			"codepoint": 62074,
+			"name": "nest_farsight_heat"
+		},
+		{
+			"codepoint": 62073,
+			"name": "nest_farsight_seasonal"
+		},
+		{
+			"codepoint": 63679,
+			"name": "nest_farsight_weather"
+		},
+		{
+			"codepoint": 63680,
+			"name": "nest_found_savings"
+		},
+		{
+			"codepoint": 62841,
+			"name": "nest_gale_wifi"
+		},
+		{
+			"codepoint": 61734,
+			"name": "nest_heat_link_e"
+		},
+		{
+			"codepoint": 61735,
+			"name": "nest_heat_link_gen_3"
+		},
+		{
+			"codepoint": 59436,
+			"name": "nest_hello_doorbell"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_locator_tag"
+		},
+		{
+			"codepoint": 59273,
+			"name": "nest_mini"
+		},
+		{
+			"codepoint": 63682,
+			"name": "nest_multi_room"
+		},
+		{
+			"codepoint": 59022,
+			"name": "nest_protect"
+		},
+		{
+			"codepoint": 62939,
+			"name": "nest_remote"
+		},
+		{
+			"codepoint": 61738,
+			"name": "nest_remote_comfort_sensor"
+		},
+		{
+			"codepoint": 61739,
+			"name": "nest_secure_alarm"
+		},
+		{
+			"codepoint": 63683,
+			"name": "nest_sunblock"
+		},
+		{
+			"codepoint": 63681,
+			"name": "nest_tag"
+		},
+		{
+			"codepoint": 59023,
+			"name": "nest_thermostat"
+		},
+		{
+			"codepoint": 61741,
+			"name": "nest_thermostat_e_eu"
+		},
+		{
+			"codepoint": 61742,
+			"name": "nest_thermostat_gen_3"
+		},
+		{
+			"codepoint": 61743,
+			"name": "nest_thermostat_sensor"
+		},
+		{
+			"codepoint": 61744,
+			"name": "nest_thermostat_sensor_eu"
+		},
+		{
+			"codepoint": 61745,
+			"name": "nest_thermostat_zirconium_eu"
+		},
+		{
+			"codepoint": 63684,
+			"name": "nest_true_radiant"
+		},
+		{
+			"codepoint": 63685,
+			"name": "nest_wake_on_approach"
+		},
+		{
+			"codepoint": 63686,
+			"name": "nest_wake_on_press"
+		},
+		{
+			"codepoint": 61746,
+			"name": "nest_wifi_gale"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_mistral"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point"
+		},
+		{
+			"codepoint": 61748,
+			"name": "nest_wifi_point_vento"
+		},
+		{
+			"codepoint": 62827,
+			"name": "nest_wifi_pro"
+		},
+		{
+			"codepoint": 62826,
+			"name": "nest_wifi_pro_2"
+		},
+		{
+			"codepoint": 61747,
+			"name": "nest_wifi_router"
+		},
+		{
+			"codepoint": 57785,
+			"name": "network_cell"
+		},
+		{
+			"codepoint": 58944,
+			"name": "network_check"
+		},
+		{
+			"codepoint": 62321,
+			"name": "network_intel_node"
+		},
+		{
+			"codepoint": 61356,
+			"name": "network_intelligence"
+		},
+		{
+			"codepoint": 62966,
+			"name": "network_intelligence_history"
+		},
+		{
+			"codepoint": 62965,
+			"name": "network_intelligence_update"
+		},
+		{
+			"codepoint": 58906,
+			"name": "network_locked"
+		},
+		{
+			"codepoint": 63403,
+			"name": "network_manage"
+		},
+		{
+			"codepoint": 62830,
+			"name": "network_node"
+		},
+		{
+			"codepoint": 60362,
+			"name": "network_ping"
+		},
+		{
+			"codepoint": 57786,
+			"name": "network_wifi"
+		},
+		{
+			"codepoint": 60388,
+			"name": "network_wifi_1_bar"
+		},
+		{
+			"codepoint": 62863,
+			"name": "network_wifi_1_bar_locked"
+		},
+		{
+			"codepoint": 60374,
+			"name": "network_wifi_2_bar"
+		},
+		{
+			"codepoint": 62862,
+			"name": "network_wifi_2_bar_locked"
+		},
+		{
+			"codepoint": 60385,
+			"name": "network_wifi_3_bar"
+		},
+		{
+			"codepoint": 62861,
+			"name": "network_wifi_3_bar_locked"
+		},
+		{
+			"codepoint": 62770,
+			"name": "network_wifi_locked"
+		},
+		{
+			"codepoint": 57614,
+			"name": "neurology"
+		},
+		{
+			"codepoint": 58889,
+			"name": "new_label"
+		},
+		{
+			"codepoint": 61302,
+			"name": "new_releases"
+		},
+		{
+			"codepoint": 63248,
+			"name": "new_window"
+		},
+		{
+			"codepoint": 57394,
+			"name": "news"
+		},
+		{
+			"codepoint": 61357,
+			"name": "newsmode"
+		},
+		{
+			"codepoint": 60289,
+			"name": "newspaper"
+		},
+		{
+			"codepoint": 59844,
+			"name": "newsstand"
+		},
+		{
+			"codepoint": 61277,
+			"name": "next_plan"
+		},
+		{
+			"codepoint": 57706,
+			"name": "next_week"
+		},
+		{
+			"codepoint": 57787,
+			"name": "nfc"
+		},
+		{
+			"codepoint": 62313,
+			"name": "nfc_off"
+		},
+		{
+			"codepoint": 61937,
+			"name": "night_shelter"
+		},
+		{
+			"codepoint": 61911,
+			"name": "night_sight_auto"
+		},
+		{
+			"codepoint": 61945,
+			"name": "night_sight_auto_off"
+		},
+		{
+			"codepoint": 63171,
+			"name": "night_sight_max"
+		},
+		{
+			"codepoint": 60002,
+			"name": "nightlife"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight"
+		},
+		{
+			"codepoint": 61501,
+			"name": "nightlight_round"
+		},
+		{
+			"codepoint": 61812,
+			"name": "nights_stay"
+		},
+		{
+			"codepoint": 61502,
+			"name": "no_accounts"
+		},
+		{
+			"codepoint": 63742,
+			"name": "no_adult_content"
+		},
+		{
+			"codepoint": 62007,
+			"name": "no_backpack"
+		},
+		{
+			"codepoint": 60400,
+			"name": "no_crash"
+		},
+		{
+			"codepoint": 61861,
+			"name": "no_drinks"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption"
+		},
+		{
+			"codepoint": 61503,
+			"name": "no_encryption_gmailerrorred"
+		},
+		{
+			"codepoint": 61862,
+			"name": "no_flash"
+		},
+		{
+			"codepoint": 61863,
+			"name": "no_food"
+		},
+		{
+			"codepoint": 62011,
+			"name": "no_luggage"
+		},
+		{
+			"codepoint": 61910,
+			"name": "no_meals"
+		},
+		{
+			"codepoint": 60238,
+			"name": "no_meeting_room"
+		},
+		{
+			"codepoint": 61864,
+			"name": "no_photography"
+		},
+		{
+			"codepoint": 57806,
+			"name": "no_sim"
+		},
+		{
+			"codepoint": 59152,
+			"name": "no_sound"
+		},
+		{
+			"codepoint": 61871,
+			"name": "no_stroller"
+		},
+		{
+			"codepoint": 61909,
+			"name": "no_transfer"
+		},
+		{
+			"codepoint": 60396,
+			"name": "noise_aware"
+		},
+		{
+			"codepoint": 60403,
+			"name": "noise_control_off"
+		},
+		{
+			"codepoint": 63656,
+			"name": "noise_control_on"
+		},
+		{
+			"codepoint": 58638,
+			"name": "nordic_walking"
+		},
+		{
+			"codepoint": 61920,
+			"name": "north"
+		},
+		{
+			"codepoint": 61921,
+			"name": "north_east"
+		},
+		{
+			"codepoint": 61922,
+			"name": "north_west"
+		},
+		{
+			"codepoint": 61694,
+			"name": "not_accessible"
+		},
+		{
+			"codepoint": 62794,
+			"name": "not_accessible_forward"
+		},
+		{
+			"codepoint": 61580,
+			"name": "not_interested"
+		},
+		{
+			"codepoint": 58741,
+			"name": "not_listed_location"
+		},
+		{
+			"codepoint": 61649,
+			"name": "not_started"
+		},
+		{
+			"codepoint": 58996,
+			"name": "note"
+		},
+		{
+			"codepoint": 59548,
+			"name": "note_add"
+		},
+		{
+			"codepoint": 61504,
+			"name": "note_alt"
+		},
+		{
+			"codepoint": 62818,
+			"name": "note_stack"
+		},
+		{
+			"codepoint": 62819,
+			"name": "note_stack_add"
+		},
+		{
+			"codepoint": 57964,
+			"name": "notes"
+		},
+		{
+			"codepoint": 58265,
+			"name": "notification_add"
+		},
+		{
+			"codepoint": 61121,
+			"name": "notification_audio"
+		},
+		{
+			"codepoint": 61120,
+			"name": "notification_audio_off"
+		},
+		{
+			"codepoint": 57348,
+			"name": "notification_important"
+		},
+		{
+			"codepoint": 59074,
+			"name": "notification_multiple"
+		},
+		{
+			"codepoint": 62311,
+			"name": "notification_settings"
+		},
+		{
+			"codepoint": 62291,
+			"name": "notification_sound"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications"
+		},
+		{
+			"codepoint": 59383,
+			"name": "notifications_active"
+		},
+		{
+			"codepoint": 59381,
+			"name": "notifications_none"
+		},
+		{
+			"codepoint": 59382,
+			"name": "notifications_off"
+		},
+		{
+			"codepoint": 59384,
+			"name": "notifications_paused"
+		},
+		{
+			"codepoint": 62718,
+			"name": "notifications_unread"
+		},
+		{
+			"codepoint": 60103,
+			"name": "numbers"
+		},
+		{
+			"codepoint": 57616,
+			"name": "nutrition"
+		},
+		{
+			"codepoint": 59112,
+			"name": "ods"
+		},
+		{
+			"codepoint": 59113,
+			"name": "odt"
+		},
+		{
+			"codepoint": 59698,
+			"name": "offline_bolt"
+		},
+		{
+			"codepoint": 59658,
+			"name": "offline_pin"
+		},
+		{
+			"codepoint": 62672,
+			"name": "offline_pin_off"
+		},
+		{
+			"codepoint": 62174,
+			"name": "offline_share"
+		},
+		{
+			"codepoint": 60437,
+			"name": "oil_barrel"
+		},
+		{
+			"codepoint": 62081,
+			"name": "okonomiyaki"
+		},
+		{
+			"codepoint": 60413,
+			"name": "on_device_training"
+		},
+		{
+			"codepoint": 59075,
+			"name": "on_hub_device"
+		},
+		{
+			"codepoint": 57620,
+			"name": "oncology"
+		},
+		{
+			"codepoint": 58938,
+			"name": "ondemand_video"
+		},
+		{
+			"codepoint": 61675,
+			"name": "online_prediction"
+		},
+		{
+			"codepoint": 63224,
+			"name": "onsen"
+		},
+		{
+			"codepoint": 59676,
+			"name": "opacity"
+		},
+		{
+			"codepoint": 59549,
+			"name": "open_in_browser"
+		},
+		{
+			"codepoint": 61902,
+			"name": "open_in_full"
+		},
+		{
+			"codepoint": 59550,
+			"name": "open_in_new"
+		},
+		{
+			"codepoint": 63247,
+			"name": "open_in_new_down"
+		},
+		{
+			"codepoint": 58614,
+			"name": "open_in_new_off"
+		},
+		{
+			"codepoint": 62162,
+			"name": "open_in_phone"
+		},
+		{
+			"codepoint": 61358,
+			"name": "open_jam"
+		},
+		{
+			"codepoint": 62647,
+			"name": "open_run"
+		},
+		{
+			"codepoint": 59551,
+			"name": "open_with"
+		},
+		{
+			"codepoint": 57621,
+			"name": "ophthalmology"
+		},
+		{
+			"codepoint": 57622,
+			"name": "oral_disease"
+		},
+		{
+			"codepoint": 62502,
+			"name": "orbit"
+		},
+		{
+			"codepoint": 63506,
+			"name": "order_approve"
+		},
+		{
+			"codepoint": 63505,
+			"name": "order_play"
+		},
+		{
+			"codepoint": 60180,
+			"name": "orders"
+		},
+		{
+			"codepoint": 63639,
+			"name": "orthopedics"
+		},
+		{
+			"codepoint": 58491,
+			"name": "other_admission"
+		},
+		{
+			"codepoint": 58764,
+			"name": "other_houses"
+		},
+		{
+			"codepoint": 57802,
+			"name": "outbound"
+		},
+		{
+			"codepoint": 61279,
+			"name": "outbox"
+		},
+		{
+			"codepoint": 60183,
+			"name": "outbox_alt"
+		},
+		{
+			"codepoint": 57861,
+			"name": "outdoor_garden"
+		},
+		{
+			"codepoint": 59975,
+			"name": "outdoor_grill"
+		},
+		{
+			"codepoint": 61650,
+			"name": "outgoing_mail"
+		},
+		{
+			"codepoint": 61908,
+			"name": "outlet"
+		},
+		{
+			"codepoint": 61638,
+			"name": "outlined_flag"
+		},
+		{
+			"codepoint": 57624,
+			"name": "outpatient"
+		},
+		{
+			"codepoint": 57625,
+			"name": "outpatient_med"
+		},
+		{
+			"codepoint": 60350,
+			"name": "output"
+		},
+		{
+			"codepoint": 63246,
+			"name": "output_circle"
+		},
+		{
+			"codepoint": 59847,
+			"name": "oven"
+		},
+		{
+			"codepoint": 59459,
+			"name": "oven_gen"
+		},
+		{
+			"codepoint": 58535,
+			"name": "overview"
+		},
+		{
+			"codepoint": 63444,
+			"name": "overview_key"
+		},
+		{
+			"codepoint": 62388,
+			"name": "owl"
+		},
+		{
+			"codepoint": 58590,
+			"name": "oxygen_saturation"
+		},
+		{
+			"codepoint": 62762,
+			"name": "p2p"
+		},
+		{
+			"codepoint": 63160,
+			"name": "pace"
+		},
+		{
+			"codepoint": 58966,
+			"name": "pacemaker"
+		},
+		{
+			"codepoint": 58511,
+			"name": "package"
+		},
+		{
+			"codepoint": 62825,
+			"name": "package_2"
+		},
+		{
+			"codepoint": 59848,
+			"name": "padding"
+		},
+		{
+			"codepoint": 62119,
+			"name": "padel"
+		},
+		{
+			"codepoint": 59185,
+			"name": "page_control"
+		},
+		{
+			"codepoint": 62339,
+			"name": "page_footer"
+		},
+		{
+			"codepoint": 62340,
+			"name": "page_header"
+		},
+		{
+			"codepoint": 62996,
+			"name": "page_info"
+		},
+		{
+			"codepoint": 61179,
+			"name": "page_menu_ios"
+		},
+		{
+			"codepoint": 62729,
+			"name": "pageless"
+		},
+		{
+			"codepoint": 59385,
+			"name": "pages"
+		},
+		{
+			"codepoint": 59552,
+			"name": "pageview"
+		},
+		{
+			"codepoint": 61505,
+			"name": "paid"
+		},
+		{
+			"codepoint": 58378,
+			"name": "palette"
+		},
+		{
+			"codepoint": 63594,
+			"name": "pallet"
+		},
+		{
+			"codepoint": 59685,
+			"name": "pan_tool"
+		},
+		{
+			"codepoint": 60345,
+			"name": "pan_tool_alt"
+		},
+		{
+			"codepoint": 63061,
+			"name": "pan_zoom"
+		},
+		{
+			"codepoint": 59025,
+			"name": "panorama"
+		},
+		{
+			"codepoint": 58380,
+			"name": "panorama_fish_eye"
+		},
+		{
+			"codepoint": 58381,
+			"name": "panorama_horizontal"
+		},
+		{
+			"codepoint": 59849,
+			"name": "panorama_photosphere"
+		},
+		{
+			"codepoint": 58382,
+			"name": "panorama_vertical"
+		},
+		{
+			"codepoint": 58383,
+			"name": "panorama_wide_angle"
+		},
+		{
+			"codepoint": 58639,
+			"name": "paragliding"
+		},
+		{
+			"codepoint": 61997,
+			"name": "parent_child_dining"
+		},
+		{
+			"codepoint": 60003,
+			"name": "park"
+		},
+		{
+			"codepoint": 62090,
+			"name": "parking_meter"
+		},
+		{
+			"codepoint": 62089,
+			"name": "parking_sign"
+		},
+		{
+			"codepoint": 62088,
+			"name": "parking_valet"
+		},
+		{
+			"codepoint": 61810,
+			"name": "partly_cloudy_day"
+		},
+		{
+			"codepoint": 61812,
+			"name": "partly_cloudy_night"
+		},
+		{
+			"codepoint": 63481,
+			"name": "partner_exchange"
+		},
+		{
+			"codepoint": 61230,
+			"name": "partner_heart"
+		},
+		{
+			"codepoint": 61359,
+			"name": "partner_reports"
+		},
+		{
+			"codepoint": 59386,
+			"name": "party_mode"
+		},
+		{
+			"codepoint": 63615,
+			"name": "passkey"
+		},
+		{
+			"codepoint": 61124,
+			"name": "passport"
+		},
+		{
+			"codepoint": 61506,
+			"name": "password"
+		},
+		{
+			"codepoint": 62633,
+			"name": "password_2"
+		},
+		{
+			"codepoint": 62632,
+			"name": "password_2_off"
+		},
+		{
+			"codepoint": 58963,
+			"name": "patient_list"
+		},
+		{
+			"codepoint": 61507,
+			"name": "pattern"
+		},
+		{
+			"codepoint": 57396,
+			"name": "pause"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_filled"
+		},
+		{
+			"codepoint": 57762,
+			"name": "pause_circle_outline"
+		},
+		{
+			"codepoint": 57578,
+			"name": "pause_presentation"
+		},
+		{
+			"codepoint": 59553,
+			"name": "payment"
+		},
+		{
+			"codepoint": 62144,
+			"name": "payment_arrow_down"
+		},
+		{
+			"codepoint": 62113,
+			"name": "payment_card"
+		},
+		{
+			"codepoint": 61283,
+			"name": "payments"
+		},
+		{
+			"codepoint": 60201,
+			"name": "pedal_bike"
+		},
+		{
+			"codepoint": 57629,
+			"name": "pediatrics"
+		},
+		{
+			"codepoint": 63317,
+			"name": "pen_size_1"
+		},
+		{
+			"codepoint": 63316,
+			"name": "pen_size_2"
+		},
+		{
+			"codepoint": 63315,
+			"name": "pen_size_3"
+		},
+		{
+			"codepoint": 63314,
+			"name": "pen_size_4"
+		},
+		{
+			"codepoint": 63313,
+			"name": "pen_size_5"
+		},
+		{
+			"codepoint": 61284,
+			"name": "pending"
+		},
+		{
+			"codepoint": 61883,
+			"name": "pending_actions"
+		},
+		{
+			"codepoint": 60240,
+			"name": "pentagon"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_alt"
+		},
+		{
+			"codepoint": 59937,
+			"name": "people_outline"
+		},
+		{
+			"codepoint": 60248,
+			"name": "percent"
+		},
+		{
+			"codepoint": 62020,
+			"name": "percent_discount"
+		},
+		{
+			"codepoint": 58650,
+			"name": "performance_max"
+		},
+		{
+			"codepoint": 57859,
+			"name": "pergola"
+		},
+		{
+			"codepoint": 59554,
+			"name": "perm_camera_mic"
+		},
+		{
+			"codepoint": 59555,
+			"name": "perm_contact_calendar"
+		},
+		{
+			"codepoint": 59556,
+			"name": "perm_data_setting"
+		},
+		{
+			"codepoint": 62172,
+			"name": "perm_device_information"
+		},
+		{
+			"codepoint": 61651,
+			"name": "perm_identity"
+		},
+		{
+			"codepoint": 59559,
+			"name": "perm_media"
+		},
+		{
+			"codepoint": 59560,
+			"name": "perm_phone_msg"
+		},
+		{
+			"codepoint": 59561,
+			"name": "perm_scan_wifi"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person"
+		},
+		{
+			"codepoint": 63716,
+			"name": "person_2"
+		},
+		{
+			"codepoint": 63717,
+			"name": "person_3"
+		},
+		{
+			"codepoint": 63718,
+			"name": "person_4"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add"
+		},
+		{
+			"codepoint": 59981,
+			"name": "person_add_alt"
+		},
+		{
+			"codepoint": 59851,
+			"name": "person_add_disabled"
+		},
+		{
+			"codepoint": 62823,
+			"name": "person_alert"
+		},
+		{
+			"codepoint": 62883,
+			"name": "person_apron"
+		},
+		{
+			"codepoint": 62952,
+			"name": "person_book"
+		},
+		{
+			"codepoint": 62822,
+			"name": "person_cancel"
+		},
+		{
+			"codepoint": 63486,
+			"name": "person_celebrate"
+		},
+		{
+			"codepoint": 62821,
+			"name": "person_check"
+		},
+		{
+			"codepoint": 62714,
+			"name": "person_edit"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_filled"
+		},
+		{
+			"codepoint": 62096,
+			"name": "person_heart"
+		},
+		{
+			"codepoint": 58640,
+			"name": "person_off"
+		},
+		{
+			"codepoint": 61651,
+			"name": "person_outline"
+		},
+		{
+			"codepoint": 58714,
+			"name": "person_pin"
+		},
+		{
+			"codepoint": 58730,
+			"name": "person_pin_circle"
+		},
+		{
+			"codepoint": 63485,
+			"name": "person_play"
+		},
+		{
+			"codepoint": 62874,
+			"name": "person_raised_hand"
+		},
+		{
+			"codepoint": 61286,
+			"name": "person_remove"
+		},
+		{
+			"codepoint": 61702,
+			"name": "person_search"
+		},
+		{
+			"codepoint": 58244,
+			"name": "person_shield"
+		},
+		{
+			"codepoint": 61117,
+			"name": "person_text"
+		},
+		{
+			"codepoint": 60174,
+			"name": "personal_bag"
+		},
+		{
+			"codepoint": 60175,
+			"name": "personal_bag_off"
+		},
+		{
+			"codepoint": 60176,
+			"name": "personal_bag_question"
+		},
+		{
+			"codepoint": 59098,
+			"name": "personal_injury"
+		},
+		{
+			"codepoint": 59139,
+			"name": "personal_places"
+		},
+		{
+			"codepoint": 58939,
+			"name": "personal_video"
+		},
+		{
+			"codepoint": 61690,
+			"name": "pest_control"
+		},
+		{
+			"codepoint": 61693,
+			"name": "pest_control_rodent"
+		},
+		{
+			"codepoint": 61361,
+			"name": "pet_supplies"
+		},
+		{
+			"codepoint": 59677,
+			"name": "pets"
+		},
+		{
+			"codepoint": 60119,
+			"name": "phishing"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone"
+		},
+		{
+			"codepoint": 61652,
+			"name": "phone_alt"
+		},
+		{
+			"codepoint": 62171,
+			"name": "phone_android"
+		},
+		{
+			"codepoint": 58907,
+			"name": "phone_bluetooth_speaker"
+		},
+		{
+			"codepoint": 58953,
+			"name": "phone_callback"
+		},
+		{
+			"codepoint": 1048477,
+			"name": "phone_cancel"
+		},
+		{
+			"codepoint": 59852,
+			"name": "phone_disabled"
+		},
+		{
+			"codepoint": 59853,
+			"name": "phone_enabled"
+		},
+		{
+			"codepoint": 58908,
+			"name": "phone_forwarded"
+		},
+		{
+			"codepoint": 58909,
+			"name": "phone_in_talk"
+		},
+		{
+			"codepoint": 62170,
+			"name": "phone_iphone"
+		},
+		{
+			"codepoint": 58910,
+			"name": "phone_locked"
+		},
+		{
+			"codepoint": 58911,
+			"name": "phone_missed"
+		},
+		{
+			"codepoint": 58912,
+			"name": "phone_paused"
+		},
+		{
+			"codepoint": 58150,
+			"name": "phonelink"
+		},
+		{
+			"codepoint": 62186,
+			"name": "phonelink_erase"
+		},
+		{
+			"codepoint": 62142,
+			"name": "phonelink_lock"
+		},
+		{
+			"codepoint": 63397,
+			"name": "phonelink_off"
+		},
+		{
+			"codepoint": 62184,
+			"name": "phonelink_ring"
+		},
+		{
+			"codepoint": 63402,
+			"name": "phonelink_ring_off"
+		},
+		{
+			"codepoint": 62169,
+			"name": "phonelink_setup"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo"
+		},
+		{
+			"codepoint": 58385,
+			"name": "photo_album"
+		},
+		{
+			"codepoint": 62768,
+			"name": "photo_auto_merge"
+		},
+		{
+			"codepoint": 58386,
+			"name": "photo_camera"
+		},
+		{
+			"codepoint": 61288,
+			"name": "photo_camera_back"
+		},
+		{
+			"codepoint": 61289,
+			"name": "photo_camera_front"
+		},
+		{
+			"codepoint": 58427,
+			"name": "photo_filter"
+		},
+		{
+			"codepoint": 61657,
+			"name": "photo_frame"
+		},
+		{
+			"codepoint": 58387,
+			"name": "photo_library"
+		},
+		{
+			"codepoint": 61362,
+			"name": "photo_prints"
+		},
+		{
+			"codepoint": 59027,
+			"name": "photo_size_select_actual"
+		},
+		{
+			"codepoint": 58419,
+			"name": "photo_size_select_large"
+		},
+		{
+			"codepoint": 58420,
+			"name": "photo_size_select_small"
+		},
+		{
+			"codepoint": 60303,
+			"name": "php"
+		},
+		{
+			"codepoint": 57630,
+			"name": "physical_therapy"
+		},
+		{
+			"codepoint": 58657,
+			"name": "piano"
+		},
+		{
+			"codepoint": 58656,
+			"name": "piano_off"
+		},
+		{
+			"codepoint": 62118,
+			"name": "pickleball"
+		},
+		{
+			"codepoint": 58389,
+			"name": "picture_as_pdf"
+		},
+		{
+			"codepoint": 59562,
+			"name": "picture_in_picture"
+		},
+		{
+			"codepoint": 59665,
+			"name": "picture_in_picture_alt"
+		},
+		{
+			"codepoint": 62800,
+			"name": "picture_in_picture_center"
+		},
+		{
+			"codepoint": 62799,
+			"name": "picture_in_picture_large"
+		},
+		{
+			"codepoint": 62798,
+			"name": "picture_in_picture_medium"
+		},
+		{
+			"codepoint": 62743,
+			"name": "picture_in_picture_mobile"
+		},
+		{
+			"codepoint": 62767,
+			"name": "picture_in_picture_off"
+		},
+		{
+			"codepoint": 62797,
+			"name": "picture_in_picture_small"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_filled"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outline"
+		},
+		{
+			"codepoint": 61658,
+			"name": "pie_chart_outlined"
+		},
+		{
+			"codepoint": 57631,
+			"name": "pill"
+		},
+		{
+			"codepoint": 63497,
+			"name": "pill_off"
+		},
+		{
+			"codepoint": 61509,
+			"name": "pin"
+		},
+		{
+			"codepoint": 58718,
+			"name": "pin_drop"
+		},
+		{
+			"codepoint": 59239,
+			"name": "pin_end"
+		},
+		{
+			"codepoint": 1048366,
+			"name": "pin_history"
+		},
+		{
+			"codepoint": 59235,
+			"name": "pin_invoke"
+		},
+		{
+			"codepoint": 1048365,
+			"name": "pin_road"
+		},
+		{
+			"codepoint": 1048299,
+			"name": "pin_road_2"
+		},
+		{
+			"codepoint": 62379,
+			"name": "pinboard"
+		},
+		{
+			"codepoint": 62380,
+			"name": "pinboard_unread"
+		},
+		{
+			"codepoint": 60216,
+			"name": "pinch"
+		},
+		{
+			"codepoint": 61946,
+			"name": "pinch_zoom_in"
+		},
+		{
+			"codepoint": 61947,
+			"name": "pinch_zoom_out"
+		},
+		{
+			"codepoint": 63053,
+			"name": "pip"
+		},
+		{
+			"codepoint": 63245,
+			"name": "pip_exit"
+		},
+		{
+			"codepoint": 59854,
+			"name": "pivot_table_chart"
+		},
+		{
+			"codepoint": 61915,
+			"name": "place"
+		},
+		{
+			"codepoint": 61936,
+			"name": "place_item"
+		},
+		{
+			"codepoint": 59994,
+			"name": "plagiarism"
+		},
+		{
+			"codepoint": 62124,
+			"name": "plane_contrails"
+		},
+		{
+			"codepoint": 62343,
+			"name": "planet"
+		},
+		{
+			"codepoint": 59026,
+			"name": "planner_banner_ad_pt"
+		},
+		{
+			"codepoint": 59028,
+			"name": "planner_review"
+		},
+		{
+			"codepoint": 57399,
+			"name": "play_arrow"
+		},
+		{
+			"codepoint": 57796,
+			"name": "play_circle"
+		},
+		{
+			"codepoint": 61290,
+			"name": "play_disabled"
+		},
+		{
+			"codepoint": 59654,
+			"name": "play_for_work"
+		},
+		{
+			"codepoint": 61511,
+			"name": "play_lesson"
+		},
+		{
+			"codepoint": 59118,
+			"name": "play_music"
+		},
+		{
+			"codepoint": 61751,
+			"name": "play_pause"
+		},
+		{
+			"codepoint": 63484,
+			"name": "play_shapes"
+		},
+		{
+			"codepoint": 62094,
+			"name": "playground"
+		},
+		{
+			"codepoint": 62095,
+			"name": "playground_2"
+		},
+		{
+			"codepoint": 62940,
+			"name": "playing_cards"
+		},
+		{
+			"codepoint": 57403,
+			"name": "playlist_add"
+		},
+		{
+			"codepoint": 57445,
+			"name": "playlist_add_check"
+		},
+		{
+			"codepoint": 59366,
+			"name": "playlist_add_check_circle"
+		},
+		{
+			"codepoint": 59365,
+			"name": "playlist_add_circle"
+		},
+		{
+			"codepoint": 57439,
+			"name": "playlist_play"
+		},
+		{
+			"codepoint": 60288,
+			"name": "playlist_remove"
+		},
+		{
+			"codepoint": 62298,
+			"name": "plug_connect"
+		},
+		{
+			"codepoint": 61703,
+			"name": "plumbing"
+		},
+		{
+			"codepoint": 59392,
+			"name": "plus_one"
+		},
+		{
+			"codepoint": 61512,
+			"name": "podcasts"
+		},
+		{
+			"codepoint": 57632,
+			"name": "podiatry"
+		},
+		{
+			"codepoint": 63483,
+			"name": "podium"
+		},
+		{
+			"codepoint": 61822,
+			"name": "point_of_sale"
+		},
+		{
+			"codepoint": 63244,
+			"name": "point_scan"
+		},
+		{
+			"codepoint": 62619,
+			"name": "poker_chip"
+		},
+		{
+			"codepoint": 59927,
+			"name": "policy"
+		},
+		{
+			"codepoint": 62471,
+			"name": "policy_alert"
+		},
+		{
+			"codepoint": 61644,
+			"name": "poll"
+		},
+		{
+			"codepoint": 60347,
+			"name": "polyline"
+		},
+		{
+			"codepoint": 59563,
+			"name": "polymer"
+		},
+		{
+			"codepoint": 60232,
+			"name": "pool"
+		},
+		{
+			"codepoint": 61575,
+			"name": "portable_wifi_off"
+		},
+		{
+			"codepoint": 59473,
+			"name": "portrait"
+		},
+		{
+			"codepoint": 63243,
+			"name": "position_bottom_left"
+		},
+		{
+			"codepoint": 63242,
+			"name": "position_bottom_right"
+		},
+		{
+			"codepoint": 63241,
+			"name": "position_top_right"
+		},
+		{
+			"codepoint": 59141,
+			"name": "post"
+		},
+		{
+			"codepoint": 59936,
+			"name": "post_add"
+		},
+		{
+			"codepoint": 63658,
+			"name": "potted_plant"
+		},
+		{
+			"codepoint": 58940,
+			"name": "power"
+		},
+		{
+			"codepoint": 58166,
+			"name": "power_input"
+		},
+		{
+			"codepoint": 58950,
+			"name": "power_off"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_rounded"
+		},
+		{
+			"codepoint": 62488,
+			"name": "power_settings_circle"
+		},
+		{
+			"codepoint": 63687,
+			"name": "power_settings_new"
+		},
+		{
+			"codepoint": 63544,
+			"name": "prayer_times"
+		},
+		{
+			"codepoint": 61513,
+			"name": "precision_manufacturing"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnancy"
+		},
+		{
+			"codepoint": 62961,
+			"name": "pregnant_woman"
+		},
+		{
+			"codepoint": 59352,
+			"name": "preliminary"
+		},
+		{
+			"codepoint": 57633,
+			"name": "prescriptions"
+		},
+		{
+			"codepoint": 57567,
+			"name": "present_to_all"
+		},
+		{
+			"codepoint": 61893,
+			"name": "preview"
+		},
+		{
+			"codepoint": 63407,
+			"name": "preview_off"
+		},
+		{
+			"codepoint": 61514,
+			"name": "price_change"
+		},
+		{
+			"codepoint": 61515,
+			"name": "price_check"
+		},
+		{
+			"codepoint": 59565,
+			"name": "print"
+		},
+		{
+			"codepoint": 63394,
+			"name": "print_add"
+		},
+		{
+			"codepoint": 63393,
+			"name": "print_connect"
+		},
+		{
+			"codepoint": 59855,
+			"name": "print_disabled"
+		},
+		{
+			"codepoint": 63392,
+			"name": "print_error"
+		},
+		{
+			"codepoint": 63057,
+			"name": "print_lock"
+		},
+		{
+			"codepoint": 61364,
+			"name": "priority"
+		},
+		{
+			"codepoint": 58949,
+			"name": "priority_high"
+		},
+		{
+			"codepoint": 61768,
+			"name": "privacy"
+		},
+		{
+			"codepoint": 61660,
+			"name": "privacy_tip"
+		},
+		{
+			"codepoint": 59204,
+			"name": "private_connectivity"
+		},
+		{
+			"codepoint": 57634,
+			"name": "problem"
+		},
+		{
+			"codepoint": 58961,
+			"name": "procedure"
+		},
+		{
+			"codepoint": 63573,
+			"name": "process_chart"
+		},
+		{
+			"codepoint": 57809,
+			"name": "production_quantity_limits"
+		},
+		{
+			"codepoint": 58006,
+			"name": "productivity"
+		},
+		{
+			"codepoint": 59856,
+			"name": "progress_activity"
+		},
+		{
+			"codepoint": 62710,
+			"name": "prompt_suggestion"
+		},
+		{
+			"codepoint": 60436,
+			"name": "propane"
+		},
+		{
+			"codepoint": 60435,
+			"name": "propane_tank"
+		},
+		{
+			"codepoint": 57635,
+			"name": "psychiatry"
+		},
+		{
+			"codepoint": 59978,
+			"name": "psychology"
+		},
+		{
+			"codepoint": 63722,
+			"name": "psychology_alt"
+		},
+		{
+			"codepoint": 59403,
+			"name": "public"
+		},
+		{
+			"codepoint": 61898,
+			"name": "public_off"
+		},
+		{
+			"codepoint": 57941,
+			"name": "publish"
+		},
+		{
+			"codepoint": 62002,
+			"name": "published_with_changes"
+		},
+		{
+			"codepoint": 57636,
+			"name": "pulmonology"
+		},
+		{
+			"codepoint": 62721,
+			"name": "pulse_alert"
+		},
+		{
+			"codepoint": 60072,
+			"name": "punch_clock"
+		},
+		{
+			"codepoint": 61709,
+			"name": "push_pin"
+		},
+		{
+			"codepoint": 61291,
+			"name": "qr_code"
+		},
+		{
+			"codepoint": 57354,
+			"name": "qr_code_2"
+		},
+		{
+			"codepoint": 63064,
+			"name": "qr_code_2_add"
+		},
+		{
+			"codepoint": 61958,
+			"name": "qr_code_scanner"
+		},
+		{
+			"codepoint": 61398,
+			"name": "query_builder"
+		},
+		{
+			"codepoint": 58620,
+			"name": "query_stats"
+		},
+		{
+			"codepoint": 59567,
+			"name": "question_answer"
+		},
+		{
+			"codepoint": 63475,
+			"name": "question_exchange"
+		},
+		{
+			"codepoint": 60299,
+			"name": "question_mark"
+		},
+		{
+			"codepoint": 57404,
+			"name": "queue"
+		},
+		{
+			"codepoint": 57405,
+			"name": "queue_music"
+		},
+		{
+			"codepoint": 57446,
+			"name": "queue_play_next"
+		},
+		{
+			"codepoint": 59345,
+			"name": "quick_phrases"
+		},
+		{
+			"codepoint": 58478,
+			"name": "quick_reference"
+		},
+		{
+			"codepoint": 63489,
+			"name": "quick_reference_all"
+		},
+		{
+			"codepoint": 60181,
+			"name": "quick_reorder"
+		},
+		{
+			"codepoint": 61292,
+			"name": "quickreply"
+		},
+		{
+			"codepoint": 61785,
+			"name": "quiet_time"
+		},
+		{
+			"codepoint": 60278,
+			"name": "quiet_time_active"
+		},
+		{
+			"codepoint": 61516,
+			"name": "quiz"
+		},
+		{
+			"codepoint": 61517,
+			"name": "r_mobiledata"
+		},
+		{
+			"codepoint": 61518,
+			"name": "radar"
+		},
+		{
+			"codepoint": 57406,
+			"name": "radio"
+		},
+		{
+			"codepoint": 59447,
+			"name": "radio_button_checked"
+		},
+		{
+			"codepoint": 62816,
+			"name": "radio_button_partial"
+		},
+		{
+			"codepoint": 59446,
+			"name": "radio_button_unchecked"
+		},
+		{
+			"codepoint": 57637,
+			"name": "radiology"
+		},
+		{
+			"codepoint": 59857,
+			"name": "railway_alert"
+		},
+		{
+			"codepoint": 62561,
+			"name": "railway_alert_2"
+		},
+		{
+			"codepoint": 61814,
+			"name": "rainy"
+		},
+		{
+			"codepoint": 63007,
+			"name": "rainy_heavy"
+		},
+		{
+			"codepoint": 63006,
+			"name": "rainy_light"
+		},
+		{
+			"codepoint": 63005,
+			"name": "rainy_snow"
+		},
+		{
+			"codepoint": 60004,
+			"name": "ramen_dining"
+		},
+		{
+			"codepoint": 60316,
+			"name": "ramp_left"
+		},
+		{
+			"codepoint": 60310,
+			"name": "ramp_right"
+		},
+		{
+			"codepoint": 57834,
+			"name": "range_hood"
+		},
+		{
+			"codepoint": 58720,
+			"name": "rate_review"
+		},
+		{
+			"codepoint": 59142,
+			"name": "rate_review_rtl"
+		},
+		{
+			"codepoint": 62805,
+			"name": "raven"
+		},
+		{
+			"codepoint": 61519,
+			"name": "raw_off"
+		},
+		{
+			"codepoint": 61520,
+			"name": "raw_on"
+		},
+		{
+			"codepoint": 61293,
+			"name": "read_more"
+		},
+		{
+			"codepoint": 63197,
+			"name": "readiness_score"
+		},
+		{
+			"codepoint": 59194,
+			"name": "real_estate_agent"
+		},
+		{
+			"codepoint": 63170,
+			"name": "rear_camera"
+		},
+		{
+			"codepoint": 63557,
+			"name": "rebase"
+		},
+		{
+			"codepoint": 63558,
+			"name": "rebase_edit"
+		},
+		{
+			"codepoint": 59568,
+			"name": "receipt"
+		},
+		{
+			"codepoint": 61294,
+			"name": "receipt_long"
+		},
+		{
+			"codepoint": 62474,
+			"name": "receipt_long_off"
+		},
+		{
+			"codepoint": 57407,
+			"name": "recent_actors"
+		},
+		{
+			"codepoint": 63496,
+			"name": "recent_patient"
+		},
+		{
+			"codepoint": 62656,
+			"name": "recenter"
+		},
+		{
+			"codepoint": 59858,
+			"name": "recommend"
+		},
+		{
+			"codepoint": 59679,
+			"name": "record_voice_over"
+		},
+		{
+			"codepoint": 60244,
+			"name": "rectangle"
+		},
+		{
+			"codepoint": 61128,
+			"name": "rectangle_add"
+		},
+		{
+			"codepoint": 59232,
+			"name": "recycling"
+		},
+		{
+			"codepoint": 59638,
+			"name": "redeem"
+		},
+		{
+			"codepoint": 57690,
+			"name": "redo"
+		},
+		{
+			"codepoint": 61980,
+			"name": "reduce_capacity"
+		},
+		{
+			"codepoint": 58837,
+			"name": "refresh"
+		},
+		{
+			"codepoint": 63312,
+			"name": "regular_expression"
+		},
+		{
+			"codepoint": 63196,
+			"name": "relax"
+		},
+		{
+			"codepoint": 63060,
+			"name": "release_alert"
+		},
+		{
+			"codepoint": 61521,
+			"name": "remember_me"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminder"
+		},
+		{
+			"codepoint": 59078,
+			"name": "reminders_alt"
+		},
+		{
+			"codepoint": 59454,
+			"name": "remote_gen"
+		},
+		{
+			"codepoint": 57691,
+			"name": "remove"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle"
+		},
+		{
+			"codepoint": 61583,
+			"name": "remove_circle_outline"
+		},
+		{
+			"codepoint": 59859,
+			"name": "remove_done"
+		},
+		{
+			"codepoint": 57447,
+			"name": "remove_from_queue"
+		},
+		{
+			"codepoint": 59860,
+			"name": "remove_moderator"
+		},
+		{
+			"codepoint": 59636,
+			"name": "remove_red_eye"
+		},
+		{
+			"codepoint": 60412,
+			"name": "remove_road"
+		},
+		{
+			"codepoint": 59861,
+			"name": "remove_selection"
+		},
+		{
+			"codepoint": 59688,
+			"name": "remove_shopping_cart"
+		},
+		{
+			"codepoint": 63240,
+			"name": "reopen_window"
+		},
+		{
+			"codepoint": 59646,
+			"name": "reorder"
+		},
+		{
+			"codepoint": 63720,
+			"name": "repartition"
+		},
+		{
+			"codepoint": 57408,
+			"name": "repeat"
+		},
+		{
+			"codepoint": 59862,
+			"name": "repeat_on"
+		},
+		{
+			"codepoint": 57409,
+			"name": "repeat_one"
+		},
+		{
+			"codepoint": 59863,
+			"name": "repeat_one_on"
+		},
+		{
+			"codepoint": 62545,
+			"name": "replace_audio"
+		},
+		{
+			"codepoint": 62544,
+			"name": "replace_image"
+		},
+		{
+			"codepoint": 62543,
+			"name": "replace_video"
+		},
+		{
+			"codepoint": 57410,
+			"name": "replay"
+		},
+		{
+			"codepoint": 57433,
+			"name": "replay_10"
+		},
+		{
+			"codepoint": 57434,
+			"name": "replay_30"
+		},
+		{
+			"codepoint": 57435,
+			"name": "replay_5"
+		},
+		{
+			"codepoint": 59864,
+			"name": "replay_circle_filled"
+		},
+		{
+			"codepoint": 57694,
+			"name": "reply"
+		},
+		{
+			"codepoint": 57695,
+			"name": "reply_all"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report"
+		},
+		{
+			"codepoint": 61522,
+			"name": "report_gmailerrorred"
+		},
+		{
+			"codepoint": 57712,
+			"name": "report_off"
+		},
+		{
+			"codepoint": 61571,
+			"name": "report_problem"
+		},
+		{
+			"codepoint": 61996,
+			"name": "request_page"
+		},
+		{
+			"codepoint": 61878,
+			"name": "request_quote"
+		},
+		{
+			"codepoint": 62594,
+			"name": "reset_brightness"
+		},
+		{
+			"codepoint": 1048290,
+			"name": "reset_colors"
+		},
+		{
+			"codepoint": 62054,
+			"name": "reset_exposure"
+		},
+		{
+			"codepoint": 62593,
+			"name": "reset_focus"
+		},
+		{
+			"codepoint": 63524,
+			"name": "reset_image"
+		},
+		{
+			"codepoint": 62592,
+			"name": "reset_iso"
+		},
+		{
+			"codepoint": 62591,
+			"name": "reset_settings"
+		},
+		{
+			"codepoint": 62590,
+			"name": "reset_shadow"
+		},
+		{
+			"codepoint": 62589,
+			"name": "reset_shutter_speed"
+		},
+		{
+			"codepoint": 59865,
+			"name": "reset_tv"
+		},
+		{
+			"codepoint": 62588,
+			"name": "reset_white_balance"
+		},
+		{
+			"codepoint": 62828,
+			"name": "reset_wrench"
+		},
+		{
+			"codepoint": 63239,
+			"name": "resize"
+		},
+		{
+			"codepoint": 1048473,
+			"name": "resize_window"
+		},
+		{
+			"codepoint": 57639,
+			"name": "respiratory_rate"
+		},
+		{
+			"codepoint": 59866,
+			"name": "responsive_layout"
+		},
+		{
+			"codepoint": 61994,
+			"name": "rest_area"
+		},
+		{
+			"codepoint": 61523,
+			"name": "restart_alt"
+		},
+		{
+			"codepoint": 58732,
+			"name": "restaurant"
+		},
+		{
+			"codepoint": 58721,
+			"name": "restaurant_menu"
+		},
+		{
+			"codepoint": 59571,
+			"name": "restore"
+		},
+		{
+			"codepoint": 59704,
+			"name": "restore_from_trash"
+		},
+		{
+			"codepoint": 59689,
+			"name": "restore_page"
+		},
+		{
+			"codepoint": 63440,
+			"name": "resume"
+		},
+		{
+			"codepoint": 61564,
+			"name": "reviews"
+		},
+		{
+			"codepoint": 61366,
+			"name": "rewarded_ads"
+		},
+		{
+			"codepoint": 57640,
+			"name": "rheumatology"
+		},
+		{
+			"codepoint": 63640,
+			"name": "rib_cage"
+		},
+		{
+			"codepoint": 61941,
+			"name": "rice_bowl"
+		},
+		{
+			"codepoint": 63238,
+			"name": "right_click"
+		},
+		{
+			"codepoint": 63237,
+			"name": "right_panel_close"
+		},
+		{
+			"codepoint": 63236,
+			"name": "right_panel_open"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume"
+		},
+		{
+			"codepoint": 61661,
+			"name": "ring_volume_filled"
+		},
+		{
+			"codepoint": 59867,
+			"name": "ripples"
+		},
+		{
+			"codepoint": 62578,
+			"name": "road"
+		},
+		{
+			"codepoint": 63618,
+			"name": "robot"
+		},
+		{
+			"codepoint": 62928,
+			"name": "robot_2"
+		},
+		{
+			"codepoint": 60325,
+			"name": "rocket"
+		},
+		{
+			"codepoint": 60315,
+			"name": "rocket_launch"
+		},
+		{
+			"codepoint": 60434,
+			"name": "roller_shades"
+		},
+		{
+			"codepoint": 60433,
+			"name": "roller_shades_closed"
+		},
+		{
+			"codepoint": 60365,
+			"name": "roller_skating"
+		},
+		{
+			"codepoint": 61953,
+			"name": "roofing"
+		},
+		{
+			"codepoint": 61915,
+			"name": "room"
+		},
+		{
+			"codepoint": 61880,
+			"name": "room_preferences"
+		},
+		{
+			"codepoint": 60233,
+			"name": "room_service"
+		},
+		{
+			"codepoint": 58392,
+			"name": "rotate_90_degrees_ccw"
+		},
+		{
+			"codepoint": 60075,
+			"name": "rotate_90_degrees_cw"
+		},
+		{
+			"codepoint": 62487,
+			"name": "rotate_auto"
+		},
+		{
+			"codepoint": 58393,
+			"name": "rotate_left"
+		},
+		{
+			"codepoint": 58394,
+			"name": "rotate_right"
+		},
+		{
+			"codepoint": 60313,
+			"name": "roundabout_left"
+		},
+		{
+			"codepoint": 60323,
+			"name": "roundabout_right"
+		},
+		{
+			"codepoint": 59680,
+			"name": "rounded_corner"
+		},
+		{
+			"codepoint": 60109,
+			"name": "route"
+		},
+		{
+			"codepoint": 58152,
+			"name": "router"
+		},
+		{
+			"codepoint": 62196,
+			"name": "router_off"
+		},
+		{
+			"codepoint": 57868,
+			"name": "routine"
+		},
+		{
+			"codepoint": 59681,
+			"name": "rowing"
+		},
+		{
+			"codepoint": 57573,
+			"name": "rss_feed"
+		},
+		{
+			"codepoint": 61525,
+			"name": "rsvp"
+		},
+		{
+			"codepoint": 59821,
+			"name": "rtt"
+		},
+		{
+			"codepoint": 60199,
+			"name": "rubric"
+		},
+		{
+			"codepoint": 61890,
+			"name": "rule"
+		},
+		{
+			"codepoint": 61897,
+			"name": "rule_folder"
+		},
+		{
+			"codepoint": 63052,
+			"name": "rule_settings"
+		},
+		{
+			"codepoint": 61295,
+			"name": "run_circle"
+		},
+		{
+			"codepoint": 58653,
+			"name": "running_with_errors"
+		},
+		{
+			"codepoint": 58946,
+			"name": "rv_hookup"
+		},
+		{
+			"codepoint": 60399,
+			"name": "safety_check"
+		},
+		{
+			"codepoint": 62877,
+			"name": "safety_check_off"
+		},
+		{
+			"codepoint": 57804,
+			"name": "safety_divider"
+		},
+		{
+			"codepoint": 58626,
+			"name": "sailing"
+		},
+		{
+			"codepoint": 63606,
+			"name": "salinity"
+		},
+		{
+			"codepoint": 61981,
+			"name": "sanitizer"
+		},
+		{
+			"codepoint": 58722,
+			"name": "satellite"
+		},
+		{
+			"codepoint": 60218,
+			"name": "satellite_alt"
+		},
+		{
+			"codepoint": 63223,
+			"name": "sauna"
+		},
+		{
+			"codepoint": 57697,
+			"name": "save"
+		},
+		{
+			"codepoint": 61584,
+			"name": "save_alt"
+		},
+		{
+			"codepoint": 60256,
+			"name": "save_as"
+		},
+		{
+			"codepoint": 62360,
+			"name": "save_clock"
+		},
+		{
+			"codepoint": 59921,
+			"name": "saved_search"
+		},
+		{
+			"codepoint": 58091,
+			"name": "savings"
+		},
+		{
+			"codepoint": 60255,
+			"name": "scale"
+		},
+		{
+			"codepoint": 63310,
+			"name": "scan"
+		},
+		{
+			"codepoint": 63311,
+			"name": "scan_delete"
+		},
+		{
+			"codepoint": 58153,
+			"name": "scanner"
+		},
+		{
+			"codepoint": 57960,
+			"name": "scatter_plot"
+		},
+		{
+			"codepoint": 58023,
+			"name": "scene"
+		},
+		{
+			"codepoint": 61398,
+			"name": "schedule"
+		},
+		{
+			"codepoint": 59914,
+			"name": "schedule_send"
+		},
+		{
+			"codepoint": 58621,
+			"name": "schema"
+		},
+		{
+			"codepoint": 59404,
+			"name": "school"
+		},
+		{
+			"codepoint": 59979,
+			"name": "science"
+		},
+		{
+			"codepoint": 62786,
+			"name": "science_off"
+		},
+		{
+			"codepoint": 62577,
+			"name": "scooter"
+		},
+		{
+			"codepoint": 57961,
+			"name": "score"
+		},
+		{
+			"codepoint": 60368,
+			"name": "scoreboard"
+		},
+		{
+			"codepoint": 62168,
+			"name": "screen_lock_landscape"
+		},
+		{
+			"codepoint": 62142,
+			"name": "screen_lock_portrait"
+		},
+		{
+			"codepoint": 62166,
+			"name": "screen_lock_rotation"
+		},
+		{
+			"codepoint": 63097,
+			"name": "screen_record"
+		},
+		{
+			"codepoint": 62165,
+			"name": "screen_rotation"
+		},
+		{
+			"codepoint": 60398,
+			"name": "screen_rotation_alt"
+		},
+		{
+			"codepoint": 63096,
+			"name": "screen_rotation_up"
+		},
+		{
+			"codepoint": 61296,
+			"name": "screen_search_desktop"
+		},
+		{
+			"codepoint": 57570,
+			"name": "screen_share"
+		},
+		{
+			"codepoint": 61526,
+			"name": "screenshot"
+		},
+		{
+			"codepoint": 63095,
+			"name": "screenshot_frame"
+		},
+		{
+			"codepoint": 62324,
+			"name": "screenshot_frame_2"
+		},
+		{
+			"codepoint": 63443,
+			"name": "screenshot_keyboard"
+		},
+		{
+			"codepoint": 60424,
+			"name": "screenshot_monitor"
+		},
+		{
+			"codepoint": 63442,
+			"name": "screenshot_region"
+		},
+		{
+			"codepoint": 63127,
+			"name": "screenshot_tablet"
+		},
+		{
+			"codepoint": 62559,
+			"name": "script"
+		},
+		{
+			"codepoint": 59868,
+			"name": "scrollable_header"
+		},
+		{
+			"codepoint": 60366,
+			"name": "scuba_diving"
+		},
+		{
+			"codepoint": 59869,
+			"name": "sd"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sd_card_alert"
+		},
+		{
+			"codepoint": 58915,
+			"name": "sd_storage"
+		},
+		{
+			"codepoint": 59168,
+			"name": "sdk"
+		},
+		{
+			"codepoint": 61306,
+			"name": "search"
+		},
+		{
+			"codepoint": 62437,
+			"name": "search_activity"
+		},
+		{
+			"codepoint": 63488,
+			"name": "search_check"
+		},
+		{
+			"codepoint": 62569,
+			"name": "search_check_2"
+		},
+		{
+			"codepoint": 61178,
+			"name": "search_gear"
+		},
+		{
+			"codepoint": 59030,
+			"name": "search_hands_free"
+		},
+		{
+			"codepoint": 62652,
+			"name": "search_insights"
+		},
+		{
+			"codepoint": 60022,
+			"name": "search_off"
+		},
+		{
+			"codepoint": 62257,
+			"name": "seat_cool_left"
+		},
+		{
+			"codepoint": 62256,
+			"name": "seat_cool_right"
+		},
+		{
+			"codepoint": 62255,
+			"name": "seat_heat_left"
+		},
+		{
+			"codepoint": 62254,
+			"name": "seat_heat_right"
+		},
+		{
+			"codepoint": 1048282,
+			"name": "seat_read"
+		},
+		{
+			"codepoint": 62253,
+			"name": "seat_vent_left"
+		},
+		{
+			"codepoint": 62252,
+			"name": "seat_vent_right"
+		},
+		{
+			"codepoint": 1048289,
+			"name": "seat_window"
+		},
+		{
+			"codepoint": 58154,
+			"name": "security"
+		},
+		{
+			"codepoint": 62723,
+			"name": "security_key"
+		},
+		{
+			"codepoint": 62157,
+			"name": "security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "security_update_warning"
+		},
+		{
+			"codepoint": 59723,
+			"name": "segment"
+		},
+		{
+			"codepoint": 63309,
+			"name": "select"
+		},
+		{
+			"codepoint": 57698,
+			"name": "select_all"
+		},
+		{
+			"codepoint": 61950,
+			"name": "select_check_box"
+		},
+		{
+			"codepoint": 63439,
+			"name": "select_to_speak"
+		},
+		{
+			"codepoint": 59130,
+			"name": "select_window"
+		},
+		{
+			"codepoint": 62664,
+			"name": "select_window_2"
+		},
+		{
+			"codepoint": 58630,
+			"name": "select_window_off"
+		},
+		{
+			"codepoint": 63597,
+			"name": "self_care"
+		},
+		{
+			"codepoint": 60024,
+			"name": "self_improvement"
+		},
+		{
+			"codepoint": 61531,
+			"name": "sell"
+		},
+		{
+			"codepoint": 1048443,
+			"name": "sell_cloud"
+		},
+		{
+			"codepoint": 57699,
+			"name": "send"
+		},
+		{
+			"codepoint": 59916,
+			"name": "send_and_archive"
+		},
+		{
+			"codepoint": 59575,
+			"name": "send_money"
+		},
+		{
+			"codepoint": 60123,
+			"name": "send_time_extension"
+		},
+		{
+			"codepoint": 62162,
+			"name": "send_to_mobile"
+		},
+		{
+			"codepoint": 61877,
+			"name": "sensor_door"
+		},
+		{
+			"codepoint": 60432,
+			"name": "sensor_occupied"
+		},
+		{
+			"codepoint": 61876,
+			"name": "sensor_window"
+		},
+		{
+			"codepoint": 58654,
+			"name": "sensors"
+		},
+		{
+			"codepoint": 62806,
+			"name": "sensors_krx"
+		},
+		{
+			"codepoint": 62741,
+			"name": "sensors_krx_off"
+		},
+		{
+			"codepoint": 58655,
+			"name": "sensors_off"
+		},
+		{
+			"codepoint": 63143,
+			"name": "sentiment_calm"
+		},
+		{
+			"codepoint": 63142,
+			"name": "sentiment_content"
+		},
+		{
+			"codepoint": 59409,
+			"name": "sentiment_dissatisfied"
+		},
+		{
+			"codepoint": 63141,
+			"name": "sentiment_excited"
+		},
+		{
+			"codepoint": 61844,
+			"name": "sentiment_extremely_dissatisfied"
+		},
+		{
+			"codepoint": 63140,
+			"name": "sentiment_frustrated"
+		},
+		{
+			"codepoint": 59410,
+			"name": "sentiment_neutral"
+		},
+		{
+			"codepoint": 63139,
+			"name": "sentiment_sad"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied"
+		},
+		{
+			"codepoint": 59411,
+			"name": "sentiment_satisfied_alt"
+		},
+		{
+			"codepoint": 63138,
+			"name": "sentiment_stressed"
+		},
+		{
+			"codepoint": 59412,
+			"name": "sentiment_very_dissatisfied"
+		},
+		{
+			"codepoint": 59413,
+			"name": "sentiment_very_satisfied"
+		},
+		{
+			"codepoint": 63137,
+			"name": "sentiment_worried"
+		},
+		{
+			"codepoint": 62636,
+			"name": "serif"
+		},
+		{
+			"codepoint": 62397,
+			"name": "server_person"
+		},
+		{
+			"codepoint": 59159,
+			"name": "service_toolbox"
+		},
+		{
+			"codepoint": 61930,
+			"name": "set_meal"
+		},
+		{
+			"codepoint": 59576,
+			"name": "settings"
+		},
+		{
+			"codepoint": 61533,
+			"name": "settings_accessibility"
+		},
+		{
+			"codepoint": 63541,
+			"name": "settings_account_box"
+		},
+		{
+			"codepoint": 61763,
+			"name": "settings_alert"
+		},
+		{
+			"codepoint": 59577,
+			"name": "settings_applications"
+		},
+		{
+			"codepoint": 63013,
+			"name": "settings_b_roll"
+		},
+		{
+			"codepoint": 59578,
+			"name": "settings_backup_restore"
+		},
+		{
+			"codepoint": 59579,
+			"name": "settings_bluetooth"
+		},
+		{
+			"codepoint": 59581,
+			"name": "settings_brightness"
+		},
+		{
+			"codepoint": 62161,
+			"name": "settings_cell"
+		},
+		{
+			"codepoint": 63012,
+			"name": "settings_cinematic_blur"
+		},
+		{
+			"codepoint": 59582,
+			"name": "settings_ethernet"
+		},
+		{
+			"codepoint": 62754,
+			"name": "settings_heart"
+		},
+		{
+			"codepoint": 59583,
+			"name": "settings_input_antenna"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_component"
+		},
+		{
+			"codepoint": 59585,
+			"name": "settings_input_composite"
+		},
+		{
+			"codepoint": 59586,
+			"name": "settings_input_hdmi"
+		},
+		{
+			"codepoint": 59587,
+			"name": "settings_input_svideo"
+		},
+		{
+			"codepoint": 63539,
+			"name": "settings_motion_mode"
+		},
+		{
+			"codepoint": 63538,
+			"name": "settings_night_sight"
+		},
+		{
+			"codepoint": 59588,
+			"name": "settings_overscan"
+		},
+		{
+			"codepoint": 63537,
+			"name": "settings_panorama"
+		},
+		{
+			"codepoint": 59589,
+			"name": "settings_phone"
+		},
+		{
+			"codepoint": 63540,
+			"name": "settings_photo_camera"
+		},
+		{
+			"codepoint": 59590,
+			"name": "settings_power"
+		},
+		{
+			"codepoint": 59591,
+			"name": "settings_remote"
+		},
+		{
+			"codepoint": 1048287,
+			"name": "settings_screen"
+		},
+		{
+			"codepoint": 61229,
+			"name": "settings_seating"
+		},
+		{
+			"codepoint": 63011,
+			"name": "settings_slow_motion"
+		},
+		{
+			"codepoint": 61534,
+			"name": "settings_suggest"
+		},
+		{
+			"codepoint": 57795,
+			"name": "settings_system_daydream"
+		},
+		{
+			"codepoint": 63010,
+			"name": "settings_timelapse"
+		},
+		{
+			"codepoint": 63009,
+			"name": "settings_video_camera"
+		},
+		{
+			"codepoint": 59592,
+			"name": "settings_voice"
+		},
+		{
+			"codepoint": 58028,
+			"name": "settop_component"
+		},
+		{
+			"codepoint": 60371,
+			"name": "severe_cold"
+		},
+		{
+			"codepoint": 1048435,
+			"name": "shades"
+		},
+		{
+			"codepoint": 1048436,
+			"name": "shades_closed"
+		},
+		{
+			"codepoint": 59871,
+			"name": "shadow"
+		},
+		{
+			"codepoint": 62852,
+			"name": "shadow_add"
+		},
+		{
+			"codepoint": 62851,
+			"name": "shadow_minus"
+		},
+		{
+			"codepoint": 63699,
+			"name": "shape_line"
+		},
+		{
+			"codepoint": 60161,
+			"name": "shape_recognition"
+		},
+		{
+			"codepoint": 58882,
+			"name": "shapes"
+		},
+		{
+			"codepoint": 59405,
+			"name": "share"
+		},
+		{
+			"codepoint": 58871,
+			"name": "share_eta"
+		},
+		{
+			"codepoint": 61535,
+			"name": "share_location"
+		},
+		{
+			"codepoint": 63179,
+			"name": "share_off"
+		},
+		{
+			"codepoint": 63652,
+			"name": "share_reviews"
+		},
+		{
+			"codepoint": 62995,
+			"name": "share_windows"
+		},
+		{
+			"codepoint": 61989,
+			"name": "shaved_ice"
+		},
+		{
+			"codepoint": 63523,
+			"name": "sheets_rtl"
+		},
+		{
+			"codepoint": 63235,
+			"name": "shelf_auto_hide"
+		},
+		{
+			"codepoint": 63234,
+			"name": "shelf_position"
+		},
+		{
+			"codepoint": 63598,
+			"name": "shelves"
+		},
+		{
+			"codepoint": 59872,
+			"name": "shield"
+		},
+		{
+			"codepoint": 1048368,
+			"name": "shield_card"
+		},
+		{
+			"codepoint": 63110,
+			"name": "shield_lock"
+		},
+		{
+			"codepoint": 62866,
+			"name": "shield_locked"
+		},
+		{
+			"codepoint": 60073,
+			"name": "shield_moon"
+		},
+		{
+			"codepoint": 63056,
+			"name": "shield_person"
+		},
+		{
+			"codepoint": 62761,
+			"name": "shield_question"
+		},
+		{
+			"codepoint": 1048367,
+			"name": "shield_radar"
+		},
+		{
+			"codepoint": 62125,
+			"name": "shield_toggle"
+		},
+		{
+			"codepoint": 62223,
+			"name": "shield_watch"
+		},
+		{
+			"codepoint": 59279,
+			"name": "shield_with_heart"
+		},
+		{
+			"codepoint": 59277,
+			"name": "shield_with_house"
+		},
+		{
+			"codepoint": 58866,
+			"name": "shift"
+		},
+		{
+			"codepoint": 63406,
+			"name": "shift_lock"
+		},
+		{
+			"codepoint": 62595,
+			"name": "shift_lock_off"
+		},
+		{
+			"codepoint": 1048499,
+			"name": "shoe_cleats"
+		},
+		{
+			"codepoint": 59593,
+			"name": "shop"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_2"
+		},
+		{
+			"codepoint": 59594,
+			"name": "shop_two"
+		},
+		{
+			"codepoint": 61900,
+			"name": "shopping_bag"
+		},
+		{
+			"codepoint": 62362,
+			"name": "shopping_bag_speed"
+		},
+		{
+			"codepoint": 59595,
+			"name": "shopping_basket"
+		},
+		{
+			"codepoint": 59596,
+			"name": "shopping_cart"
+		},
+		{
+			"codepoint": 60296,
+			"name": "shopping_cart_checkout"
+		},
+		{
+			"codepoint": 62711,
+			"name": "shopping_cart_off"
+		},
+		{
+			"codepoint": 61367,
+			"name": "shoppingmode"
+		},
+		{
+			"codepoint": 58576,
+			"name": "short_stay"
+		},
+		{
+			"codepoint": 57953,
+			"name": "short_text"
+		},
+		{
+			"codepoint": 62842,
+			"name": "shortcut"
+		},
+		{
+			"codepoint": 59105,
+			"name": "show_chart"
+		},
+		{
+			"codepoint": 61537,
+			"name": "shower"
+		},
+		{
+			"codepoint": 57411,
+			"name": "shuffle"
+		},
+		{
+			"codepoint": 59873,
+			"name": "shuffle_on"
+		},
+		{
+			"codepoint": 58429,
+			"name": "shutter_speed"
+		},
+		{
+			"codepoint": 62846,
+			"name": "shutter_speed_add"
+		},
+		{
+			"codepoint": 62845,
+			"name": "shutter_speed_minus"
+		},
+		{
+			"codepoint": 61984,
+			"name": "sick"
+		},
+		{
+			"codepoint": 59874,
+			"name": "side_navigation"
+		},
+		{
+			"codepoint": 60389,
+			"name": "sign_language"
+		},
+		{
+			"codepoint": 62040,
+			"name": "sign_language_2"
+		},
+		{
+			"codepoint": 1048292,
+			"name": "sign_language_off"
+		},
+		{
+			"codepoint": 61608,
+			"name": "signal_cellular_0_bar"
+		},
+		{
+			"codepoint": 61609,
+			"name": "signal_cellular_1_bar"
+		},
+		{
+			"codepoint": 61610,
+			"name": "signal_cellular_2_bar"
+		},
+		{
+			"codepoint": 61611,
+			"name": "signal_cellular_3_bar"
+		},
+		{
+			"codepoint": 57800,
+			"name": "signal_cellular_4_bar"
+		},
+		{
+			"codepoint": 63401,
+			"name": "signal_cellular_add"
+		},
+		{
+			"codepoint": 57858,
+			"name": "signal_cellular_alt"
+		},
+		{
+			"codepoint": 60383,
+			"name": "signal_cellular_alt_1_bar"
+		},
+		{
+			"codepoint": 60387,
+			"name": "signal_cellular_alt_2_bar"
+		},
+		{
+			"codepoint": 1048458,
+			"name": "signal_cellular_alt_off"
+		},
+		{
+			"codepoint": 61612,
+			"name": "signal_cellular_connected_no_internet_0_bar"
+		},
+		{
+			"codepoint": 57805,
+			"name": "signal_cellular_connected_no_internet_4_bar"
+		},
+		{
+			"codepoint": 57806,
+			"name": "signal_cellular_no_sim"
+		},
+		{
+			"codepoint": 61538,
+			"name": "signal_cellular_nodata"
+		},
+		{
+			"codepoint": 57807,
+			"name": "signal_cellular_null"
+		},
+		{
+			"codepoint": 57808,
+			"name": "signal_cellular_off"
+		},
+		{
+			"codepoint": 62887,
+			"name": "signal_cellular_pause"
+		},
+		{
+			"codepoint": 62009,
+			"name": "signal_disconnected"
+		},
+		{
+			"codepoint": 61616,
+			"name": "signal_wifi_0_bar"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_4_bar"
+		},
+		{
+			"codepoint": 57825,
+			"name": "signal_wifi_4_bar_lock"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_bad"
+		},
+		{
+			"codepoint": 61540,
+			"name": "signal_wifi_connected_no_internet_4"
+		},
+		{
+			"codepoint": 57818,
+			"name": "signal_wifi_off"
+		},
+		{
+			"codepoint": 61541,
+			"name": "signal_wifi_statusbar_4_bar"
+		},
+		{
+			"codepoint": 61679,
+			"name": "signal_wifi_statusbar_not_connected"
+		},
+		{
+			"codepoint": 61543,
+			"name": "signal_wifi_statusbar_null"
+		},
+		{
+			"codepoint": 63308,
+			"name": "signature"
+		},
+		{
+			"codepoint": 60305,
+			"name": "signpost"
+		},
+		{
+			"codepoint": 58155,
+			"name": "sim_card"
+		},
+		{
+			"codepoint": 61527,
+			"name": "sim_card_alert"
+		},
+		{
+			"codepoint": 61544,
+			"name": "sim_card_download"
+		},
+		{
+			"codepoint": 62433,
+			"name": "simulation"
+		},
+		{
+			"codepoint": 1048281,
+			"name": "single_arrow"
+		},
+		{
+			"codepoint": 59976,
+			"name": "single_bed"
+		},
+		{
+			"codepoint": 61545,
+			"name": "sip"
+		},
+		{
+			"codepoint": 62375,
+			"name": "siren"
+		},
+		{
+			"codepoint": 62374,
+			"name": "siren_check"
+		},
+		{
+			"codepoint": 62373,
+			"name": "siren_open"
+		},
+		{
+			"codepoint": 62372,
+			"name": "siren_question"
+		},
+		{
+			"codepoint": 58641,
+			"name": "skateboarding"
+		},
+		{
+			"codepoint": 63641,
+			"name": "skeleton"
+		},
+		{
+			"codepoint": 62787,
+			"name": "skillet"
+		},
+		{
+			"codepoint": 62788,
+			"name": "skillet_cooktop"
+		},
+		{
+			"codepoint": 57412,
+			"name": "skip_next"
+		},
+		{
+			"codepoint": 57413,
+			"name": "skip_previous"
+		},
+		{
+			"codepoint": 63642,
+			"name": "skull"
+		},
+		{
+			"codepoint": 62320,
+			"name": "skull_list"
+		},
+		{
+			"codepoint": 62635,
+			"name": "slab_serif"
+		},
+		{
+			"codepoint": 58642,
+			"name": "sledding"
+		},
+		{
+			"codepoint": 57875,
+			"name": "sleep"
+		},
+		{
+			"codepoint": 63159,
+			"name": "sleep_score"
+		},
+		{
+			"codepoint": 63522,
+			"name": "slide_library"
+		},
+		{
+			"codepoint": 59875,
+			"name": "sliders"
+		},
+		{
+			"codepoint": 58395,
+			"name": "slideshow"
+		},
+		{
+			"codepoint": 57448,
+			"name": "slow_motion_video"
+		},
+		{
+			"codepoint": 61889,
+			"name": "smart_button"
+		},
+		{
+			"codepoint": 62629,
+			"name": "smart_card_reader"
+		},
+		{
+			"codepoint": 62630,
+			"name": "smart_card_reader_off"
+		},
+		{
+			"codepoint": 61546,
+			"name": "smart_display"
+		},
+		{
+			"codepoint": 59460,
+			"name": "smart_outlet"
+		},
+		{
+			"codepoint": 62160,
+			"name": "smart_screen"
+		},
+		{
+			"codepoint": 61548,
+			"name": "smart_toy"
+		},
+		{
+			"codepoint": 59322,
+			"name": "smartphone"
+		},
+		{
+			"codepoint": 62542,
+			"name": "smartphone_camera"
+		},
+		{
+			"codepoint": 63307,
+			"name": "smb_share"
+		},
+		{
+			"codepoint": 60234,
+			"name": "smoke_free"
+		},
+		{
+			"codepoint": 60235,
+			"name": "smoking_rooms"
+		},
+		{
+			"codepoint": 58917,
+			"name": "sms"
+		},
+		{
+			"codepoint": 59519,
+			"name": "sms_failed"
+		},
+		{
+			"codepoint": 1048286,
+			"name": "snail"
+		},
+		{
+			"codepoint": 61895,
+			"name": "snippet_folder"
+		},
+		{
+			"codepoint": 57414,
+			"name": "snooze"
+		},
+		{
+			"codepoint": 58643,
+			"name": "snowboarding"
+		},
+		{
+			"codepoint": 60763,
+			"name": "snowflake"
+		},
+		{
+			"codepoint": 59407,
+			"name": "snowing"
+		},
+		{
+			"codepoint": 63004,
+			"name": "snowing_heavy"
+		},
+		{
+			"codepoint": 58627,
+			"name": "snowmobile"
+		},
+		{
+			"codepoint": 58644,
+			"name": "snowshoeing"
+		},
+		{
+			"codepoint": 61874,
+			"name": "soap"
+		},
+		{
+			"codepoint": 61238,
+			"name": "soba"
+		},
+		{
+			"codepoint": 57803,
+			"name": "social_distance"
+		},
+		{
+			"codepoint": 63136,
+			"name": "social_leaderboard"
+		},
+		{
+			"codepoint": 60431,
+			"name": "solar_power"
+		},
+		{
+			"codepoint": 61237,
+			"name": "solo_dining"
+		},
+		{
+			"codepoint": 57700,
+			"name": "sort"
+		},
+		{
+			"codepoint": 57427,
+			"name": "sort_by_alpha"
+		},
+		{
+			"codepoint": 60407,
+			"name": "sos"
+		},
+		{
+			"codepoint": 61769,
+			"name": "sound_detection_dog_barking"
+		},
+		{
+			"codepoint": 61770,
+			"name": "sound_detection_glass_break"
+		},
+		{
+			"codepoint": 61771,
+			"name": "sound_detection_loud_sound"
+		},
+		{
+			"codepoint": 63156,
+			"name": "sound_sampler"
+		},
+		{
+			"codepoint": 1048434,
+			"name": "soundbar"
+		},
+		{
+			"codepoint": 59347,
+			"name": "soup_kitchen"
+		},
+		{
+			"codepoint": 61896,
+			"name": "source"
+		},
+		{
+			"codepoint": 58663,
+			"name": "source_environment"
+		},
+		{
+			"codepoint": 57645,
+			"name": "source_notes"
+		},
+		{
+			"codepoint": 61923,
+			"name": "south"
+		},
+		{
+			"codepoint": 59364,
+			"name": "south_america"
+		},
+		{
+			"codepoint": 61924,
+			"name": "south_east"
+		},
+		{
+			"codepoint": 61925,
+			"name": "south_west"
+		},
+		{
+			"codepoint": 60236,
+			"name": "spa"
+		},
+		{
+			"codepoint": 57942,
+			"name": "space_bar"
+		},
+		{
+			"codepoint": 58987,
+			"name": "space_dashboard"
+		},
+		{
+			"codepoint": 1048460,
+			"name": "space_dashboard_2"
+		},
+		{
+			"codepoint": 60395,
+			"name": "spatial_audio"
+		},
+		{
+			"codepoint": 60392,
+			"name": "spatial_audio_off"
+		},
+		{
+			"codepoint": 62671,
+			"name": "spatial_speaker"
+		},
+		{
+			"codepoint": 60394,
+			"name": "spatial_tracking"
+		},
+		{
+			"codepoint": 58157,
+			"name": "speaker"
+		},
+		{
+			"codepoint": 1048433,
+			"name": "speaker_2"
+		},
+		{
+			"codepoint": 58158,
+			"name": "speaker_group"
+		},
+		{
+			"codepoint": 59597,
+			"name": "speaker_notes"
+		},
+		{
+			"codepoint": 59690,
+			"name": "speaker_notes_off"
+		},
+		{
+			"codepoint": 57554,
+			"name": "speaker_phone"
+		},
+		{
+			"codepoint": 63306,
+			"name": "special_character"
+		},
+		{
+			"codepoint": 63602,
+			"name": "specific_gravity"
+		},
+		{
+			"codepoint": 63655,
+			"name": "speech_to_text"
+		},
+		{
+			"codepoint": 59876,
+			"name": "speed"
+		},
+		{
+			"codepoint": 62676,
+			"name": "speed_0_25"
+		},
+		{
+			"codepoint": 62616,
+			"name": "speed_0_2x"
+		},
+		{
+			"codepoint": 62690,
+			"name": "speed_0_5"
+		},
+		{
+			"codepoint": 62615,
+			"name": "speed_0_5x"
+		},
+		{
+			"codepoint": 62675,
+			"name": "speed_0_75"
+		},
+		{
+			"codepoint": 62614,
+			"name": "speed_0_7x"
+		},
+		{
+			"codepoint": 62689,
+			"name": "speed_1_2"
+		},
+		{
+			"codepoint": 62674,
+			"name": "speed_1_25"
+		},
+		{
+			"codepoint": 62613,
+			"name": "speed_1_2x"
+		},
+		{
+			"codepoint": 62688,
+			"name": "speed_1_5"
+		},
+		{
+			"codepoint": 62612,
+			"name": "speed_1_5x"
+		},
+		{
+			"codepoint": 62673,
+			"name": "speed_1_75"
+		},
+		{
+			"codepoint": 62611,
+			"name": "speed_1_7x"
+		},
+		{
+			"codepoint": 1048376,
+			"name": "speed_2"
+		},
+		{
+			"codepoint": 62699,
+			"name": "speed_2x"
+		},
+		{
+			"codepoint": 1048375,
+			"name": "speed_3"
+		},
+		{
+			"codepoint": 1048374,
+			"name": "speed_4"
+		},
+		{
+			"codepoint": 62576,
+			"name": "speed_camera"
+		},
+		{
+			"codepoint": 59598,
+			"name": "spellcheck"
+		},
+		{
+			"codepoint": 62399,
+			"name": "split_scene"
+		},
+		{
+			"codepoint": 1048311,
+			"name": "split_scene_2"
+		},
+		{
+			"codepoint": 62207,
+			"name": "split_scene_down"
+		},
+		{
+			"codepoint": 62206,
+			"name": "split_scene_left"
+		},
+		{
+			"codepoint": 62205,
+			"name": "split_scene_right"
+		},
+		{
+			"codepoint": 62204,
+			"name": "split_scene_up"
+		},
+		{
+			"codepoint": 61549,
+			"name": "splitscreen"
+		},
+		{
+			"codepoint": 62717,
+			"name": "splitscreen_add"
+		},
+		{
+			"codepoint": 63094,
+			"name": "splitscreen_bottom"
+		},
+		{
+			"codepoint": 62553,
+			"name": "splitscreen_landscape"
+		},
+		{
+			"codepoint": 1048506,
+			"name": "splitscreen_landscape_add"
+		},
+		{
+			"codepoint": 63093,
+			"name": "splitscreen_left"
+		},
+		{
+			"codepoint": 62552,
+			"name": "splitscreen_portrait"
+		},
+		{
+			"codepoint": 63092,
+			"name": "splitscreen_right"
+		},
+		{
+			"codepoint": 63091,
+			"name": "splitscreen_top"
+		},
+		{
+			"codepoint": 62716,
+			"name": "splitscreen_vertical_add"
+		},
+		{
+			"codepoint": 63195,
+			"name": "spo2"
+		},
+		{
+			"codepoint": 59815,
+			"name": "spoke"
+		},
+		{
+			"codepoint": 59952,
+			"name": "sports"
+		},
+		{
+			"codepoint": 61368,
+			"name": "sports_and_outdoors"
+		},
+		{
+			"codepoint": 61939,
+			"name": "sports_bar"
+		},
+		{
+			"codepoint": 59985,
+			"name": "sports_baseball"
+		},
+		{
+			"codepoint": 59942,
+			"name": "sports_basketball"
+		},
+		{
+			"codepoint": 59943,
+			"name": "sports_cricket"
+		},
+		{
+			"codepoint": 59944,
+			"name": "sports_esports"
+		},
+		{
+			"codepoint": 59945,
+			"name": "sports_football"
+		},
+		{
+			"codepoint": 59946,
+			"name": "sports_golf"
+		},
+		{
+			"codepoint": 60356,
+			"name": "sports_gymnastics"
+		},
+		{
+			"codepoint": 59955,
+			"name": "sports_handball"
+		},
+		{
+			"codepoint": 59947,
+			"name": "sports_hockey"
+		},
+		{
+			"codepoint": 59956,
+			"name": "sports_kabaddi"
+		},
+		{
+			"codepoint": 60137,
+			"name": "sports_martial_arts"
+		},
+		{
+			"codepoint": 59948,
+			"name": "sports_mma"
+		},
+		{
+			"codepoint": 59949,
+			"name": "sports_motorsports"
+		},
+		{
+			"codepoint": 59950,
+			"name": "sports_rugby"
+		},
+		{
+			"codepoint": 61550,
+			"name": "sports_score"
+		},
+		{
+			"codepoint": 59951,
+			"name": "sports_soccer"
+		},
+		{
+			"codepoint": 59954,
+			"name": "sports_tennis"
+		},
+		{
+			"codepoint": 59953,
+			"name": "sports_volleyball"
+		},
+		{
+			"codepoint": 58010,
+			"name": "sprinkler"
+		},
+		{
+			"codepoint": 63519,
+			"name": "sprint"
+		},
+		{
+			"codepoint": 1048469,
+			"name": "sql"
+		},
+		{
+			"codepoint": 60214,
+			"name": "square"
+		},
+		{
+			"codepoint": 61127,
+			"name": "square_circle"
+		},
+		{
+			"codepoint": 62387,
+			"name": "square_dot"
+		},
+		{
+			"codepoint": 59977,
+			"name": "square_foot"
+		},
+		{
+			"codepoint": 60262,
+			"name": "ssid_chart"
+		},
+		{
+			"codepoint": 62985,
+			"name": "stack"
+		},
+		{
+			"codepoint": 62297,
+			"name": "stack_group"
+		},
+		{
+			"codepoint": 62492,
+			"name": "stack_hexagon"
+		},
+		{
+			"codepoint": 62984,
+			"name": "stack_off"
+		},
+		{
+			"codepoint": 62983,
+			"name": "stack_star"
+		},
+		{
+			"codepoint": 59878,
+			"name": "stacked_bar_chart"
+		},
+		{
+			"codepoint": 59079,
+			"name": "stacked_email"
+		},
+		{
+			"codepoint": 59081,
+			"name": "stacked_inbox"
+		},
+		{
+			"codepoint": 61995,
+			"name": "stacked_line_chart"
+		},
+		{
+			"codepoint": 62720,
+			"name": "stacks"
+		},
+		{
+			"codepoint": 61749,
+			"name": "stadia_controller"
+		},
+		{
+			"codepoint": 60304,
+			"name": "stadium"
+		},
+		{
+			"codepoint": 61865,
+			"name": "stairs"
+		},
+		{
+			"codepoint": 62572,
+			"name": "stairs_2"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_border_purple500"
+		},
+		{
+			"codepoint": 59449,
+			"name": "star_half"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_outline"
+		},
+		{
+			"codepoint": 61594,
+			"name": "star_purple500"
+		},
+		{
+			"codepoint": 61676,
+			"name": "star_rate"
+		},
+		{
+			"codepoint": 60485,
+			"name": "star_rate_half"
+		},
+		{
+			"codepoint": 62237,
+			"name": "star_shine"
+		},
+		{
+			"codepoint": 59600,
+			"name": "stars"
+		},
+		{
+			"codepoint": 62236,
+			"name": "stars_2"
+		},
+		{
+			"codepoint": 57481,
+			"name": "start"
+		},
+		{
+			"codepoint": 59031,
+			"name": "stat_0"
+		},
+		{
+			"codepoint": 59032,
+			"name": "stat_1"
+		},
+		{
+			"codepoint": 59033,
+			"name": "stat_2"
+		},
+		{
+			"codepoint": 59034,
+			"name": "stat_3"
+		},
+		{
+			"codepoint": 59035,
+			"name": "stat_minus_1"
+		},
+		{
+			"codepoint": 59036,
+			"name": "stat_minus_2"
+		},
+		{
+			"codepoint": 59037,
+			"name": "stat_minus_3"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_current_landscape"
+		},
+		{
+			"codepoint": 59322,
+			"name": "stay_current_portrait"
+		},
+		{
+			"codepoint": 60734,
+			"name": "stay_primary_landscape"
+		},
+		{
+			"codepoint": 62163,
+			"name": "stay_primary_portrait"
+		},
+		{
+			"codepoint": 62251,
+			"name": "steering_wheel_heat"
+		},
+		{
+			"codepoint": 63230,
+			"name": "step"
+		},
+		{
+			"codepoint": 63233,
+			"name": "step_into"
+		},
+		{
+			"codepoint": 63232,
+			"name": "step_out"
+		},
+		{
+			"codepoint": 63231,
+			"name": "step_over"
+		},
+		{
+			"codepoint": 59879,
+			"name": "steppers"
+		},
+		{
+			"codepoint": 63194,
+			"name": "steps"
+		},
+		{
+			"codepoint": 63493,
+			"name": "stethoscope"
+		},
+		{
+			"codepoint": 63495,
+			"name": "stethoscope_arrow"
+		},
+		{
+			"codepoint": 63494,
+			"name": "stethoscope_check"
+		},
+		{
+			"codepoint": 59143,
+			"name": "sticker"
+		},
+		{
+			"codepoint": 61122,
+			"name": "sticker_add"
+		},
+		{
+			"codepoint": 59880,
+			"name": "sticky_note"
+		},
+		{
+			"codepoint": 61948,
+			"name": "sticky_note_2"
+		},
+		{
+			"codepoint": 62832,
+			"name": "stock_media"
+		},
+		{
+			"codepoint": 62789,
+			"name": "stockpot"
+		},
+		{
+			"codepoint": 57415,
+			"name": "stop"
+		},
+		{
+			"codepoint": 61297,
+			"name": "stop_circle"
+		},
+		{
+			"codepoint": 57571,
+			"name": "stop_screen_share"
+		},
+		{
+			"codepoint": 57819,
+			"name": "storage"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store"
+		},
+		{
+			"codepoint": 59601,
+			"name": "store_mall_directory"
+		},
+		{
+			"codepoint": 59922,
+			"name": "storefront"
+		},
+		{
+			"codepoint": 61552,
+			"name": "storm"
+		},
+		{
+			"codepoint": 60309,
+			"name": "straight"
+		},
+		{
+			"codepoint": 58396,
+			"name": "straighten"
+		},
+		{
+			"codepoint": 62943,
+			"name": "strategy"
+		},
+		{
+			"codepoint": 59881,
+			"name": "stream"
+		},
+		{
+			"codepoint": 63391,
+			"name": "stream_apps"
+		},
+		{
+			"codepoint": 58734,
+			"name": "streetview"
+		},
+		{
+			"codepoint": 63193,
+			"name": "stress_management"
+		},
+		{
+			"codepoint": 57943,
+			"name": "strikethrough_s"
+		},
+		{
+			"codepoint": 63305,
+			"name": "stroke_full"
+		},
+		{
+			"codepoint": 63304,
+			"name": "stroke_partial"
+		},
+		{
+			"codepoint": 61870,
+			"name": "stroller"
+		},
+		{
+			"codepoint": 58397,
+			"name": "style"
+		},
+		{
+			"codepoint": 57971,
+			"name": "styler"
+		},
+		{
+			"codepoint": 62980,
+			"name": "stylus"
+		},
+		{
+			"codepoint": 62310,
+			"name": "stylus_brush"
+		},
+		{
+			"codepoint": 62309,
+			"name": "stylus_fountain_pen"
+		},
+		{
+			"codepoint": 62308,
+			"name": "stylus_highlighter"
+		},
+		{
+			"codepoint": 63303,
+			"name": "stylus_laser_pointer"
+		},
+		{
+			"codepoint": 62979,
+			"name": "stylus_note"
+		},
+		{
+			"codepoint": 62307,
+			"name": "stylus_pen"
+		},
+		{
+			"codepoint": 62306,
+			"name": "stylus_pencil"
+		},
+		{
+			"codepoint": 58841,
+			"name": "subdirectory_arrow_left"
+		},
+		{
+			"codepoint": 58842,
+			"name": "subdirectory_arrow_right"
+		},
+		{
+			"codepoint": 59882,
+			"name": "subheader"
+		},
+		{
+			"codepoint": 59602,
+			"name": "subject"
+		},
+		{
+			"codepoint": 61713,
+			"name": "subscript"
+		},
+		{
+			"codepoint": 57444,
+			"name": "subscriptions"
+		},
+		{
+			"codepoint": 57416,
+			"name": "subtitles"
+		},
+		{
+			"codepoint": 62293,
+			"name": "subtitles_gear"
+		},
+		{
+			"codepoint": 61298,
+			"name": "subtitles_off"
+		},
+		{
+			"codepoint": 58735,
+			"name": "subway"
+		},
+		{
+			"codepoint": 62087,
+			"name": "subway_walk"
+		},
+		{
+			"codepoint": 1048432,
+			"name": "subwoofer"
+		},
+		{
+			"codepoint": 61553,
+			"name": "summarize"
+		},
+		{
+			"codepoint": 59418,
+			"name": "sunny"
+		},
+		{
+			"codepoint": 59417,
+			"name": "sunny_snowing"
+		},
+		{
+			"codepoint": 61714,
+			"name": "superscript"
+		},
+		{
+			"codepoint": 59705,
+			"name": "supervised_user_circle"
+		},
+		{
+			"codepoint": 62990,
+			"name": "supervised_user_circle_off"
+		},
+		{
+			"codepoint": 59603,
+			"name": "supervisor_account"
+		},
+		{
+			"codepoint": 61299,
+			"name": "support"
+		},
+		{
+			"codepoint": 61666,
+			"name": "support_agent"
+		},
+		{
+			"codepoint": 58645,
+			"name": "surfing"
+		},
+		{
+			"codepoint": 57649,
+			"name": "surgical"
+		},
+		{
+			"codepoint": 57417,
+			"name": "surround_sound"
+		},
+		{
+			"codepoint": 57559,
+			"name": "swap_calls"
+		},
+		{
+			"codepoint": 59038,
+			"name": "swap_driving_apps"
+		},
+		{
+			"codepoint": 59039,
+			"name": "swap_driving_apps_wheel"
+		},
+		{
+			"codepoint": 59604,
+			"name": "swap_horiz"
+		},
+		{
+			"codepoint": 59699,
+			"name": "swap_horizontal_circle"
+		},
+		{
+			"codepoint": 59605,
+			"name": "swap_vert"
+		},
+		{
+			"codepoint": 59606,
+			"name": "swap_vertical_circle"
+		},
+		{
+			"codepoint": 59052,
+			"name": "sweep"
+		},
+		{
+			"codepoint": 59884,
+			"name": "swipe"
+		},
+		{
+			"codepoint": 60243,
+			"name": "swipe_down"
+		},
+		{
+			"codepoint": 60208,
+			"name": "swipe_down_alt"
+		},
+		{
+			"codepoint": 60249,
+			"name": "swipe_left"
+		},
+		{
+			"codepoint": 1048468,
+			"name": "swipe_left_2"
+		},
+		{
+			"codepoint": 60211,
+			"name": "swipe_left_alt"
+		},
+		{
+			"codepoint": 60242,
+			"name": "swipe_right"
+		},
+		{
+			"codepoint": 1048467,
+			"name": "swipe_right_2"
+		},
+		{
+			"codepoint": 60246,
+			"name": "swipe_right_alt"
+		},
+		{
+			"codepoint": 60206,
+			"name": "swipe_up"
+		},
+		{
+			"codepoint": 60213,
+			"name": "swipe_up_alt"
+		},
+		{
+			"codepoint": 60241,
+			"name": "swipe_vertical"
+		},
+		{
+			"codepoint": 57844,
+			"name": "switch"
+		},
+		{
+			"codepoint": 63229,
+			"name": "switch_access"
+		},
+		{
+			"codepoint": 62726,
+			"name": "switch_access_2"
+		},
+		{
+			"codepoint": 62285,
+			"name": "switch_access_3"
+		},
+		{
+			"codepoint": 59361,
+			"name": "switch_access_shortcut"
+		},
+		{
+			"codepoint": 59362,
+			"name": "switch_access_shortcut_add"
+		},
+		{
+			"codepoint": 59885,
+			"name": "switch_account"
+		},
+		{
+			"codepoint": 58398,
+			"name": "switch_camera"
+		},
+		{
+			"codepoint": 61905,
+			"name": "switch_left"
+		},
+		{
+			"codepoint": 1048431,
+			"name": "switch_off"
+		},
+		{
+			"codepoint": 61906,
+			"name": "switch_right"
+		},
+		{
+			"codepoint": 58399,
+			"name": "switch_video"
+		},
+		{
+			"codepoint": 59187,
+			"name": "switches"
+		},
+		{
+			"codepoint": 62942,
+			"name": "sword_rose"
+		},
+		{
+			"codepoint": 63625,
+			"name": "swords"
+		},
+		{
+			"codepoint": 57650,
+			"name": "symptoms"
+		},
+		{
+			"codepoint": 60080,
+			"name": "synagogue"
+		},
+		{
+			"codepoint": 58919,
+			"name": "sync"
+		},
+		{
+			"codepoint": 59928,
+			"name": "sync_alt"
+		},
+		{
+			"codepoint": 62332,
+			"name": "sync_arrow_down"
+		},
+		{
+			"codepoint": 62331,
+			"name": "sync_arrow_up"
+		},
+		{
+			"codepoint": 62490,
+			"name": "sync_desktop"
+		},
+		{
+			"codepoint": 58920,
+			"name": "sync_disabled"
+		},
+		{
+			"codepoint": 60142,
+			"name": "sync_lock"
+		},
+		{
+			"codepoint": 58921,
+			"name": "sync_problem"
+		},
+		{
+			"codepoint": 63520,
+			"name": "sync_saved_locally"
+		},
+		{
+			"codepoint": 62052,
+			"name": "sync_saved_locally_off"
+		},
+		{
+			"codepoint": 57651,
+			"name": "syringe"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_security_update"
+		},
+		{
+			"codepoint": 61555,
+			"name": "system_security_update_good"
+		},
+		{
+			"codepoint": 62163,
+			"name": "system_security_update_warning"
+		},
+		{
+			"codepoint": 62157,
+			"name": "system_update"
+		},
+		{
+			"codepoint": 59607,
+			"name": "system_update_alt"
+		},
+		{
+			"codepoint": 59608,
+			"name": "tab"
+		},
+		{
+			"codepoint": 63301,
+			"name": "tab_close"
+		},
+		{
+			"codepoint": 62416,
+			"name": "tab_close_inactive"
+		},
+		{
+			"codepoint": 63302,
+			"name": "tab_close_right"
+		},
+		{
+			"codepoint": 63300,
+			"name": "tab_duplicate"
+		},
+		{
+			"codepoint": 63299,
+			"name": "tab_group"
+		},
+		{
+			"codepoint": 62523,
+			"name": "tab_inactive"
+		},
+		{
+			"codepoint": 63298,
+			"name": "tab_move"
+		},
+		{
+			"codepoint": 63297,
+			"name": "tab_new_right"
+		},
+		{
+			"codepoint": 63296,
+			"name": "tab_recent"
+		},
+		{
+			"codepoint": 62194,
+			"name": "tab_search"
+		},
+		{
+			"codepoint": 59609,
+			"name": "tab_unselected"
+		},
+		{
+			"codepoint": 61841,
+			"name": "table"
+		},
+		{
+			"codepoint": 60114,
+			"name": "table_bar"
+		},
+		{
+			"codepoint": 57957,
+			"name": "table_chart"
+		},
+		{
+			"codepoint": 63215,
+			"name": "table_chart_view"
+		},
+		{
+			"codepoint": 62407,
+			"name": "table_convert"
+		},
+		{
+			"codepoint": 62406,
+			"name": "table_edit"
+		},
+		{
+			"codepoint": 62566,
+			"name": "table_eye"
+		},
+		{
+			"codepoint": 57842,
+			"name": "table_lamp"
+		},
+		{
+			"codepoint": 62105,
+			"name": "table_large"
+		},
+		{
+			"codepoint": 60102,
+			"name": "table_restaurant"
+		},
+		{
+			"codepoint": 61697,
+			"name": "table_rows"
+		},
+		{
+			"codepoint": 63295,
+			"name": "table_rows_narrow"
+		},
+		{
+			"codepoint": 61228,
+			"name": "table_sign"
+		},
+		{
+			"codepoint": 61886,
+			"name": "table_view"
+		},
+		{
+			"codepoint": 58159,
+			"name": "tablet"
+		},
+		{
+			"codepoint": 58160,
+			"name": "tablet_android"
+		},
+		{
+			"codepoint": 62541,
+			"name": "tablet_camera"
+		},
+		{
+			"codepoint": 58161,
+			"name": "tablet_mac"
+		},
+		{
+			"codepoint": 59886,
+			"name": "tabs"
+		},
+		{
+			"codepoint": 62820,
+			"name": "tactic"
+		},
+		{
+			"codepoint": 59887,
+			"name": "tag"
+		},
+		{
+			"codepoint": 59938,
+			"name": "tag_faces"
+		},
+		{
+			"codepoint": 60020,
+			"name": "takeout_dining"
+		},
+		{
+			"codepoint": 61236,
+			"name": "takeout_dining_2"
+		},
+		{
+			"codepoint": 59438,
+			"name": "tamper_detection_off"
+		},
+		{
+			"codepoint": 63688,
+			"name": "tamper_detection_on"
+		},
+		{
+			"codepoint": 62156,
+			"name": "tap_and_play"
+		},
+		{
+			"codepoint": 61929,
+			"name": "tapas"
+		},
+		{
+			"codepoint": 59161,
+			"name": "target"
+		},
+		{
+			"codepoint": 61557,
+			"name": "task"
+		},
+		{
+			"codepoint": 58086,
+			"name": "task_alt"
+		},
+		{
+			"codepoint": 61235,
+			"name": "tatami_seat"
+		},
+		{
+			"codepoint": 63135,
+			"name": "taunt"
+		},
+		{
+			"codepoint": 61300,
+			"name": "taxi_alert"
+		},
+		{
+			"codepoint": 57363,
+			"name": "team_dashboard"
+		},
+		{
+			"codepoint": 63689,
+			"name": "temp_preferences_custom"
+		},
+		{
+			"codepoint": 63690,
+			"name": "temp_preferences_eco"
+		},
+		{
+			"codepoint": 60083,
+			"name": "temple_buddhist"
+		},
+		{
+			"codepoint": 60079,
+			"name": "temple_hindu"
+		},
+		{
+			"codepoint": 61667,
+			"name": "tenancy"
+		},
+		{
+			"codepoint": 60302,
+			"name": "terminal"
+		},
+		{
+			"codepoint": 1048462,
+			"name": "terminal_2"
+		},
+		{
+			"codepoint": 58724,
+			"name": "terrain"
+		},
+		{
+			"codepoint": 59176,
+			"name": "text_ad"
+		},
+		{
+			"codepoint": 1048466,
+			"name": "text_ad_off"
+		},
+		{
+			"codepoint": 62405,
+			"name": "text_compare"
+		},
+		{
+			"codepoint": 60125,
+			"name": "text_decrease"
+		},
+		{
+			"codepoint": 57954,
+			"name": "text_fields"
+		},
+		{
+			"codepoint": 59889,
+			"name": "text_fields_alt"
+		},
+		{
+			"codepoint": 57701,
+			"name": "text_format"
+		},
+		{
+			"codepoint": 60130,
+			"name": "text_increase"
+		},
+		{
+			"codepoint": 59706,
+			"name": "text_rotate_up"
+		},
+		{
+			"codepoint": 59707,
+			"name": "text_rotate_vertical"
+		},
+		{
+			"codepoint": 59708,
+			"name": "text_rotation_angledown"
+		},
+		{
+			"codepoint": 59709,
+			"name": "text_rotation_angleup"
+		},
+		{
+			"codepoint": 59710,
+			"name": "text_rotation_down"
+		},
+		{
+			"codepoint": 59711,
+			"name": "text_rotation_none"
+		},
+		{
+			"codepoint": 63294,
+			"name": "text_select_end"
+		},
+		{
+			"codepoint": 63293,
+			"name": "text_select_jump_to_beginning"
+		},
+		{
+			"codepoint": 63292,
+			"name": "text_select_jump_to_end"
+		},
+		{
+			"codepoint": 63291,
+			"name": "text_select_move_back_character"
+		},
+		{
+			"codepoint": 63290,
+			"name": "text_select_move_back_word"
+		},
+		{
+			"codepoint": 63289,
+			"name": "text_select_move_down"
+		},
+		{
+			"codepoint": 63288,
+			"name": "text_select_move_forward_character"
+		},
+		{
+			"codepoint": 63287,
+			"name": "text_select_move_forward_word"
+		},
+		{
+			"codepoint": 63286,
+			"name": "text_select_move_up"
+		},
+		{
+			"codepoint": 63285,
+			"name": "text_select_start"
+		},
+		{
+			"codepoint": 61894,
+			"name": "text_snippet"
+		},
+		{
+			"codepoint": 61884,
+			"name": "text_to_speech"
+		},
+		{
+			"codepoint": 62622,
+			"name": "text_up"
+		},
+		{
+			"codepoint": 58917,
+			"name": "textsms"
+		},
+		{
+			"codepoint": 58401,
+			"name": "texture"
+		},
+		{
+			"codepoint": 62844,
+			"name": "texture_add"
+		},
+		{
+			"codepoint": 62843,
+			"name": "texture_minus"
+		},
+		{
+			"codepoint": 60006,
+			"name": "theater_comedy"
+		},
+		{
+			"codepoint": 59610,
+			"name": "theaters"
+		},
+		{
+			"codepoint": 59462,
+			"name": "thermometer"
+		},
+		{
+			"codepoint": 62850,
+			"name": "thermometer_add"
+		},
+		{
+			"codepoint": 1048571,
+			"name": "thermometer_alert"
+		},
+		{
+			"codepoint": 63192,
+			"name": "thermometer_gain"
+		},
+		{
+			"codepoint": 63191,
+			"name": "thermometer_loss"
+		},
+		{
+			"codepoint": 62849,
+			"name": "thermometer_minus"
+		},
+		{
+			"codepoint": 61558,
+			"name": "thermostat"
+		},
+		{
+			"codepoint": 62330,
+			"name": "thermostat_arrow_down"
+		},
+		{
+			"codepoint": 62329,
+			"name": "thermostat_arrow_up"
+		},
+		{
+			"codepoint": 61559,
+			"name": "thermostat_auto"
+		},
+		{
+			"codepoint": 61816,
+			"name": "thermostat_carbon"
+		},
+		{
+			"codepoint": 60202,
+			"name": "things_to_do"
+		},
+		{
+			"codepoint": 62713,
+			"name": "thread_unread"
+		},
+		{
+			"codepoint": 60141,
+			"name": "threat_intelligence"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_alt"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_filled"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off"
+		},
+		{
+			"codepoint": 62840,
+			"name": "thumb_down_off_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_alt"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_filled"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off"
+		},
+		{
+			"codepoint": 62839,
+			"name": "thumb_up_off_alt"
+		},
+		{
+			"codepoint": 63284,
+			"name": "thumbnail_bar"
+		},
+		{
+			"codepoint": 61180,
+			"name": "thumbs_up_double"
+		},
+		{
+			"codepoint": 59613,
+			"name": "thumbs_up_down"
+		},
+		{
+			"codepoint": 60379,
+			"name": "thunderstorm"
+		},
+		{
+			"codepoint": 63643,
+			"name": "tibia"
+		},
+		{
+			"codepoint": 63644,
+			"name": "tibia_alt"
+		},
+		{
+			"codepoint": 62403,
+			"name": "tile_large"
+		},
+		{
+			"codepoint": 62402,
+			"name": "tile_medium"
+		},
+		{
+			"codepoint": 62401,
+			"name": "tile_small"
+		},
+		{
+			"codepoint": 1048358,
+			"name": "tilt_arrow_down"
+		},
+		{
+			"codepoint": 1048357,
+			"name": "tilt_arrow_up"
+		},
+		{
+			"codepoint": 61668,
+			"name": "time_auto"
+		},
+		{
+			"codepoint": 61431,
+			"name": "time_to_leave"
+		},
+		{
+			"codepoint": 58402,
+			"name": "timelapse"
+		},
+		{
+			"codepoint": 59682,
+			"name": "timeline"
+		},
+		{
+			"codepoint": 58405,
+			"name": "timer"
+		},
+		{
+			"codepoint": 62127,
+			"name": "timer_1"
+		},
+		{
+			"codepoint": 58403,
+			"name": "timer_10"
+		},
+		{
+			"codepoint": 61375,
+			"name": "timer_10_alt_1"
+		},
+		{
+			"codepoint": 61562,
+			"name": "timer_10_select"
+		},
+		{
+			"codepoint": 62126,
+			"name": "timer_2"
+		},
+		{
+			"codepoint": 58404,
+			"name": "timer_3"
+		},
+		{
+			"codepoint": 61376,
+			"name": "timer_3_alt_1"
+		},
+		{
+			"codepoint": 61563,
+			"name": "timer_3_select"
+		},
+		{
+			"codepoint": 62641,
+			"name": "timer_5"
+		},
+		{
+			"codepoint": 62642,
+			"name": "timer_5_shutter"
+		},
+		{
+			"codepoint": 62328,
+			"name": "timer_arrow_down"
+		},
+		{
+			"codepoint": 62327,
+			"name": "timer_arrow_up"
+		},
+		{
+			"codepoint": 58406,
+			"name": "timer_off"
+		},
+		{
+			"codepoint": 62651,
+			"name": "timer_pause"
+		},
+		{
+			"codepoint": 62650,
+			"name": "timer_play"
+		},
+		{
+			"codepoint": 59290,
+			"name": "tips_and_updates"
+		},
+		{
+			"codepoint": 60360,
+			"name": "tire_repair"
+		},
+		{
+			"codepoint": 57956,
+			"name": "title"
+		},
+		{
+			"codepoint": 62601,
+			"name": "titlecase"
+		},
+		{
+			"codepoint": 61377,
+			"name": "toast"
+		},
+		{
+			"codepoint": 59614,
+			"name": "toc"
+		},
+		{
+			"codepoint": 59615,
+			"name": "today"
+		},
+		{
+			"codepoint": 59893,
+			"name": "toggle_off"
+		},
+		{
+			"codepoint": 59894,
+			"name": "toggle_on"
+		},
+		{
+			"codepoint": 59941,
+			"name": "token"
+		},
+		{
+			"codepoint": 59616,
+			"name": "toll"
+		},
+		{
+			"codepoint": 58407,
+			"name": "tonality"
+		},
+		{
+			"codepoint": 62132,
+			"name": "tonality_2"
+		},
+		{
+			"codepoint": 59895,
+			"name": "toolbar"
+		},
+		{
+			"codepoint": 63691,
+			"name": "tools_flat_head"
+		},
+		{
+			"codepoint": 58027,
+			"name": "tools_installation_kit"
+		},
+		{
+			"codepoint": 58059,
+			"name": "tools_ladder"
+		},
+		{
+			"codepoint": 59259,
+			"name": "tools_level"
+		},
+		{
+			"codepoint": 63692,
+			"name": "tools_phillips"
+		},
+		{
+			"codepoint": 58026,
+			"name": "tools_pliers_wire_stripper"
+		},
+		{
+			"codepoint": 57833,
+			"name": "tools_power_drill"
+		},
+		{
+			"codepoint": 63693,
+			"name": "tools_wrench"
+		},
+		{
+			"codepoint": 59896,
+			"name": "tooltip"
+		},
+		{
+			"codepoint": 62445,
+			"name": "tooltip_2"
+		},
+		{
+			"codepoint": 63283,
+			"name": "top_panel_close"
+		},
+		{
+			"codepoint": 63282,
+			"name": "top_panel_open"
+		},
+		{
+			"codepoint": 61896,
+			"name": "topic"
+		},
+		{
+			"codepoint": 57753,
+			"name": "tornado"
+		},
+		{
+			"codepoint": 63607,
+			"name": "total_dissolved_solids"
+		},
+		{
+			"codepoint": 59667,
+			"name": "touch_app"
+		},
+		{
+			"codepoint": 62347,
+			"name": "touch_double"
+		},
+		{
+			"codepoint": 1048373,
+			"name": "touch_double_2"
+		},
+		{
+			"codepoint": 62346,
+			"name": "touch_long"
+		},
+		{
+			"codepoint": 62345,
+			"name": "touch_triple"
+		},
+		{
+			"codepoint": 63111,
+			"name": "touchpad_mouse"
+		},
+		{
+			"codepoint": 62694,
+			"name": "touchpad_mouse_off"
+		},
+		{
+			"codepoint": 61301,
+			"name": "tour"
+		},
+		{
+			"codepoint": 58162,
+			"name": "toys"
+		},
+		{
+			"codepoint": 61378,
+			"name": "toys_and_games"
+		},
+		{
+			"codepoint": 63623,
+			"name": "toys_fan"
+		},
+		{
+			"codepoint": 59617,
+			"name": "track_changes"
+		},
+		{
+			"codepoint": 62663,
+			"name": "trackpad_input"
+		},
+		{
+			"codepoint": 62473,
+			"name": "trackpad_input_2"
+		},
+		{
+			"codepoint": 62472,
+			"name": "trackpad_input_3"
+		},
+		{
+			"codepoint": 58725,
+			"name": "traffic"
+		},
+		{
+			"codepoint": 62575,
+			"name": "traffic_jam"
+		},
+		{
+			"codepoint": 60254,
+			"name": "trail_length"
+		},
+		{
+			"codepoint": 60259,
+			"name": "trail_length_medium"
+		},
+		{
+			"codepoint": 60269,
+			"name": "trail_length_short"
+		},
+		{
+			"codepoint": 58736,
+			"name": "train"
+		},
+		{
+			"codepoint": 58737,
+			"name": "tram"
+		},
+		{
+			"codepoint": 63724,
+			"name": "transcribe"
+		},
+		{
+			"codepoint": 58738,
+			"name": "transfer_within_a_station"
+		},
+		{
+			"codepoint": 58408,
+			"name": "transform"
+		},
+		{
+			"codepoint": 58765,
+			"name": "transgender"
+		},
+		{
+			"codepoint": 58745,
+			"name": "transit_enterexit"
+		},
+		{
+			"codepoint": 62449,
+			"name": "transit_ticket"
+		},
+		{
+			"codepoint": 62734,
+			"name": "transition_chop"
+		},
+		{
+			"codepoint": 62733,
+			"name": "transition_dissolve"
+		},
+		{
+			"codepoint": 62732,
+			"name": "transition_fade"
+		},
+		{
+			"codepoint": 62731,
+			"name": "transition_push"
+		},
+		{
+			"codepoint": 62730,
+			"name": "transition_slide"
+		},
+		{
+			"codepoint": 59618,
+			"name": "translate"
+		},
+		{
+			"codepoint": 62051,
+			"name": "translate_indic"
+		},
+		{
+			"codepoint": 57885,
+			"name": "transportation"
+		},
+		{
+			"codepoint": 61331,
+			"name": "travel"
+		},
+		{
+			"codepoint": 58075,
+			"name": "travel_explore"
+		},
+		{
+			"codepoint": 61379,
+			"name": "travel_luggage_and_bags"
+		},
+		{
+			"codepoint": 59619,
+			"name": "trending_down"
+		},
+		{
+			"codepoint": 59620,
+			"name": "trending_flat"
+		},
+		{
+			"codepoint": 59621,
+			"name": "trending_up"
+		},
+		{
+			"codepoint": 61126,
+			"name": "triangle_circle"
+		},
+		{
+			"codepoint": 59131,
+			"name": "trip"
+		},
+		{
+			"codepoint": 58747,
+			"name": "trip_origin"
+		},
+		{
+			"codepoint": 63595,
+			"name": "trolley"
+		},
+		{
+			"codepoint": 62574,
+			"name": "trolley_cable_car"
+		},
+		{
+			"codepoint": 59939,
+			"name": "trophy"
+		},
+		{
+			"codepoint": 57810,
+			"name": "troubleshoot"
+		},
+		{
+			"codepoint": 61564,
+			"name": "try"
+		},
+		{
+			"codepoint": 60376,
+			"name": "tsunami"
+		},
+		{
+			"codepoint": 59094,
+			"name": "tsv"
+		},
+		{
+			"codepoint": 61866,
+			"name": "tty"
+		},
+		{
+			"codepoint": 58409,
+			"name": "tune"
+		},
+		{
+			"codepoint": 61565,
+			"name": "tungsten"
+		},
+		{
+			"codepoint": 60326,
+			"name": "turn_left"
+		},
+		{
+			"codepoint": 60331,
+			"name": "turn_right"
+		},
+		{
+			"codepoint": 60327,
+			"name": "turn_sharp_left"
+		},
+		{
+			"codepoint": 60330,
+			"name": "turn_sharp_right"
+		},
+		{
+			"codepoint": 60324,
+			"name": "turn_slight_left"
+		},
+		{
+			"codepoint": 60314,
+			"name": "turn_slight_right"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in"
+		},
+		{
+			"codepoint": 59623,
+			"name": "turned_in_not"
+		},
+		{
+			"codepoint": 58939,
+			"name": "tv"
+		},
+		{
+			"codepoint": 62444,
+			"name": "tv_displays"
+		},
+		{
+			"codepoint": 59440,
+			"name": "tv_gen"
+		},
+		{
+			"codepoint": 57820,
+			"name": "tv_guide"
+		},
+		{
+			"codepoint": 62443,
+			"name": "tv_next"
+		},
+		{
+			"codepoint": 58951,
+			"name": "tv_off"
+		},
+		{
+			"codepoint": 57821,
+			"name": "tv_options_edit_channels"
+		},
+		{
+			"codepoint": 57822,
+			"name": "tv_options_input_settings"
+		},
+		{
+			"codepoint": 62937,
+			"name": "tv_remote"
+		},
+		{
+			"codepoint": 59163,
+			"name": "tv_signin"
+		},
+		{
+			"codepoint": 59269,
+			"name": "tv_with_assistant"
+		},
+		{
+			"codepoint": 62751,
+			"name": "two_pager"
+		},
+		{
+			"codepoint": 62404,
+			"name": "two_pager_store"
+		},
+		{
+			"codepoint": 59897,
+			"name": "two_wheeler"
+		},
+		{
+			"codepoint": 63728,
+			"name": "type_specimen"
+		},
+		{
+			"codepoint": 60321,
+			"name": "u_turn_left"
+		},
+		{
+			"codepoint": 60322,
+			"name": "u_turn_right"
+		},
+		{
+			"codepoint": 61234,
+			"name": "udon"
+		},
+		{
+			"codepoint": 63645,
+			"name": "ulna_radius"
+		},
+		{
+			"codepoint": 63646,
+			"name": "ulna_radius_alt"
+		},
+		{
+			"codepoint": 61869,
+			"name": "umbrella"
+		},
+		{
+			"codepoint": 57705,
+			"name": "unarchive"
+		},
+		{
+			"codepoint": 61105,
+			"name": "undereye"
+		},
+		{
+			"codepoint": 57702,
+			"name": "undo"
+		},
+		{
+			"codepoint": 58838,
+			"name": "unfold_less"
+		},
+		{
+			"codepoint": 63695,
+			"name": "unfold_less_double"
+		},
+		{
+			"codepoint": 58839,
+			"name": "unfold_more"
+		},
+		{
+			"codepoint": 63696,
+			"name": "unfold_more_double"
+		},
+		{
+			"codepoint": 63281,
+			"name": "ungroup"
+		},
+		{
+			"codepoint": 59898,
+			"name": "universal_currency"
+		},
+		{
+			"codepoint": 59188,
+			"name": "universal_currency_alt"
+		},
+		{
+			"codepoint": 59899,
+			"name": "universal_local"
+		},
+		{
+			"codepoint": 62623,
+			"name": "unknown_2"
+		},
+		{
+			"codepoint": 59045,
+			"name": "unknown_5"
+		},
+		{
+			"codepoint": 62622,
+			"name": "unknown_7"
+		},
+		{
+			"codepoint": 63492,
+			"name": "unknown_document"
+		},
+		{
+			"codepoint": 60093,
+			"name": "unknown_med"
+		},
+		{
+			"codepoint": 60165,
+			"name": "unlicense"
+		},
+		{
+			"codepoint": 62573,
+			"name": "unpaved_road"
+		},
+		{
+			"codepoint": 59129,
+			"name": "unpin"
+		},
+		{
+			"codepoint": 62006,
+			"name": "unpublished"
+		},
+		{
+			"codepoint": 57579,
+			"name": "unsubscribe"
+		},
+		{
+			"codepoint": 61566,
+			"name": "upcoming"
+		},
+		{
+			"codepoint": 59683,
+			"name": "update"
+		},
+		{
+			"codepoint": 57461,
+			"name": "update_disabled"
+		},
+		{
+			"codepoint": 61691,
+			"name": "upgrade"
+		},
+		{
+			"codepoint": 62415,
+			"name": "upi_pay"
+		},
+		{
+			"codepoint": 61595,
+			"name": "upload"
+		},
+		{
+			"codepoint": 62753,
+			"name": "upload_2"
+		},
+		{
+			"codepoint": 59900,
+			"name": "upload_file"
+		},
+		{
+			"codepoint": 62600,
+			"name": "uppercase"
+		},
+		{
+			"codepoint": 57655,
+			"name": "urology"
+		},
+		{
+			"codepoint": 57824,
+			"name": "usb"
+		},
+		{
+			"codepoint": 58618,
+			"name": "usb_off"
+		},
+		{
+			"codepoint": 59144,
+			"name": "user_attributes"
+		},
+		{
+			"codepoint": 57656,
+			"name": "vaccines"
+		},
+		{
+			"codepoint": 61381,
+			"name": "vacuum"
+		},
+		{
+			"codepoint": 1048429,
+			"name": "vacuum_2"
+		},
+		{
+			"codepoint": 1048430,
+			"name": "vacuum_2_on"
+		},
+		{
+			"codepoint": 57892,
+			"name": "valve"
+		},
+		{
+			"codepoint": 60358,
+			"name": "vape_free"
+		},
+		{
+			"codepoint": 60367,
+			"name": "vaping_rooms"
+		},
+		{
+			"codepoint": 62750,
+			"name": "variable_add"
+		},
+		{
+			"codepoint": 62749,
+			"name": "variable_insert"
+		},
+		{
+			"codepoint": 62748,
+			"name": "variable_remove"
+		},
+		{
+			"codepoint": 63569,
+			"name": "variables"
+		},
+		{
+			"codepoint": 57657,
+			"name": "ventilator"
+		},
+		{
+			"codepoint": 61302,
+			"name": "verified"
+		},
+		{
+			"codepoint": 62222,
+			"name": "verified_off"
+		},
+		{
+			"codepoint": 61459,
+			"name": "verified_user"
+		},
+		{
+			"codepoint": 57944,
+			"name": "vertical_align_bottom"
+		},
+		{
+			"codepoint": 57945,
+			"name": "vertical_align_center"
+		},
+		{
+			"codepoint": 57946,
+			"name": "vertical_align_top"
+		},
+		{
+			"codepoint": 57462,
+			"name": "vertical_distribute"
+		},
+		{
+			"codepoint": 60430,
+			"name": "vertical_shades"
+		},
+		{
+			"codepoint": 60429,
+			"name": "vertical_shades_closed"
+		},
+		{
+			"codepoint": 59721,
+			"name": "vertical_split"
+		},
+		{
+			"codepoint": 62155,
+			"name": "vibration"
+		},
+		{
+			"codepoint": 57456,
+			"name": "video_call"
+		},
+		{
+			"codepoint": 61567,
+			"name": "video_camera_back"
+		},
+		{
+			"codepoint": 62476,
+			"name": "video_camera_back_add"
+		},
+		{
+			"codepoint": 61568,
+			"name": "video_camera_front"
+		},
+		{
+			"codepoint": 63547,
+			"name": "video_camera_front_off"
+		},
+		{
+			"codepoint": 63648,
+			"name": "video_chat"
+		},
+		{
+			"codepoint": 60295,
+			"name": "video_file"
+		},
+		{
+			"codepoint": 1048333,
+			"name": "video_frame_copy"
+		},
+		{
+			"codepoint": 1048332,
+			"name": "video_frame_save"
+		},
+		{
+			"codepoint": 57457,
+			"name": "video_label"
+		},
+		{
+			"codepoint": 57418,
+			"name": "video_library"
+		},
+		{
+			"codepoint": 61382,
+			"name": "video_search"
+		},
+		{
+			"codepoint": 60021,
+			"name": "video_settings"
+		},
+		{
+			"codepoint": 61569,
+			"name": "video_stable"
+		},
+		{
+			"codepoint": 1048531,
+			"name": "video_template"
+		},
+		{
+			"codepoint": 57419,
+			"name": "videocam"
+		},
+		{
+			"codepoint": 62352,
+			"name": "videocam_alert"
+		},
+		{
+			"codepoint": 57420,
+			"name": "videocam_off"
+		},
+		{
+			"codepoint": 58168,
+			"name": "videogame_asset"
+		},
+		{
+			"codepoint": 58624,
+			"name": "videogame_asset_off"
+		},
+		{
+			"codepoint": 59625,
+			"name": "view_agenda"
+		},
+		{
+			"codepoint": 62326,
+			"name": "view_apps"
+		},
+		{
+			"codepoint": 59626,
+			"name": "view_array"
+		},
+		{
+			"codepoint": 59627,
+			"name": "view_carousel"
+		},
+		{
+			"codepoint": 59628,
+			"name": "view_column"
+		},
+		{
+			"codepoint": 63559,
+			"name": "view_column_2"
+		},
+		{
+			"codepoint": 58410,
+			"name": "view_comfy"
+		},
+		{
+			"codepoint": 60275,
+			"name": "view_comfy_alt"
+		},
+		{
+			"codepoint": 58411,
+			"name": "view_compact"
+		},
+		{
+			"codepoint": 60276,
+			"name": "view_compact_alt"
+		},
+		{
+			"codepoint": 60277,
+			"name": "view_cozy"
+		},
+		{
+			"codepoint": 59629,
+			"name": "view_day"
+		},
+		{
+			"codepoint": 59630,
+			"name": "view_headline"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar"
+		},
+		{
+			"codepoint": 61385,
+			"name": "view_in_ar_new"
+		},
+		{
+			"codepoint": 63003,
+			"name": "view_in_ar_off"
+		},
+		{
+			"codepoint": 60287,
+			"name": "view_kanban"
+		},
+		{
+			"codepoint": 59631,
+			"name": "view_list"
+		},
+		{
+			"codepoint": 59632,
+			"name": "view_module"
+		},
+		{
+			"codepoint": 62514,
+			"name": "view_object_track"
+		},
+		{
+			"codepoint": 59633,
+			"name": "view_quilt"
+		},
+		{
+			"codepoint": 62658,
+			"name": "view_real_size"
+		},
+		{
+			"codepoint": 61716,
+			"name": "view_sidebar"
+		},
+		{
+			"codepoint": 59634,
+			"name": "view_stream"
+		},
+		{
+			"codepoint": 60293,
+			"name": "view_timeline"
+		},
+		{
+			"codepoint": 59635,
+			"name": "view_week"
+		},
+		{
+			"codepoint": 58421,
+			"name": "vignette"
+		},
+		{
+			"codepoint": 62131,
+			"name": "vignette_2"
+		},
+		{
+			"codepoint": 58758,
+			"name": "villa"
+		},
+		{
+			"codepoint": 59636,
+			"name": "visibility"
+		},
+		{
+			"codepoint": 63059,
+			"name": "visibility_lock"
+		},
+		{
+			"codepoint": 59637,
+			"name": "visibility_off"
+		},
+		{
+			"codepoint": 58960,
+			"name": "vital_signs"
+		},
+		{
+			"codepoint": 57659,
+			"name": "vitals"
+		},
+		{
+			"codepoint": 62634,
+			"name": "vo2_max"
+		},
+		{
+			"codepoint": 58926,
+			"name": "voice_chat"
+		},
+		{
+			"codepoint": 61118,
+			"name": "voice_chat_off"
+		},
+		{
+			"codepoint": 59722,
+			"name": "voice_over_off"
+		},
+		{
+			"codepoint": 62858,
+			"name": "voice_selection"
+		},
+		{
+			"codepoint": 62508,
+			"name": "voice_selection_off"
+		},
+		{
+			"codepoint": 57561,
+			"name": "voicemail"
+		},
+		{
+			"codepoint": 62290,
+			"name": "voicemail_2"
+		},
+		{
+			"codepoint": 60378,
+			"name": "volcano"
+		},
+		{
+			"codepoint": 57421,
+			"name": "volume_down"
+		},
+		{
+			"codepoint": 59292,
+			"name": "volume_down_alt"
+		},
+		{
+			"codepoint": 57422,
+			"name": "volume_mute"
+		},
+		{
+			"codepoint": 57423,
+			"name": "volume_off"
+		},
+		{
+			"codepoint": 57424,
+			"name": "volume_up"
+		},
+		{
+			"codepoint": 60016,
+			"name": "volunteer_activism"
+		},
+		{
+			"codepoint": 63570,
+			"name": "voting_chip"
+		},
+		{
+			"codepoint": 57562,
+			"name": "vpn_key"
+		},
+		{
+			"codepoint": 63180,
+			"name": "vpn_key_alert"
+		},
+		{
+			"codepoint": 60282,
+			"name": "vpn_key_off"
+		},
+		{
+			"codepoint": 58927,
+			"name": "vpn_lock"
+		},
+		{
+			"codepoint": 62288,
+			"name": "vpn_lock_2"
+		},
+		{
+			"codepoint": 61386,
+			"name": "vr180_create2d"
+		},
+		{
+			"codepoint": 62833,
+			"name": "vr180_create2d_off"
+		},
+		{
+			"codepoint": 61570,
+			"name": "vrpano"
+		},
+		{
+			"codepoint": 1048321,
+			"name": "walk_bike"
+		},
+		{
+			"codepoint": 61387,
+			"name": "wall_art"
+		},
+		{
+			"codepoint": 58036,
+			"name": "wall_lamp"
+		},
+		{
+			"codepoint": 63743,
+			"name": "wallet"
+		},
+		{
+			"codepoint": 57788,
+			"name": "wallpaper"
+		},
+		{
+			"codepoint": 63090,
+			"name": "wallpaper_slideshow"
+		},
+		{
+			"codepoint": 62239,
+			"name": "wand_shine"
+		},
+		{
+			"codepoint": 62238,
+			"name": "wand_stars"
+		},
+		{
+			"codepoint": 57660,
+			"name": "ward"
+		},
+		{
+			"codepoint": 60344,
+			"name": "warehouse"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning"
+		},
+		{
+			"codepoint": 61571,
+			"name": "warning_amber"
+		},
+		{
+			"codepoint": 63405,
+			"name": "warning_off"
+		},
+		{
+			"codepoint": 61873,
+			"name": "wash"
+		},
+		{
+			"codepoint": 62080,
+			"name": "washoku"
+		},
+		{
+			"codepoint": 58164,
+			"name": "watch"
+		},
+		{
+			"codepoint": 1048529,
+			"name": "watch_alert"
+		},
+		{
+			"codepoint": 62154,
+			"name": "watch_arrow"
+		},
+		{
+			"codepoint": 1048527,
+			"name": "watch_arrow_down"
+		},
+		{
+			"codepoint": 1048352,
+			"name": "watch_button"
+		},
+		{
+			"codepoint": 63146,
+			"name": "watch_button_press"
+		},
+		{
+			"codepoint": 62568,
+			"name": "watch_check"
+		},
+		{
+			"codepoint": 61398,
+			"name": "watch_later"
+		},
+		{
+			"codepoint": 61161,
+			"name": "watch_lock"
+		},
+		{
+			"codepoint": 60131,
+			"name": "watch_off"
+		},
+		{
+			"codepoint": 63150,
+			"name": "watch_screentime"
+		},
+		{
+			"codepoint": 62567,
+			"name": "watch_vibration"
+		},
+		{
+			"codepoint": 63145,
+			"name": "watch_wake"
+		},
+		{
+			"codepoint": 61572,
+			"name": "water"
+		},
+		{
+			"codepoint": 63133,
+			"name": "water_bottle"
+		},
+		{
+			"codepoint": 63134,
+			"name": "water_bottle_large"
+		},
+		{
+			"codepoint": 61955,
+			"name": "water_damage"
+		},
+		{
+			"codepoint": 63600,
+			"name": "water_do"
+		},
+		{
+			"codepoint": 59288,
+			"name": "water_drop"
+		},
+		{
+			"codepoint": 1048485,
+			"name": "water_drops"
+		},
+		{
+			"codepoint": 63605,
+			"name": "water_ec"
+		},
+		{
+			"codepoint": 63190,
+			"name": "water_full"
+		},
+		{
+			"codepoint": 57988,
+			"name": "water_heater"
+		},
+		{
+			"codepoint": 63149,
+			"name": "water_lock"
+		},
+		{
+			"codepoint": 63189,
+			"name": "water_loss"
+		},
+		{
+			"codepoint": 63604,
+			"name": "water_lux"
+		},
+		{
+			"codepoint": 63188,
+			"name": "water_medium"
+		},
+		{
+			"codepoint": 63608,
+			"name": "water_orp"
+		},
+		{
+			"codepoint": 63610,
+			"name": "water_ph"
+		},
+		{
+			"codepoint": 62936,
+			"name": "water_pump"
+		},
+		{
+			"codepoint": 63611,
+			"name": "water_voc"
+		},
+		{
+			"codepoint": 59904,
+			"name": "waterfall_chart"
+		},
+		{
+			"codepoint": 57718,
+			"name": "waves"
+		},
+		{
+			"codepoint": 59238,
+			"name": "waving_hand"
+		},
+		{
+			"codepoint": 58412,
+			"name": "wb_auto"
+		},
+		{
+			"codepoint": 61788,
+			"name": "wb_cloudy"
+		},
+		{
+			"codepoint": 58414,
+			"name": "wb_incandescent"
+		},
+		{
+			"codepoint": 61565,
+			"name": "wb_iridescent"
+		},
+		{
+			"codepoint": 59905,
+			"name": "wb_shade"
+		},
+		{
+			"codepoint": 58416,
+			"name": "wb_sunny"
+		},
+		{
+			"codepoint": 57798,
+			"name": "wb_twilight"
+		},
+		{
+			"codepoint": 1048351,
+			"name": "wb_twilight_2"
+		},
+		{
+			"codepoint": 58941,
+			"name": "wc"
+		},
+		{
+			"codepoint": 63103,
+			"name": "weather_hail"
+		},
+		{
+			"codepoint": 62987,
+			"name": "weather_mix"
+		},
+		{
+			"codepoint": 58061,
+			"name": "weather_snowy"
+		},
+		{
+			"codepoint": 59009,
+			"name": "web"
+		},
+		{
+			"codepoint": 57449,
+			"name": "web_asset"
+		},
+		{
+			"codepoint": 61255,
+			"name": "web_asset_off"
+		},
+		{
+			"codepoint": 58773,
+			"name": "web_stories"
+		},
+		{
+			"codepoint": 59907,
+			"name": "web_traffic"
+		},
+		{
+			"codepoint": 60306,
+			"name": "webhook"
+		},
+		{
+			"codepoint": 57707,
+			"name": "weekend"
+		},
+		{
+			"codepoint": 57661,
+			"name": "weight"
+		},
+		{
+			"codepoint": 61926,
+			"name": "west"
+		},
+		{
+			"codepoint": 59406,
+			"name": "whatshot"
+		},
+		{
+			"codepoint": 1048484,
+			"name": "wheat"
+		},
+		{
+			"codepoint": 61867,
+			"name": "wheelchair_pickup"
+		},
+		{
+			"codepoint": 57719,
+			"name": "where_to_vote"
+		},
+		{
+			"codepoint": 62394,
+			"name": "widget_medium"
+		},
+		{
+			"codepoint": 61111,
+			"name": "widget_menu"
+		},
+		{
+			"codepoint": 62393,
+			"name": "widget_small"
+		},
+		{
+			"codepoint": 62392,
+			"name": "widget_width"
+		},
+		{
+			"codepoint": 57789,
+			"name": "widgets"
+		},
+		{
+			"codepoint": 63280,
+			"name": "width"
+		},
+		{
+			"codepoint": 63733,
+			"name": "width_full"
+		},
+		{
+			"codepoint": 63734,
+			"name": "width_normal"
+		},
+		{
+			"codepoint": 63735,
+			"name": "width_wide"
+		},
+		{
+			"codepoint": 58942,
+			"name": "wifi"
+		},
+		{
+			"codepoint": 58570,
+			"name": "wifi_1_bar"
+		},
+		{
+			"codepoint": 58585,
+			"name": "wifi_2_bar"
+		},
+		{
+			"codepoint": 63400,
+			"name": "wifi_add"
+		},
+		{
+			"codepoint": 61303,
+			"name": "wifi_calling"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_1"
+		},
+		{
+			"codepoint": 61686,
+			"name": "wifi_calling_2"
+		},
+		{
+			"codepoint": 61671,
+			"name": "wifi_calling_3"
+		},
+		{
+			"codepoint": 62540,
+			"name": "wifi_calling_bar_1"
+		},
+		{
+			"codepoint": 62539,
+			"name": "wifi_calling_bar_2"
+		},
+		{
+			"codepoint": 62538,
+			"name": "wifi_calling_bar_3"
+		},
+		{
+			"codepoint": 60266,
+			"name": "wifi_channel"
+		},
+		{
+			"codepoint": 1048372,
+			"name": "wifi_device"
+		},
+		{
+			"codepoint": 60209,
+			"name": "wifi_find"
+		},
+		{
+			"codepoint": 63089,
+			"name": "wifi_home"
+		},
+		{
+			"codepoint": 57825,
+			"name": "wifi_lock"
+		},
+		{
+			"codepoint": 63088,
+			"name": "wifi_notification"
+		},
+		{
+			"codepoint": 58952,
+			"name": "wifi_off"
+		},
+		{
+			"codepoint": 60267,
+			"name": "wifi_password"
+		},
+		{
+			"codepoint": 61692,
+			"name": "wifi_protected_setup"
+		},
+		{
+			"codepoint": 63399,
+			"name": "wifi_proxy"
+		},
+		{
+			"codepoint": 57826,
+			"name": "wifi_tethering"
+		},
+		{
+			"codepoint": 60121,
+			"name": "wifi_tethering_error"
+		},
+		{
+			"codepoint": 61575,
+			"name": "wifi_tethering_off"
+		},
+		{
+			"codepoint": 60428,
+			"name": "wind_power"
+		},
+		{
+			"codepoint": 61576,
+			"name": "window"
+		},
+		{
+			"codepoint": 59262,
+			"name": "window_closed"
+		},
+		{
+			"codepoint": 59276,
+			"name": "window_open"
+		},
+		{
+			"codepoint": 58043,
+			"name": "window_sensor"
+		},
+		{
+			"codepoint": 62024,
+			"name": "windshield_defrost_auto"
+		},
+		{
+			"codepoint": 62250,
+			"name": "windshield_defrost_front"
+		},
+		{
+			"codepoint": 62249,
+			"name": "windshield_defrost_rear"
+		},
+		{
+			"codepoint": 62248,
+			"name": "windshield_heat_front"
+		},
+		{
+			"codepoint": 61928,
+			"name": "wine_bar"
+		},
+		{
+			"codepoint": 57662,
+			"name": "woman"
+		},
+		{
+			"codepoint": 63719,
+			"name": "woman_2"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work"
+		},
+		{
+			"codepoint": 62967,
+			"name": "work_alert"
+		},
+		{
+			"codepoint": 60425,
+			"name": "work_history"
+		},
+		{
+			"codepoint": 59714,
+			"name": "work_off"
+		},
+		{
+			"codepoint": 59715,
+			"name": "work_outline"
+		},
+		{
+			"codepoint": 62968,
+			"name": "work_update"
+		},
+		{
+			"codepoint": 59908,
+			"name": "workflow"
+		},
+		{
+			"codepoint": 59311,
+			"name": "workspace_premium"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces"
+		},
+		{
+			"codepoint": 59919,
+			"name": "workspaces_outline"
+		},
+		{
+			"codepoint": 57663,
+			"name": "wounds_injuries"
+		},
+		{
+			"codepoint": 57947,
+			"name": "wrap_text"
+		},
+		{
+			"codepoint": 63132,
+			"name": "wrist"
+		},
+		{
+			"codepoint": 61304,
+			"name": "wrong_location"
+		},
+		{
+			"codepoint": 61891,
+			"name": "wysiwyg"
+		},
+		{
+			"codepoint": 58185,
+			"name": "x_circle"
+		},
+		{
+			"codepoint": 61125,
+			"name": "y_circle"
+		},
+		{
+			"codepoint": 61233,
+			"name": "yakitori"
+		},
+		{
+			"codepoint": 61577,
+			"name": "yard"
+		},
+		{
+			"codepoint": 62079,
+			"name": "yoshoku"
+		},
+		{
+			"codepoint": 60203,
+			"name": "your_trips"
+		},
+		{
+			"codepoint": 63578,
+			"name": "youtube_activity"
+		},
+		{
+			"codepoint": 59642,
+			"name": "youtube_searched_for"
+		},
+		{
+			"codepoint": 59265,
+			"name": "zone_person_alert"
+		},
+		{
+			"codepoint": 59258,
+			"name": "zone_person_idle"
+		},
+		{
+			"codepoint": 59272,
+			"name": "zone_person_urgent"
+		},
+		{
+			"codepoint": 59647,
+			"name": "zoom_in"
+		},
+		{
+			"codepoint": 60205,
+			"name": "zoom_in_map"
+		},
+		{
+			"codepoint": 59648,
+			"name": "zoom_out"
+		},
+		{
+			"codepoint": 58731,
+			"name": "zoom_out_map"
+		}
+	],
+	"source": {
+		"path": "variablefont/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].codepoints",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"sha256": "8567a3d0512ce8a735a739d325e83ee7010d9bf7f6f8ed6a699c07c817ea907d"
+	}
+}

--- a/registry/data/families/google-icons/material-symbols-sharp/inspection.json
+++ b/registry/data/families/google-icons/material-symbols-sharp/inspection.json
@@ -1,0 +1,46 @@
+{
+	"files": [
+		{
+			"axes": [
+				{
+					"default": 0,
+					"max": 1,
+					"min": 0,
+					"tag": "FILL"
+				},
+				{
+					"default": 0,
+					"max": 200,
+					"min": -50,
+					"tag": "GRAD"
+				},
+				{
+					"default": 24,
+					"max": 48,
+					"min": 20,
+					"tag": "opsz"
+				},
+				{
+					"default": 400,
+					"max": 700,
+					"min": 100,
+					"tag": "wght"
+				}
+			],
+			"cmap": {
+				"codepointCount": 4382,
+				"sha256": "c7e2330b037a77ee633c96bab75b961eb0376d69ff3e00ecce87a89de557b18d"
+			},
+			"colorTables": [],
+			"fontVersion": "Version 2.961",
+			"outline": "glyf",
+			"path": "variablefont/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf",
+			"style": "normal",
+			"weight": {
+				"default": 400,
+				"max": 700,
+				"min": 100
+			}
+		}
+	]
+}

--- a/registry/data/families/google-icons/material-symbols-sharp/license.txt
+++ b/registry/data/families/google-icons/material-symbols-sharp/license.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/data/families/google-icons/material-symbols-sharp/metadata.json
+++ b/registry/data/families/google-icons/material-symbols-sharp/metadata.json
@@ -1,0 +1,38 @@
+{
+	"classifications": [
+		"symbols"
+	],
+	"family": "Material Symbols Sharp",
+	"id": "material-symbols-sharp",
+	"languages": [],
+	"license": {
+		"id": "Apache-2.0",
+		"url": "https://www.apache.org/licenses/LICENSE-2.0"
+	},
+	"project": {
+		"repository": "https://github.com/google/material-design-icons"
+	},
+	"provenance": {
+		"directory": "variablefont",
+		"repository": "google/material-design-icons",
+		"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2",
+		"type": "github"
+	},
+	"provider": "google-icons",
+	"sourceFiles": [
+		{
+			"path": "variablefont/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf",
+			"sha256": "c56a37227b580aa30bcbf352a770a2598dc86bca43bf060ff8d0550c081827e6",
+			"size": 8841632,
+			"variant": {
+				"style": "normal",
+				"weight": 400
+			}
+		}
+	],
+	"sourceModified": "2026-07-24",
+	"status": "active",
+	"tags": [
+		"special-use/icons"
+	]
+}

--- a/registry/data/index.json
+++ b/registry/data/index.json
@@ -1,5 +1,13 @@
 {
 	"families": [
+		"google-icons/material-icons",
+		"google-icons/material-icons-outlined",
+		"google-icons/material-icons-round",
+		"google-icons/material-icons-sharp",
+		"google-icons/material-icons-two-tone",
+		"google-icons/material-symbols-outlined",
+		"google-icons/material-symbols-rounded",
+		"google-icons/material-symbols-sharp",
 		"google/42dot-sans",
 		"google/abeezee",
 		"google/abel",
@@ -2223,6 +2231,10 @@
 		"googleFonts": {
 			"repository": "google/fonts",
 			"revision": "389b770410cc0b7c21c85673bfa2077420fe7f65"
+		},
+		"googleIcons": {
+			"repository": "google/material-design-icons",
+			"revision": "528cb964c01fb2b09bc3b9208f82b6d8f8c1c1e2"
 		},
 		"namFiles": {
 			"repository": "googlefonts/nam-files",

--- a/registry/data/taxonomy.json
+++ b/registry/data/taxonomy.json
@@ -208,6 +208,9 @@
 		"special-use/barcode": {
 			"label": "Barcode"
 		},
+		"special-use/icons": {
+			"label": "Icons"
+		},
 		"special-use/redaction": {
 			"label": "Redaction"
 		},

--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -34,6 +34,7 @@ describe('registry source archive', () => {
 		let current: unknown;
 		let family: unknown;
 		let familyWithVariantOverride: unknown;
+		let iconFamily: unknown;
 		let replacement: unknown;
 		let language: unknown;
 		let sourceContentType: string | undefined;
@@ -59,6 +60,11 @@ describe('registry source archive', () => {
 				}
 				if (object.key.endsWith('/api/families/alegreya-sans.json')) {
 					familyWithVariantOverride = JSON.parse(
+						Buffer.from(await object.read()).toString('utf8'),
+					);
+				}
+				if (object.key.endsWith('/api/families/material-icons.json')) {
+					iconFamily = JSON.parse(
 						Buffer.from(await object.read()).toString('utf8'),
 					);
 				}
@@ -96,6 +102,9 @@ describe('registry source archive', () => {
 			registryRevision: REVISION,
 			registry: expect.arrayContaining([
 				expect.objectContaining({ path: 'index.json' }),
+				expect.objectContaining({
+					path: 'families/google-icons/material-icons/icons.json',
+				}),
 			]),
 			sources: expect.arrayContaining([
 				expect.objectContaining({
@@ -152,6 +161,14 @@ describe('registry source archive', () => {
 		expect(RegistryFamilyDetailSchema.parse(familyWithVariantOverride)).toEqual(
 			familyWithVariantOverride,
 		);
+		expect(iconFamily).toMatchObject({
+			id: 'material-icons',
+			provider: 'google-icons',
+			classifications: ['symbols'],
+			tags: ['special-use/icons'],
+			languages: [],
+		});
+		expect(RegistryFamilyDetailSchema.parse(iconFamily)).toEqual(iconFamily);
 		expect(replacement).toMatchObject({
 			id: 'ek-mukta',
 			status: 'deprecated',

--- a/registry/scripts/generate.ts
+++ b/registry/scripts/generate.ts
@@ -3,6 +3,7 @@ import { consola } from 'consola';
 import { generateFontFiles } from './font-files.ts';
 import { openGitSnapshot } from './git.ts';
 import { generateGoogle } from './google.ts';
+import { generateGoogleIcons } from './google-icons.ts';
 import { generateNam } from './nam.ts';
 import {
 	familyMetadataSchema,
@@ -44,6 +45,8 @@ export const applyReplacements = async (
 export const generateRegistry = async (
 	googleRepository: string,
 	googleRevision: string,
+	googleIconsRepository: string,
+	googleIconsRevision: string,
 	namRepository: string,
 	namRevision: string,
 	fontFilesRepository: string,
@@ -51,6 +54,11 @@ export const generateRegistry = async (
 	root: string,
 ): Promise<void> => {
 	const google = openGitSnapshot(googleRepository, googleRevision);
+	const googleIcons = openGitSnapshot(
+		googleIconsRepository,
+		googleIconsRevision,
+		['LICENSE', 'font', 'variablefont'],
+	);
 	const nam = openGitSnapshot(namRepository, namRevision);
 	const fontFiles = openGitSnapshot(fontFilesRepository, fontFilesRevision);
 	const previousValue = await readJsonIfExists(join(root, 'index.json'));
@@ -64,6 +72,9 @@ export const generateRegistry = async (
 	const previousGoogleIds = previousFamilies
 		.filter((family) => family.startsWith('google/'))
 		.map((family) => family.slice('google/'.length));
+	const previousGoogleIconIds = previousFamilies
+		.filter((family) => family.startsWith('google-icons/'))
+		.map((family) => family.slice('google-icons/'.length));
 	const previousFontsourceIds = previousFamilies
 		.filter((family) => family.startsWith('fontsource/'))
 		.map((family) => family.slice('fontsource/'.length));
@@ -80,6 +91,15 @@ export const generateRegistry = async (
 		taxonomy,
 	);
 	logger.success(`Generated ${googleFamilies.length} Google font families`);
+	logger.start(
+		`Generating families from google/material-design-icons@${googleIcons.revision}`,
+	);
+	const googleIconFamilies = await generateGoogleIcons(
+		googleIcons,
+		root,
+		previousGoogleIconIds,
+	);
+	logger.success(`Generated ${googleIconFamilies.length} Google icon families`);
 	const languages = languageCatalogSchema.parse(
 		await readJson(join(root, 'languages.json')),
 	);
@@ -98,6 +118,7 @@ export const generateRegistry = async (
 
 	const families = [
 		...googleFamilies.map((family) => `google/${family}`),
+		...googleIconFamilies.map((family) => `google-icons/${family}`),
 		...fontsourceFamilies.map((family) => `fontsource/${family}`),
 	].toSorted(compareStrings);
 
@@ -111,6 +132,10 @@ export const generateRegistry = async (
 			googleFonts: {
 				repository: 'google/fonts',
 				revision: google.revision,
+			},
+			googleIcons: {
+				repository: 'google/material-design-icons',
+				revision: googleIcons.revision,
 			},
 			namFiles: {
 				repository: 'googlefonts/nam-files',
@@ -135,6 +160,8 @@ if (import.meta.main) {
 	const [
 		googleRepository,
 		googleRevision,
+		googleIconsRepository,
+		googleIconsRevision,
 		namRepository,
 		namRevision,
 		fontFilesRepository,
@@ -143,19 +170,23 @@ if (import.meta.main) {
 	if (
 		!googleRepository ||
 		!googleRevision ||
+		!googleIconsRepository ||
+		!googleIconsRevision ||
 		!namRepository ||
 		!namRevision ||
 		!fontFilesRepository ||
 		!fontFilesRevision ||
-		process.argv.length !== 8
+		process.argv.length !== 10
 	) {
 		throw new Error(
-			'Usage: generate.ts <google-fonts-repo> <google-commit> <nam-files-repo> <nam-commit> <font-files-repo> <font-files-commit>',
+			'Usage: generate.ts <google-fonts-repo> <google-commit> <google-icons-repo> <google-icons-commit> <nam-files-repo> <nam-commit> <font-files-repo> <font-files-commit>',
 		);
 	}
 	await generateRegistry(
 		googleRepository,
 		googleRevision,
+		googleIconsRepository,
+		googleIconsRevision,
 		namRepository,
 		namRevision,
 		fontFilesRepository,

--- a/registry/scripts/git.ts
+++ b/registry/scripts/git.ts
@@ -40,6 +40,7 @@ export type GitSnapshot = {
 export const openGitSnapshot = (
 	repository: string,
 	revision: string,
+	pathspecs: readonly string[] = [],
 ): GitSnapshot => {
 	if (!/^[0-9a-f]{40}$/.test(revision)) {
 		throw new Error('Revision must be a full lowercase 40-character commit');
@@ -65,6 +66,8 @@ export const openGitSnapshot = (
 		'-r',
 		'--name-only',
 		revision,
+		'--',
+		...pathspecs,
 	])
 		.split('\n')
 		.filter(Boolean)

--- a/registry/scripts/google-icons.ts
+++ b/registry/scripts/google-icons.ts
@@ -1,0 +1,270 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, extname, join } from 'node:path';
+import { createFontContext, inspectFont } from '@fontsource-utils/core';
+import type { GitSnapshot } from './git.ts';
+import { normalizeInspection } from './inspection.ts';
+import {
+	type FamilyIcons,
+	familyIconsSchema,
+	familyInspectionSchema,
+	familyMetadataSchema,
+} from './schema.ts';
+import {
+	compareStrings,
+	normalizeText,
+	readJson,
+	sha256,
+	writeJson,
+} from './shared.ts';
+
+const REPOSITORY = 'google/material-design-icons';
+const PROJECT_URL = `https://github.com/${REPOSITORY}`;
+const LICENSE = {
+	id: 'Apache-2.0',
+	url: 'https://www.apache.org/licenses/LICENSE-2.0',
+} as const;
+const TAGS = ['special-use/icons'] as const;
+
+type FamilyDefinition = {
+	id: string;
+	family: string;
+	fontPath: string;
+	set: 'icons' | 'symbols';
+};
+
+const FAMILIES: readonly FamilyDefinition[] = [
+	{
+		id: 'material-icons',
+		family: 'Material Icons',
+		fontPath: 'font/MaterialIcons-Regular.ttf',
+		set: 'icons',
+	},
+	{
+		id: 'material-icons-outlined',
+		family: 'Material Icons Outlined',
+		fontPath: 'font/MaterialIconsOutlined-Regular.otf',
+		set: 'icons',
+	},
+	{
+		id: 'material-icons-round',
+		family: 'Material Icons Round',
+		fontPath: 'font/MaterialIconsRound-Regular.otf',
+		set: 'icons',
+	},
+	{
+		id: 'material-icons-sharp',
+		family: 'Material Icons Sharp',
+		fontPath: 'font/MaterialIconsSharp-Regular.otf',
+		set: 'icons',
+	},
+	{
+		id: 'material-icons-two-tone',
+		family: 'Material Icons Two Tone',
+		fontPath: 'font/MaterialIconsTwoTone-Regular.otf',
+		set: 'icons',
+	},
+	{
+		id: 'material-symbols-outlined',
+		family: 'Material Symbols Outlined',
+		fontPath: 'variablefont/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf',
+		set: 'symbols',
+	},
+	{
+		id: 'material-symbols-rounded',
+		family: 'Material Symbols Rounded',
+		fontPath: 'variablefont/MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf',
+		set: 'symbols',
+	},
+	{
+		id: 'material-symbols-sharp',
+		family: 'Material Symbols Sharp',
+		fontPath: 'variablefont/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf',
+		set: 'symbols',
+	},
+];
+
+const codepointsPath = (fontPath: string): string =>
+	`${fontPath.slice(0, -extname(fontPath).length)}.codepoints`;
+
+const readIcons = (
+	snapshot: GitSnapshot,
+	path: string,
+): { manifest: FamilyIcons; modified: string } => {
+	const contents = snapshot.read(path);
+	const icons = contents
+		.toString('utf8')
+		.trim()
+		.split(/\r?\n/)
+		.map((line, index) => {
+			const match = line.match(/^(\S+)\s+([0-9a-fA-F]+)$/);
+			if (!match?.[1] || !match[2]) {
+				throw new Error(`${path}:${index + 1} is not a codepoint mapping`);
+			}
+			return {
+				name: match[1],
+				codepoint: Number.parseInt(match[2], 16),
+			};
+		})
+		.toSorted(
+			(left, right) =>
+				compareStrings(left.name, right.name) ||
+				left.codepoint - right.codepoint,
+		);
+	const changed = snapshot.lastChanged(path);
+	return {
+		manifest: familyIconsSchema.parse({
+			icons,
+			source: {
+				repository: REPOSITORY,
+				revision: changed.revision,
+				path,
+				sha256: sha256(contents),
+			},
+		}),
+		modified: changed.date,
+	};
+};
+
+const supportsCodepoint = (
+	ranges: Awaited<ReturnType<typeof inspectFont>>['unicodeRanges'],
+	codepoint: number,
+): boolean =>
+	ranges.some((range) =>
+		typeof range === 'number'
+			? range === codepoint
+			: range[0] <= codepoint && codepoint <= range[1],
+	);
+
+const description = ({ family, set }: FamilyDefinition): string =>
+	set === 'symbols'
+		? `${family} is part of Google's current Material Symbols collection. It is a variable icon font with fill, weight, grade, and optical size axes.`
+		: `${family} is part of Google's classic Material Icons collection. It is a static icon font at Regular weight; Google recommends Material Symbols for current icons.`;
+
+const writeFamily = async (
+	snapshot: GitSnapshot,
+	root: string,
+	ctx: ReturnType<typeof createFontContext>,
+	definition: FamilyDefinition,
+): Promise<void> => {
+	const contents = snapshot.read(definition.fontPath);
+	const inspected = await inspectFont(ctx, new Uint8Array(contents));
+	const { manifest: icons, modified: iconsModified } = readIcons(
+		snapshot,
+		codepointsPath(definition.fontPath),
+	);
+	const missingCodepoints = new Set(
+		icons.icons
+			.map((icon) => icon.codepoint)
+			.filter(
+				(codepoint) => !supportsCodepoint(inspected.unicodeRanges, codepoint),
+			),
+	);
+	if (missingCodepoints.size > 0) {
+		throw new Error(
+			`${definition.id} codepoint manifest references ${missingCodepoints.size} missing glyphs`,
+		);
+	}
+
+	const changed = snapshot.lastChanged(definition.fontPath);
+	const metadata = familyMetadataSchema.parse({
+		id: definition.id,
+		family: definition.family,
+		provider: 'google-icons',
+		status: 'active',
+		provenance: {
+			type: 'github',
+			repository: REPOSITORY,
+			revision: changed.revision,
+			directory: dirname(definition.fontPath),
+		},
+		classifications: ['symbols'],
+		tags: TAGS,
+		languages: [],
+		sourceModified: changed.date > iconsModified ? changed.date : iconsModified,
+		license: LICENSE,
+		project: { repository: PROJECT_URL },
+		sourceFiles: [
+			{
+				path: definition.fontPath,
+				sha256: sha256(contents),
+				size: contents.byteLength,
+				variant: { weight: 400, style: 'normal' },
+			},
+		],
+	});
+	const output = join(root, 'families', 'google-icons', definition.id);
+	await mkdir(output, { recursive: true });
+	await writeJson(join(output, 'metadata.json'), metadata);
+	await writeJson(
+		join(output, 'inspection.json'),
+		familyInspectionSchema.parse({
+			files: [normalizeInspection(definition.fontPath, inspected)],
+		}),
+	);
+	await writeJson(join(output, 'icons.json'), icons);
+	await writeFile(
+		join(output, 'description.en-US.md'),
+		normalizeText(description(definition)),
+	);
+	await writeFile(
+		join(output, 'license.txt'),
+		normalizeText(snapshot.read('LICENSE').toString('utf8')),
+	);
+};
+
+const currentFamilies = (
+	snapshot: GitSnapshot,
+): readonly FamilyDefinition[] => {
+	const paths = new Set(snapshot.paths);
+	const declaredPaths = new Set(
+		FAMILIES.flatMap((family) => [
+			family.fontPath,
+			codepointsPath(family.fontPath),
+		]),
+	);
+	const unknown = snapshot.paths.filter(
+		(path) =>
+			/^(?:font|variablefont)\/.+\.(?:codepoints|otf|ttf)$/.test(path) &&
+			!declaredPaths.has(path),
+	);
+	if (unknown.length > 0) {
+		throw new Error(`Unknown Google icon sources: ${unknown.join(', ')}`);
+	}
+
+	return FAMILIES.filter((family) => {
+		const hasFont = paths.has(family.fontPath);
+		const hasCodepoints = paths.has(codepointsPath(family.fontPath));
+		if (hasFont !== hasCodepoints) {
+			throw new Error(`${family.id} has an incomplete source pair`);
+		}
+		return hasFont;
+	});
+};
+
+export const generateGoogleIcons = async (
+	snapshot: GitSnapshot,
+	root: string,
+	previousFamilyIds: readonly string[],
+): Promise<string[]> => {
+	const families = currentFamilies(snapshot);
+	const familyIds = new Set(previousFamilyIds);
+	const ctx = createFontContext();
+	try {
+		for (const family of families) {
+			await writeFamily(snapshot, root, ctx, family);
+			familyIds.add(family.id);
+		}
+	} finally {
+		ctx.destroy();
+	}
+
+	const currentIds = new Set(families.map((family) => family.id));
+	for (const id of previousFamilyIds) {
+		if (currentIds.has(id)) continue;
+		const path = join(root, 'families', 'google-icons', id, 'metadata.json');
+		const metadata = familyMetadataSchema.parse(await readJson(path));
+		await writeJson(path, { ...metadata, status: 'deprecated' });
+	}
+
+	return [...familyIds].toSorted(compareStrings);
+};

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -17,6 +17,7 @@ import { assertGitPathClean, openGitSnapshot } from './git.ts';
 import {
 	familyMetadataSchema,
 	languageCatalogSchema,
+	registryIndexSchema,
 	sourceFamilySchema,
 } from './schema.ts';
 import { canonicalJson, compareStrings, readJson, sha256 } from './shared.ts';
@@ -307,6 +308,52 @@ const createNamRepository = async (): Promise<{
 	};
 };
 
+const createGoogleIconsRepository = async (): Promise<{
+	repository: string;
+	revision: string;
+}> => {
+	const repository = await createGitRepository('google-icons');
+	const staticFonts = [
+		'MaterialIcons-Regular.ttf',
+		'MaterialIconsOutlined-Regular.otf',
+		'MaterialIconsRound-Regular.otf',
+		'MaterialIconsSharp-Regular.otf',
+		'MaterialIconsTwoTone-Regular.otf',
+	];
+	const variableFonts = [
+		'MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf',
+		'MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf',
+		'MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf',
+	];
+	for (const filename of staticFonts) {
+		await copyFont(repository, 'abel-latin-400-normal.ttf', `font/${filename}`);
+		await writeFixture(
+			repository,
+			`font/${filename.replace(/\.(?:otf|ttf)$/, '.codepoints')}`,
+			filename === 'MaterialIcons-Regular.ttf'
+				? 'flourescent 41\nflourescent 42\n'
+				: 'home 41\n',
+		);
+	}
+	for (const filename of variableFonts) {
+		await copyFont(
+			repository,
+			'recursive-latin-full-normal.ttf',
+			`variablefont/${filename}`,
+		);
+		await writeFixture(
+			repository,
+			`variablefont/${filename.replace(/\.ttf$/, '.codepoints')}`,
+			'home 41\nsettings 42\n',
+		);
+	}
+	await writeFixture(repository, 'LICENSE', 'Apache License\n');
+	return {
+		repository,
+		revision: commitAll(repository, 'initial Google icons snapshot'),
+	};
+};
+
 const createFontFilesRepository = async (): Promise<{
 	repository: string;
 	revision: string;
@@ -435,6 +482,10 @@ describe('registry ingestion', () => {
 						repository: 'google/fonts',
 						revision: '1'.repeat(40),
 					},
+					googleIcons: {
+						repository: 'google/material-design-icons',
+						revision: '4'.repeat(40),
+					},
 					namFiles: {
 						repository: 'googlefonts/nam-files',
 						revision: '2'.repeat(40),
@@ -522,6 +573,7 @@ describe('registry ingestion', () => {
 
 	it('regenerates deterministically, applies replacements, and retains missing families', async () => {
 		const google = await createGoogleRepository();
+		const googleIcons = await createGoogleIconsRepository();
 		const nam = await createNamRepository();
 		const fontFiles = await createFontFilesRepository();
 		const registry = await temporaryDirectory('registry');
@@ -529,6 +581,8 @@ describe('registry ingestion', () => {
 		await generateRegistry(
 			google.repository,
 			google.revision,
+			googleIcons.repository,
+			googleIcons.revision,
 			nam.repository,
 			nam.revision,
 			fontFiles.repository,
@@ -554,6 +608,8 @@ describe('registry ingestion', () => {
 		await generateRegistry(
 			google.repository,
 			unrelatedRevision,
+			googleIcons.repository,
+			googleIcons.revision,
 			nam.repository,
 			nam.revision,
 			fontFiles.repository,
@@ -569,6 +625,8 @@ describe('registry ingestion', () => {
 		await generateRegistry(
 			google.repository,
 			unrelatedRevision,
+			googleIcons.repository,
+			googleIcons.revision,
 			nam.repository,
 			nam.revision,
 			fontFiles.repository,
@@ -627,6 +685,69 @@ describe('registry ingestion', () => {
 				join(registry, 'families/fontsource/example/metadata.json'),
 			),
 		).toMatchObject({ provider: 'fontsource', status: 'active' });
+		const index = registryIndexSchema.parse(
+			await readJson(join(registry, 'index.json')),
+		);
+		expect(
+			index.families.filter((family) => family.startsWith('google-icons/')),
+		).toEqual([
+			'google-icons/material-icons',
+			'google-icons/material-icons-outlined',
+			'google-icons/material-icons-round',
+			'google-icons/material-icons-sharp',
+			'google-icons/material-icons-two-tone',
+			'google-icons/material-symbols-outlined',
+			'google-icons/material-symbols-rounded',
+			'google-icons/material-symbols-sharp',
+		]);
+		expect(
+			await readJson(
+				join(registry, 'families/google-icons/material-icons/metadata.json'),
+			),
+		).toMatchObject({
+			provider: 'google-icons',
+			classifications: ['symbols'],
+			tags: ['special-use/icons'],
+			languages: [],
+			license: { id: 'Apache-2.0' },
+			sourceFiles: [
+				{
+					path: 'font/MaterialIcons-Regular.ttf',
+					variant: { weight: 400, style: 'normal' },
+				},
+			],
+		});
+		expect(
+			await readJson(
+				join(registry, 'families/google-icons/material-icons/icons.json'),
+			),
+		).toMatchObject({
+			icons: [
+				{ name: 'flourescent', codepoint: 65 },
+				{ name: 'flourescent', codepoint: 66 },
+			],
+			source: {
+				repository: 'google/material-design-icons',
+				path: 'font/MaterialIcons-Regular.codepoints',
+			},
+		});
+		expect(
+			await readJson(
+				join(
+					registry,
+					'families/google-icons/material-symbols-outlined/inspection.json',
+				),
+			),
+		).toMatchObject({
+			files: [
+				{
+					path: 'variablefont/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf',
+					axes: expect.arrayContaining([
+						expect.objectContaining({ tag: 'wght' }),
+					]),
+				},
+			],
+		});
 		const description = await readFile(
 			join(registry, 'families/google/abel/description.en-US.md'),
 			'utf8',
@@ -644,9 +765,19 @@ describe('registry ingestion', () => {
 			fontFiles.repository,
 			'remove Symbols',
 		);
+		await rm(join(googleIcons.repository, 'font/MaterialIcons-Regular.ttf'));
+		await rm(
+			join(googleIcons.repository, 'font/MaterialIcons-Regular.codepoints'),
+		);
+		const removedGoogleIconsRevision = commitAll(
+			googleIcons.repository,
+			'remove Material Icons',
+		);
 		await generateRegistry(
 			google.repository,
 			removedRevision,
+			googleIcons.repository,
+			removedGoogleIconsRevision,
 			nam.repository,
 			nam.revision,
 			fontFiles.repository,
@@ -668,6 +799,14 @@ describe('registry ingestion', () => {
 		).toMatchObject({
 			status: 'deprecated',
 			provenance: { revision: fontFiles.revision },
+		});
+		expect(
+			await readJson(
+				join(registry, 'families/google-icons/material-icons/metadata.json'),
+			),
+		).toMatchObject({
+			status: 'deprecated',
+			provenance: { revision: googleIcons.revision },
 		});
 
 		const replacementPath = join(

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -5,10 +5,10 @@ const idSchema = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 const languageIdSchema = z
 	.string()
 	.regex(/^[a-z][a-z0-9]*(?:[-_][A-Za-z0-9]+)*$/);
-const familyProviderSchema = z.enum(['google', 'fontsource']);
+const familyProviderSchema = z.enum(['google', 'google-icons', 'fontsource']);
 const familyKeySchema = z
 	.string()
-	.regex(/^(?:google|fontsource)\/[a-z0-9]+(?:-[a-z0-9]+)*$/);
+	.regex(/^(?:google|google-icons|fontsource)\/[a-z0-9]+(?:-[a-z0-9]+)*$/);
 const revisionSchema = z.string().regex(/^[0-9a-f]{40}$/);
 const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const dateSchema = z.iso.date();
@@ -59,6 +59,9 @@ const sourcePathSchema = z
 			!value.split('/').includes('..'),
 		{ message: 'must be a safe repository-relative POSIX path' },
 	);
+const githubRepositorySchema = z
+	.string()
+	.regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/);
 
 const sampleTextSchema = z
 	.strictObject({
@@ -87,6 +90,10 @@ export const registryIndexSchema = z.strictObject({
 	upstreams: z.strictObject({
 		googleFonts: z.strictObject({
 			repository: z.literal('google/fonts'),
+			revision: revisionSchema,
+		}),
+		googleIcons: z.strictObject({
+			repository: z.literal('google/material-design-icons'),
 			revision: revisionSchema,
 		}),
 		namFiles: z.strictObject({
@@ -141,7 +148,7 @@ export const familyMetadataSchema = z.strictObject({
 	provenance: z.discriminatedUnion('type', [
 		z.strictObject({
 			type: z.literal('github'),
-			repository: z.string().regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/),
+			repository: githubRepositorySchema,
 			revision: revisionSchema,
 			directory: sourcePathSchema,
 		}),
@@ -169,6 +176,23 @@ export const familyMetadataSchema = z.strictObject({
 		})
 		.optional(),
 	sourceFiles: z.array(sourceFileSchema).min(1),
+});
+
+export const familyIconsSchema = z.strictObject({
+	icons: z
+		.array(
+			z.strictObject({
+				name: z.string().min(1).regex(/^\S+$/),
+				codepoint: unicodeScalarSchema,
+			}),
+		)
+		.min(1),
+	source: z.strictObject({
+		repository: githubRepositorySchema,
+		revision: revisionSchema,
+		path: sourcePathSchema,
+		sha256: sha256Schema,
+	}),
 });
 
 export const sourceFamilySchema = familyMetadataSchema
@@ -295,6 +319,7 @@ export const taxonomySchema = z.strictObject({
 
 export type FamilyMetadata = z.infer<typeof familyMetadataSchema>;
 export type FamilyInspection = z.infer<typeof familyInspectionSchema>;
+export type FamilyIcons = z.infer<typeof familyIconsSchema>;
 export type FamilyPolicy = z.infer<typeof familyPolicySchema>;
 export type LanguageCatalog = z.infer<typeof languageCatalogSchema>;
 export type ReplacementRegistry = z.infer<typeof replacementRegistrySchema>;

--- a/registry/scripts/validator.ts
+++ b/registry/scripts/validator.ts
@@ -8,6 +8,7 @@ import {
 	type FamilyInspection,
 	type FamilyMetadata,
 	type FamilyPolicy,
+	familyIconsSchema,
 	familyInspectionSchema,
 	familyMetadataSchema,
 	familyPolicySchema,
@@ -274,6 +275,20 @@ const validateFamily = async (
 		}
 	}
 
+	const iconsPath = join(directory, 'icons.json');
+	if (await pathExists(iconsPath)) {
+		const manifest = await validateCanonicalJson(iconsPath, familyIconsSchema);
+		assert(
+			metadata.classifications.includes('symbols'),
+			`${id} has icons but is not classified as symbols`,
+		);
+		assertSortedUnique(
+			manifest.icons,
+			(icon) => `${icon.name}\0${icon.codepoint.toString(16).padStart(6, '0')}`,
+			`${id} icons`,
+		);
+	}
+
 	const policyPath = join(directory, 'policy.json');
 	if (!(await pathExists(policyPath))) return metadata;
 	const policy = await validateCanonicalJson(policyPath, familyPolicySchema);
@@ -477,6 +492,7 @@ export const validateRegistry = async (root: string): Promise<void> => {
 		for (const filename of [
 			'metadata.json',
 			'inspection.json',
+			'icons.json',
 			'license.txt',
 			'policy.json',
 			'description.en-US.md',


### PR DESCRIPTION
## Overview

Adds a dedicated Google icon provider for Material Icons and Material Symbols, including source provenance, font inspection, name-to-codepoint manifests, and weekly registry synchronization.