### PR TITLE
feat(registry): model character distribution

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -77,8 +77,10 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
   declarations, and inspected source properties. IDs are globally unique
   across providers and are derived from directory names.
 - Reviewed families may include `distribution.json` with the exact static
-  variants, variable axis bundles, and public subset mappings Fontsource
-  publishes. Its absence means the family has no official distribution.
+  variants, variable axis bundles, and character distribution Fontsource
+  publishes. Character distribution is either the full repertoire or named
+  subset mappings with an optional family-wide slicing strategy. Its absence
+  means the family has no official distribution.
 - Icon families also include `icons.json` with public names and Unicode
   codepoints.
 - `data/languages.json` defines semantic languages, public names, and the
@@ -103,6 +105,8 @@ credentials in `REGISTRY_R2_ACCESS_KEY_ID` and
   `registry` provenance requires the source to be promoted to R2 first.
 - Distribution is reviewed registry state, not derived from legacy catalogs.
 - Published variants are explicit relations, not weight/style cross-products.
+- Named subset definitions and a slicing strategy are separate outputs. A
+  family-wide slicing strategy replaces named subsets in aggregate CSS.
 - Build format, package version, storage paths, and artifact hashes are global
   release concerns and do not belong in family distribution records.
 - Core owns generic font processing; these scripts own provider ingestion and

--- a/registry/scripts/distribution.test.ts
+++ b/registry/scripts/distribution.test.ts
@@ -39,8 +39,10 @@ describe('distribution resolution', () => {
 		);
 		const distribution: FamilyDistribution = {
 			static: [...variants],
-			defaultSubset: 'latin',
-			subsets: [{ id: 'latin', definition: 'latin' }],
+			characters: {
+				defaultSubset: 'latin',
+				subsets: [{ id: 'latin', definition: 'latin' }],
+			},
 		};
 
 		expect(() =>
@@ -86,8 +88,7 @@ describe('distribution resolution', () => {
 				{ axisKey: 'standard', style: 'normal' },
 				{ axisKey: 'wght', style: 'normal' },
 			],
-			defaultSubset: 'latin',
-			subsets: [{ id: 'latin', definition: 'latin' }],
+			characters: 'all',
 		};
 
 		expect(() =>

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -25,8 +25,11 @@ import { listFamilyKeys, validateRegistry } from './validator.ts';
 
 const ABEL_DISTRIBUTION = {
 	static: [{ weight: 400, style: 'normal' }],
-	defaultSubset: 'latin',
-	subsets: [{ id: 'latin', definition: 'latin' }],
+	characters: {
+		defaultSubset: 'latin',
+		subsets: [{ id: 'latin', definition: 'latin' }],
+		slicing: 'japanese-web',
+	},
 } as const;
 
 const TEST_LANGUAGES = languageCatalogSchema.parse({

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -242,14 +242,19 @@ const variableDistributionSchema = z.strictObject({
 	style: fontStyleSchema,
 });
 
+const subsetDistributionSchema = z.strictObject({
+	defaultSubset: idSchema,
+	subsets: z
+		.array(z.strictObject({ id: idSchema, definition: idSchema }))
+		.min(1),
+	slicing: idSchema.optional(),
+});
+
 export const familyDistributionSchema = z
 	.strictObject({
 		static: z.array(staticVariantSchema).min(1).optional(),
 		variable: z.array(variableDistributionSchema).min(1).optional(),
-		defaultSubset: idSchema,
-		subsets: z
-			.array(z.strictObject({ id: idSchema, definition: idSchema }))
-			.min(1),
+		characters: z.union([z.literal('all'), subsetDistributionSchema]),
 	})
 	.refine((value) => value.static || value.variable, {
 		message: 'must declare static or variable packages',

--- a/registry/scripts/validator.ts
+++ b/registry/scripts/validator.ts
@@ -20,6 +20,7 @@ import {
 	type LanguageCatalog,
 	languageCatalogSchema,
 	replacementRegistrySchema,
+	type SubsetDefinition,
 	subsetDefinitionSchema,
 	type Taxonomy,
 	taxonomySchema,
@@ -210,7 +211,7 @@ export const validateDistributionResolution = (
 const validateFamily = async (
 	root: string,
 	key: string,
-	subsets: ReadonlySet<string>,
+	subsets: ReadonlyMap<string, SubsetDefinition>,
 	taxonomy: Taxonomy,
 	languages: LanguageCatalog,
 ): Promise<{ id: string; family: Family }> => {
@@ -305,33 +306,52 @@ const validateFamily = async (
 		(variant) => `${variant.axisKey.toLowerCase()}:${variant.style}`,
 		`${id} variable variants`,
 	);
-	assertSortedUnique(
-		distribution.subsets,
-		(subset) => subset.id,
-		`${id} public subsets`,
-	);
-	const subsetIds = new Set(distribution.subsets.map((subset) => subset.id));
-	assert(
-		subsetIds.has(distribution.defaultSubset),
-		`${id} default subset is not mapped`,
-	);
-	for (const subset of distribution.subsets) {
-		assert(
-			subsets.has(subset.definition),
-			`${id} references missing subset ${subset.definition}`,
+	if (distribution.characters !== 'all') {
+		const {
+			defaultSubset,
+			slicing,
+			subsets: publicSubsets,
+		} = distribution.characters;
+		assertSortedUnique(
+			publicSubsets,
+			(subset) => subset.id,
+			`${id} public subsets`,
 		);
+		assert(
+			publicSubsets.some((subset) => subset.id === defaultSubset),
+			`${id} default subset is not mapped`,
+		);
+		for (const subset of publicSubsets) {
+			const definition = subsets.get(subset.definition);
+			assert(
+				definition,
+				`${id} references missing subset ${subset.definition}`,
+			);
+			assert(
+				!definition.slices,
+				`${id} named subset ${subset.definition} must not be sliced`,
+			);
+		}
+		if (slicing) {
+			const definition = subsets.get(slicing);
+			assert(definition, `${id} references missing slicing ${slicing}`);
+			assert(definition.slices, `${id} slicing ${slicing} must contain slices`);
+		}
 	}
 	validateDistributionResolution(distribution, family, id);
 	return { id, family };
 };
 
-const validateSubset = async (root: string, id: string): Promise<void> => {
+const validateSubset = async (
+	root: string,
+	id: string,
+): Promise<SubsetDefinition> => {
 	const definition = await validateCanonicalJson(
 		join(root, 'subsets', `${id}.json`),
 		subsetDefinitionSchema,
 	);
 	validateRanges(definition.ranges, id);
-	if (!definition.slices) return;
+	if (!definition.slices) return definition;
 	assertSortedUnique(
 		definition.slices,
 		(slice) => String(Number(slice.id)).padStart(8, '0'),
@@ -350,6 +370,7 @@ const validateSubset = async (root: string, id: string): Promise<void> => {
 	}
 	const expected = expandRanges(definition.ranges);
 	deepStrictEqual(union, expected, `${id} slice union differs from its ranges`);
+	return definition;
 };
 
 export const listFiles = async (root: string): Promise<string[]> =>
@@ -390,6 +411,13 @@ export const validateRegistry = async (root: string): Promise<void> => {
 	await validateCanonicalJson(join(root, 'upstreams.json'), upstreamsSchema);
 	const familyKeys = await listFamilyKeys(root);
 	const subsetIds = await listSubsetIds(root);
+	const subsets = new Map(
+		await Promise.all(
+			subsetIds.map(
+				async (id) => [id, await validateSubset(root, id)] as const,
+			),
+		),
+	);
 	const familyIds = new Set<string>();
 	for (const family of familyKeys) {
 		const { id } = parseFamilyKey(family);
@@ -426,14 +454,13 @@ export const validateRegistry = async (root: string): Promise<void> => {
 		);
 	}
 
-	const subsetSet = new Set(subsetIds);
 	let validated = 0;
 	const families = await Promise.all(
 		familyKeys.map(async (family) => {
 			const validatedFamily = await validateFamily(
 				root,
 				family,
-				subsetSet,
+				subsets,
 				taxonomy,
 				languages,
 			);
@@ -460,7 +487,6 @@ export const validateRegistry = async (root: string): Promise<void> => {
 			`Replacement target ${replacedBy} must be active`,
 		);
 	}
-	await Promise.all(subsetIds.map((id) => validateSubset(root, id)));
 	await validateCanonicalJson(join(root, 'axes.json'), axisRegistrySchema);
 
 	const allowed = new Set<string>([


### PR DESCRIPTION
## Overview

Models full repertoire, named subsets, and an optional family-wide slicing strategy as reviewed registry distribution intent.