### PR TITLE
feat(fonts): build composite distributions

### DIFF
--- a/api/tests/__snapshots__/cdn.test.ts.snap
+++ b/api/tests/__snapshots__/cdn.test.ts.snap
@@ -8,7 +8,7 @@ exports[`cdn routes > public asset outputs > generates correct CSS output 1`] = 
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(https://cdn.jsdelivr.net/fontsource/fonts/abel@5.0.0/latin-400-normal.woff2) format('woff2'),
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/abel@5.0.0/latin-400-normal.woff2) format(woff2),
        url(https://cdn.jsdelivr.net/fontsource/fonts/abel@5.0.0/latin-400-normal.woff) format('woff');
   unicode-range: U+0000-00FF;
 }",

--- a/packages/core/src/css/face-rule.ts
+++ b/packages/core/src/css/face-rule.ts
@@ -24,11 +24,13 @@ const getSourceValue = (
 		? resolver({ face, source })
 		: `./files/${source.filename}`;
 
-	let format = 'woff';
 	if (source.format === 'woff2') {
-		// Special format to make it clear to browsers that this is a variable font.
-		format = face.isVariable ? 'woff2-variations' : 'woff2';
-	} else if (source.format === 'ttf') {
+		const technology = face.isVariable ? ' tech(variations)' : '';
+		return `url(${url}) format(woff2)${technology}`;
+	}
+
+	let format = 'woff';
+	if (source.format === 'ttf') {
 		format = 'truetype';
 	}
 

--- a/packages/core/src/css/planner.ts
+++ b/packages/core/src/css/planner.ts
@@ -56,10 +56,11 @@ const pickVariableIndexCSS = (
 // italic face contributes to both `400-italic.css` and `latin-italic.css`.
 const groupFacesByCSSFile = (faces: FontFace[]): Map<string, FontFace[]> => {
 	const facesByCSSFile = new Map<string, FontFace[]>();
+	const useSlicedAggregate = faces.some((face) => face.sliceIndex > 0);
 
 	// Iterate over each face and assign it to the appropriate CSS files based on its properties.
 	for (const face of faces) {
-		for (const cssFile of getCSSFiles(face)) {
+		for (const cssFile of getCSSFiles(face, useSlicedAggregate)) {
 			const cssFaces = facesByCSSFile.get(cssFile);
 
 			if (cssFaces) {
@@ -73,22 +74,33 @@ const groupFacesByCSSFile = (faces: FontFace[]): Map<string, FontFace[]> => {
 	return facesByCSSFile;
 };
 
-const getCSSFiles = (face: FontFace): string[] => {
+const getCSSFiles = (face: FontFace, useSlicedAggregate = false): string[] => {
 	const style = formatStyle(face.style);
+	const isSlice = face.sliceIndex > 0;
+	const isAggregateFace = !useSlicedAggregate || isSlice;
 
 	if (face.isVariable) {
+		if (!isAggregateFace) return [];
+
 		const axisKey = face.axisKey ?? 'wght';
 		return [style === 'normal' ? `${axisKey}.css` : `${axisKey}-${style}.css`];
 	}
 
-	// Static packages publish both weight and subset entrypoints.
-	const assetFilenames = [
-		style === 'normal' ? `${face.weight}.css` : `${face.weight}-${style}.css`,
-		`${face.subset}.css`,
-	];
+	const assetFilenames = isAggregateFace
+		? [
+				style === 'normal'
+					? `${face.weight}.css`
+					: `${face.weight}-${style}.css`,
+			]
+		: [];
+
+	// Named subsets and full-repertoire builds keep their direct entrypoints.
+	if (!isSlice) {
+		assetFilenames.push(`${face.subset}.css`);
+	}
 
 	// Keep the legacy subset italic entrypoint.
-	if (style !== 'normal') {
+	if (!isSlice && style !== 'normal') {
 		assetFilenames.push(`${face.subset}-italic.css`);
 	}
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export { buildFont } from './processor';
 export type {
 	CSSAsset,
 	FontAsset,
+	FontBuildCharacters,
 	FontBuildConfig,
 	FontBuildResult,
 	FontConfig,
@@ -23,6 +24,7 @@ export type {
 	FontSource,
 	FontStyle,
 	StaticFontBuildConfig,
+	SubsetFontBuildCharacters,
 	VariableAxisConfig,
 	VariableAxisKey,
 	VariableFontAxis,

--- a/packages/core/src/processor.ts
+++ b/packages/core/src/processor.ts
@@ -144,20 +144,27 @@ export const buildFont = async (
 	);
 	const fontRefs = await glyphtContext.loadFonts(normalizedBuffers);
 	const familyId = config.id ?? normalizeKebabCase(config.family);
-	const keepAllCharacters = config.characters === 'all';
+	const characterConfig =
+		config.characters === 'all' ? undefined : config.characters;
+	const keepAllCharacters = characterConfig === undefined;
 	const subsets: ReturnType<typeof generateSubsetData> = keepAllCharacters
 		? new Map()
-		: generateSubsetData(config);
+		: generateSubsetData(characterConfig);
+	const slicing = characterConfig?.slicing
+		? generateSubsetData({
+				subsets: [characterConfig.slicing.subset],
+				subsetSources: {
+					[characterConfig.slicing.subset]: characterConfig.slicing.source,
+				},
+			}).get(characterConfig.slicing.subset)
+		: undefined;
 	const isVariableFont = config.type === 'variable';
 	const variableConfig =
 		config.type !== 'variable'
 			? undefined
-			: keepAllCharacters
-				? getSourceVariableConfig(fontRefs)
-				: config.variable;
+			: (config.variable ?? getSourceVariableConfig(fontRefs));
 
 	const families = sortFontsIntoFamilies(fontRefs);
-	const defaultSubset = keepAllCharacters ? 'full' : config.subsets[0];
 	const requestedFormats = new Set(config.formats ?? ['woff2']);
 	const exportFormats = {
 		woff: requestedFormats.has('woff'),
@@ -173,50 +180,82 @@ export const buildFont = async (
 		assetFormats.push('woff');
 	}
 
-	// Build `unicode-range` character sets.
-	const includeCharacters = keepAllCharacters
-		? []
-		: config.subsets.flatMap((subsetName) => {
-				const def = subsets.get(subsetName);
-				if (!def) return [];
+	type CharacterSet = Pick<FontFace, 'subset' | 'unicodeRange' | 'sliceIndex'>;
+	const characterSets = new Map<string, CharacterSet>();
+	const includeCharacters: Array<{
+		name: string;
+		includeUnicodeRanges: number[];
+	}> = [];
+	const addCharacterSet = (
+		characterSet: CharacterSet,
+		codepoints: number[],
+	) => {
+		const name = `fontsource-${characterSets.size + 1}`;
+		characterSets.set(name, characterSet);
+		includeCharacters.push({ name, includeUnicodeRanges: codepoints });
+	};
 
-				if (def.type === 'range') {
-					return [{ name: subsetName, includeUnicodeRanges: def.codepoints }];
-				}
-
-				return def.slices.map((slice) => ({
-					name: `${subsetName}-${slice.index}`,
-					includeUnicodeRanges: slice.codepoints,
-				}));
-			});
-	const subsetUnicodeRanges = new Map<string, string>();
-
-	for (const [subsetName, subsetDef] of subsets) {
-		if (subsetDef.type === 'range') {
-			subsetUnicodeRanges.set(subsetName, subsetDef.unicodeRange);
-			continue;
+	const addSubset = (
+		subsetName: string,
+		definition: NonNullable<ReturnType<typeof subsets.get>>,
+	) => {
+		if (definition.type === 'range') {
+			addCharacterSet(
+				{
+					subset: subsetName,
+					unicodeRange: definition.unicodeRange,
+					sliceIndex: 0,
+				},
+				definition.codepoints,
+			);
+			return;
 		}
 
-		for (const slice of subsetDef.slices) {
-			subsetUnicodeRanges.set(
-				`${subsetName}-${slice.index}`,
-				codepointsToRangeString(slice.codepoints),
+		for (const slice of definition.slices) {
+			addCharacterSet(
+				{
+					subset: subsetName,
+					unicodeRange: codepointsToRangeString(slice.codepoints),
+					sliceIndex: slice.index,
+				},
+				slice.codepoints,
 			);
 		}
+	};
+
+	for (const subsetName of characterConfig?.subsets ?? []) {
+		const definition = subsets.get(subsetName);
+		if (definition) addSubset(subsetName, definition);
 	}
+
+	if (characterConfig?.slicing) {
+		if (slicing?.type !== 'sliced') {
+			throw new Error(
+				`Slicing source for "${characterConfig.slicing.subset}" must contain slices`,
+			);
+		}
+		addSubset(characterConfig.slicing.subset, slicing);
+	}
+	if (!keepAllCharacters && characterSets.size === 0) {
+		throw new Error(
+			'At least one character subset or slicing source is required',
+		);
+	}
+
+	const fullCharacterSet: CharacterSet = {
+		subset: 'full',
+		unicodeRange: '',
+		sliceIndex: 0,
+	};
+	const defaultCharacterSet = keepAllCharacters
+		? fullCharacterSet
+		: characterSets.values().next().value;
 
 	// Build Glypht FamilySettings for each family.
 	const buildFamilySettings = (
 		variableConfig?: VariableAxisConfig,
 	): FamilySettings[] =>
 		families.map((family) => {
-			if (keepAllCharacters) {
-				return {
-					fonts: family.fonts,
-					enableSubsetting: false,
-				};
-			}
-
 			let fonts = isVariableFont
 				? family.fonts
 				: family.fonts.map(({ font, styleValues }) => ({
@@ -242,6 +281,23 @@ export const buildFont = async (
 						styleValues[styleKey] = setting;
 					} else {
 						axes[tag] = setting;
+					}
+				}
+
+				// Glypht preserves unspecified axes, so pin every source axis that
+				// does not belong to this published bundle.
+				for (const [styleKey, tag] of Object.entries(STYLE_VALUE_AXIS_MAP)) {
+					const styleValue = family.styleValues[styleKey as keyof StyleValues];
+					if (styleValue?.type === 'variable' && !variableConfig[tag]) {
+						styleValues[styleKey] = {
+							type: 'single',
+							value: styleValue.value.defaultValue,
+						};
+					}
+				}
+				for (const { tag, defaultValue } of family.axes) {
+					if (!variableConfig[tag]) {
+						axes[tag] = { type: 'single', value: defaultValue };
 					}
 				}
 			} else {
@@ -322,8 +378,8 @@ export const buildFont = async (
 				enableSubsetting: true,
 				styleValues,
 				axes,
-				features: config.featureSettings,
-				includeCharacters,
+				features: config.featureSettings ?? {},
+				includeCharacters: keepAllCharacters ? 'all' : includeCharacters,
 			};
 		});
 
@@ -331,9 +387,9 @@ export const buildFont = async (
 	const variableAxisKeys =
 		config.type !== 'variable'
 			? [undefined]
-			: keepAllCharacters
+			: keepAllCharacters && !config.axisKeys
 				? ['full']
-				: getRequestedAxisKeys(config.variable, config.axisKeys);
+				: getRequestedAxisKeys(variableConfig ?? {}, config.axisKeys);
 
 	// Generate a unique key for each face based on its defining properties.
 	const getFaceKey = (
@@ -383,26 +439,15 @@ export const buildFont = async (
 		for (const exported of exportedFonts) {
 			const { weight, style } = extractFontStyle(exported.font.styleValues);
 
-			const charsetName = (exported.charsetNameOrIndex ??
-				defaultSubset) as string;
-			if (!charsetName) continue;
+			const charsetName = exported.charsetNameOrIndex;
+			const characterSet = keepAllCharacters
+				? fullCharacterSet
+				: typeof charsetName === 'string'
+					? characterSets.get(charsetName)
+					: defaultCharacterSet;
+			if (!characterSet) continue;
 
-			// Handle sliced subsets by extracting the base subset name and slice index.
-			const sliceMatch = charsetName.match(/^(.+)-(\d+)$/);
-			const subsetName = sliceMatch
-				? (sliceMatch[1] ?? charsetName)
-				: charsetName;
-			const sliceIndex = sliceMatch
-				? Number.parseInt(sliceMatch[2] ?? '0', 10)
-				: 0;
-
-			const subsetDef = subsets.get(subsetName);
-			if (!keepAllCharacters && !subsetDef) continue;
-
-			const unicodeRange = keepAllCharacters
-				? undefined
-				: (subsetUnicodeRanges.get(charsetName) ??
-					subsetUnicodeRanges.get(subsetName));
+			const { subset: subsetName, sliceIndex, unicodeRange } = characterSet;
 
 			const faceStyle =
 				axisKey && axisConfig
@@ -463,7 +508,7 @@ export const buildFont = async (
 					weight: faceWeight,
 					style: faceStyle,
 					isVariable: isVariableFont,
-					unicodeRange: unicodeRange ?? '',
+					unicodeRange,
 					sources: [],
 					axisKey,
 					stretch: variableStretch,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,46 +86,36 @@ export interface FontConfig
 	variable?: VariableAxisConfig;
 }
 
-interface FontBuildFeatures {
-	featureSettings: Record<string, boolean>;
+export interface SubsetFontBuildCharacters {
+	subsets: string[];
+	subsetSources: Partial<UnicodeRangeMap>;
+	slicing?: {
+		subset: string;
+		source: string;
+	};
 }
 
-interface BaseFontBuildConfigFields extends FontIdentity, FontBuildFeatures {
-	weights: number[];
-	styles: FontStyle[];
-	unicodeRange?: UnicodeRangeMap;
+export type FontBuildCharacters = 'all' | SubsetFontBuildCharacters;
+
+interface BaseFontBuildConfigFields extends FontIdentity {
+	characters: FontBuildCharacters;
+	weights?: number[];
+	styles?: FontStyle[];
+	featureSettings?: Record<string, boolean>;
 	formats?: WebFontFormat[];
 }
 
-interface SubsetFontBuildConfigFields extends BaseFontBuildConfigFields {
-	characters?: undefined;
-	subsets: string[];
-	subsetSources: Partial<UnicodeRangeMap>;
-}
-
-interface FullFontBuildConfig
-	extends FontIdentity,
-		FormatOptions<WebFontFormat> {
-	type: 'static' | 'variable';
-	characters: 'all';
-	subsets?: never;
-	subsetSources?: never;
-}
-
-export interface StaticFontBuildConfig extends SubsetFontBuildConfigFields {
+export interface StaticFontBuildConfig extends BaseFontBuildConfigFields {
 	type: 'static';
 }
 
-export interface VariableFontBuildConfig extends SubsetFontBuildConfigFields {
+export interface VariableFontBuildConfig extends BaseFontBuildConfigFields {
 	type: 'variable';
-	variable: VariableAxisConfig;
+	variable?: VariableAxisConfig;
 	axisKeys?: VariableAxisKey[];
 }
 
-export type FontBuildConfig =
-	| StaticFontBuildConfig
-	| VariableFontBuildConfig
-	| FullFontBuildConfig;
+export type FontBuildConfig = StaticFontBuildConfig | VariableFontBuildConfig;
 
 export interface FontAsset extends FontSource {
 	content: Uint8Array;

--- a/packages/core/tests/__snapshots__/css/config-static.css
+++ b/packages/core/tests/__snapshots__/css/config-static.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -15,7 +15,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin.css */
@@ -25,7 +25,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -35,7 +35,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -45,7 +45,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -55,7 +55,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 400-italic.css */
@@ -65,7 +65,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -75,7 +75,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-italic.css */
@@ -85,7 +85,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -95,7 +95,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 700.css */
@@ -105,7 +105,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -115,7 +115,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* 700-italic.css */
@@ -125,7 +125,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -135,7 +135,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-ext.css */
@@ -145,7 +145,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -155,7 +155,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -165,7 +165,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -175,7 +175,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-ext-italic.css */
@@ -185,7 +185,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -195,7 +195,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* index.css */
@@ -205,7 +205,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -215,6 +215,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }

--- a/packages/core/tests/__snapshots__/css/config-variable.css
+++ b/packages/core/tests/__snapshots__/css/config-variable.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }
 /* wght-italic.css */
@@ -15,7 +15,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-italic.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-italic.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }
 /* index.css */
@@ -25,6 +25,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-bold.css
+++ b/packages/core/tests/__snapshots__/css/face-static-bold.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-display-block.css
+++ b/packages/core/tests/__snapshots__/css/face-static-display-block.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: block;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-italic.css
+++ b/packages/core/tests/__snapshots__/css/face-static-italic.css
@@ -4,6 +4,6 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-no-unicode-range.css
+++ b/packages/core/tests/__snapshots__/css/face-static-no-unicode-range.css
@@ -4,5 +4,5 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
 }

--- a/packages/core/tests/__snapshots__/css/face-static-oblique-decimal.css
+++ b/packages/core/tests/__snapshots__/css/face-static-oblique-decimal.css
@@ -4,6 +4,6 @@
   font-style: oblique 12.5deg;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-oblique-integer.css
+++ b/packages/core/tests/__snapshots__/css/face-static-oblique-integer.css
@@ -4,6 +4,6 @@
   font-style: oblique 10deg;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }

--- a/packages/core/tests/__snapshots__/css/face-static-resolver.css
+++ b/packages/core/tests/__snapshots__/css/face-static-resolver.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/inter-latin-400-normal.woff2) format('woff2');
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-static.css
+++ b/packages/core/tests/__snapshots__/css/face-static.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-already-named.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-already-named.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-fixed-slant.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-fixed-slant.css
@@ -4,6 +4,6 @@
   font-style: oblique 12deg;
   font-display: swap;
   font-weight: 300 600;
-  src: url(./files/testfont-latin-standard-italic.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-standard-italic.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-fixed-width.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-fixed-width.css
@@ -5,6 +5,6 @@
   font-display: swap;
   font-weight: 400;
   font-stretch: 100%;
-  src: url(./files/testfont-latin-wdth-normal.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-wdth-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-no-axis.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-no-axis.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/no-axis.woff2) format('woff2-variations');
+  src: url(./files/no-axis.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-slant-only.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-slant-only.css
@@ -4,6 +4,6 @@
   font-style: oblique 10deg 10deg;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/testfont-latin-slnt-italic.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-slnt-italic.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-slant.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-slant.css
@@ -4,6 +4,6 @@
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 400 700;
-  src: url(./files/testfont-latin-standard-italic.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-standard-italic.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-sliced.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-sliced.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-variable-1.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-variable-1.woff2) format(woff2) tech(variations);
   unicode-range: U+3041-3042;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-stretch.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-stretch.css
@@ -5,6 +5,6 @@
   font-display: swap;
   font-weight: 400;
   font-stretch: 75% 125%;
-  src: url(./files/testfont-latin-wdth-normal.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-wdth-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/face-variable-wght.css
+++ b/packages/core/tests/__snapshots__/css/face-variable-wght.css
@@ -4,6 +4,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-static-asymmetric.css
+++ b/packages/core/tests/__snapshots__/css/grouped-static-asymmetric.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* latin.css */
@@ -15,7 +15,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -25,7 +25,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -35,7 +35,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 400-italic.css */
@@ -45,7 +45,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* latin-italic.css */
@@ -55,7 +55,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 700.css */
@@ -65,7 +65,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* index.css */
@@ -75,6 +75,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-static-comprehensive.css
+++ b/packages/core/tests/__snapshots__/css/grouped-static-comprehensive.css
@@ -1,44 +1,3 @@
-/* 400.css */
-/* inter-latin-400-normal */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2'),
-       url(./files/inter-latin-400-normal.woff) format('woff');
-  unicode-range: U+0000-00FF;
-}
-
-/* inter-latin-ext-400-normal */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
-  unicode-range: U+0100-024F;
-}
-
-/* inter-japanese-400-normal-1 */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-1.woff2) format('woff2');
-  unicode-range: U+3041-3042;
-}
-
-/* inter-japanese-400-normal-2 */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-2.woff2) format('woff2');
-  unicode-range: U+3044-3045;
-}
 /* latin.css */
 /* inter-latin-400-normal */
 @font-face {
@@ -46,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2'),
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2),
        url(./files/inter-latin-400-normal.woff) format('woff');
   unicode-range: U+0000-00FF;
 }
@@ -57,17 +16,17 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
-/* japanese.css */
+/* 400.css */
 /* inter-japanese-400-normal-1 */
 @font-face {
   font-family: 'Inter';
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-1.woff2) format('woff2');
+  src: url(./files/inter-japanese-400-normal-1.woff2) format(woff2);
   unicode-range: U+3041-3042;
 }
 
@@ -77,38 +36,17 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-2.woff2) format('woff2');
+  src: url(./files/inter-japanese-400-normal-2.woff2) format(woff2);
   unicode-range: U+3044-3045;
 }
 /* index.css */
-/* inter-latin-400-normal */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2'),
-       url(./files/inter-latin-400-normal.woff) format('woff');
-  unicode-range: U+0000-00FF;
-}
-
-/* inter-latin-ext-400-normal */
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
-  unicode-range: U+0100-024F;
-}
-
 /* inter-japanese-400-normal-1 */
 @font-face {
   font-family: 'Inter';
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-1.woff2) format('woff2');
+  src: url(./files/inter-japanese-400-normal-1.woff2) format(woff2);
   unicode-range: U+3041-3042;
 }
 
@@ -118,6 +56,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-japanese-400-normal-2.woff2) format('woff2');
+  src: url(./files/inter-japanese-400-normal-2.woff2) format(woff2);
   unicode-range: U+3044-3045;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-static-full.css
+++ b/packages/core/tests/__snapshots__/css/grouped-static-full.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -15,7 +15,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin.css */
@@ -25,7 +25,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -35,7 +35,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -45,7 +45,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -55,7 +55,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 400-italic.css */
@@ -65,7 +65,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -75,7 +75,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-italic.css */
@@ -85,7 +85,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -95,7 +95,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* 700.css */
@@ -105,7 +105,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-700-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -115,7 +115,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* 700-italic.css */
@@ -125,7 +125,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-700-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -135,7 +135,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-ext.css */
@@ -145,7 +145,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -155,7 +155,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -165,7 +165,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -175,7 +175,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* latin-ext-italic.css */
@@ -185,7 +185,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 
@@ -195,7 +195,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url(./files/inter-latin-ext-700-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-700-italic.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }
 /* index.css */
@@ -205,7 +205,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-400-normal.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 
@@ -215,6 +215,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-ext-400-normal.woff2) format('woff2');
+  src: url(./files/inter-latin-ext-400-normal.woff2) format(woff2);
   unicode-range: U+0100-024F;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-static-italic-only.css
+++ b/packages/core/tests/__snapshots__/css/grouped-static-italic-only.css
@@ -5,7 +5,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* latin.css */
@@ -15,7 +15,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* latin-italic.css */
@@ -25,7 +25,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }
 /* index.css */
@@ -35,6 +35,6 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/inter-latin-400-italic.woff2) format('woff2');
+  src: url(./files/inter-latin-400-italic.woff2) format(woff2);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-variable-comprehensive.css
+++ b/packages/core/tests/__snapshots__/css/grouped-variable-comprehensive.css
@@ -1,22 +1,11 @@
 /* wght.css */
-/* inter-latin-wght-normal */
-@font-face {
-  font-family: 'Inter Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations'),
-       url(./files/inter-latin-wght-normal.woff) format('woff');
-  unicode-range: U+0000-00FF;
-}
-
 /* inter-japanese-wght-normal-1 */
 @font-face {
   font-family: 'Inter Variable';
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-1.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+3041-3042;
 }
 
@@ -26,38 +15,17 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-2.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+3044-3045;
 }
-/* slnt-italic.css */
-/* inter-latin-ext-slnt-italic */
-@font-face {
-  font-family: 'Inter Variable';
-  font-style: oblique 10deg 10deg;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/inter-latin-ext-slnt-italic.woff2) format('woff2-variations');
-  unicode-range: U+0100-024F;
-}
 /* index.css */
-/* inter-latin-wght-normal */
-@font-face {
-  font-family: 'Inter Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations'),
-       url(./files/inter-latin-wght-normal.woff) format('woff');
-  unicode-range: U+0000-00FF;
-}
-
 /* inter-japanese-wght-normal-1 */
 @font-face {
   font-family: 'Inter Variable';
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-1.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+3041-3042;
 }
 
@@ -67,6 +35,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-2.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+3044-3045;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-variable-multiple-formats.css
+++ b/packages/core/tests/__snapshots__/css/grouped-variable-multiple-formats.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400 600;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations'),
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations),
        url(./files/inter-latin-wght-normal.woff) format('woff');
   unicode-range: U+0000-00FF;
 }
@@ -16,7 +16,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400 600;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations'),
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations),
        url(./files/inter-latin-wght-normal.woff) format('woff');
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-variable-sliced.css
+++ b/packages/core/tests/__snapshots__/css/grouped-variable-sliced.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-1.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+3041-3042;
 }
 
@@ -15,7 +15,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-2.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+3044-3045;
 }
 /* index.css */
@@ -25,7 +25,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-1.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+3041-3042;
 }
 
@@ -35,6 +35,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 300 800;
-  src: url(./files/inter-japanese-wght-normal-2.woff2) format('woff2-variations');
+  src: url(./files/inter-japanese-wght-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+3044-3045;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-variable-wdth.css
+++ b/packages/core/tests/__snapshots__/css/grouped-variable-wdth.css
@@ -6,7 +6,7 @@
   font-display: swap;
   font-weight: 400;
   font-stretch: 75% 125%;
-  src: url(./files/testfont-latin-wdth-normal.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-wdth-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }
 /* index.css */
@@ -17,6 +17,6 @@
   font-display: swap;
   font-weight: 400;
   font-stretch: 75% 125%;
-  src: url(./files/testfont-latin-wdth-normal.woff2) format('woff2-variations');
+  src: url(./files/testfont-latin-wdth-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/css/grouped-variable-wght.css
+++ b/packages/core/tests/__snapshots__/css/grouped-variable-wght.css
@@ -5,7 +5,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }
 /* wght-italic.css */
@@ -15,7 +15,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-italic.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-italic.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }
 /* index.css */
@@ -25,6 +25,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url(./files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/inter-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+0000-00FF;
 }

--- a/packages/core/tests/__snapshots__/processor.test.ts.snap
+++ b/packages/core/tests/__snapshots__/processor.test.ts.snap
@@ -10,7 +10,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: normal;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-wght-normal-1.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-wght-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+42;
 }
 
@@ -20,7 +20,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: normal;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-wght-normal-2.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-wght-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+41;
 }",
       "filename": "wght.css",
@@ -32,7 +32,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-slnt-normal-1.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-slnt-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+42;
 }
 
@@ -42,7 +42,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-slnt-normal-2.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-slnt-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+41;
 }",
       "filename": "slnt-italic.css",
@@ -54,7 +54,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-standard-normal-1.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-standard-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+42;
 }
 
@@ -64,7 +64,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-standard-normal-2.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-standard-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+41;
 }",
       "filename": "standard-italic.css",
@@ -76,7 +76,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-standard-normal-1.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-standard-normal-1.woff2) format(woff2) tech(variations);
   unicode-range: U+42;
 }
 
@@ -86,7 +86,7 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-standard-normal-2.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-standard-normal-2.woff2) format(woff2) tech(variations);
   unicode-range: U+41;
 }",
       "filename": "index.css",
@@ -194,32 +194,32 @@ exports[`buildFont integration with real fixtures > builds variable slices for r
     {
       "filename": "files/recursive-latin-wght-normal-1.woff2",
       "format": "woff2",
-      "size": 7704,
+      "size": 1888,
     },
     {
       "filename": "files/recursive-latin-wght-normal-2.woff2",
       "format": "woff2",
-      "size": 8408,
+      "size": 1816,
     },
     {
       "filename": "files/recursive-latin-slnt-normal-1.woff2",
       "format": "woff2",
-      "size": 7720,
+      "size": 2996,
     },
     {
       "filename": "files/recursive-latin-slnt-normal-2.woff2",
       "format": "woff2",
-      "size": 8368,
+      "size": 2852,
     },
     {
       "filename": "files/recursive-latin-standard-normal-1.woff2",
       "format": "woff2",
-      "size": 7720,
+      "size": 2996,
     },
     {
       "filename": "files/recursive-latin-standard-normal-2.woff2",
       "format": "woff2",
-      "size": 8368,
+      "size": 2852,
     },
   ],
 }
@@ -235,7 +235,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: normal;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-wght-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-wght-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "wght.css",
@@ -247,7 +247,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-slnt-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-slnt-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "slnt-italic.css",
@@ -259,7 +259,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: normal;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-casl-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-casl-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "CASL.css",
@@ -271,7 +271,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-standard-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-standard-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "standard-italic.css",
@@ -283,7 +283,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-full-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-full-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "full-italic.css",
@@ -295,7 +295,7 @@ exports[`buildFont integration with real fixtures > emits every published axis k
   font-style: oblique 0deg 15deg;
   font-display: swap;
   font-weight: 300 1000;
-  src: url(./files/recursive-latin-full-normal.woff2) format('woff2-variations');
+  src: url(./files/recursive-latin-full-normal.woff2) format(woff2) tech(variations);
   unicode-range: U+20-22;
 }",
       "filename": "index.css",
@@ -387,27 +387,27 @@ exports[`buildFont integration with real fixtures > emits every published axis k
     {
       "filename": "files/recursive-latin-wght-normal.woff2",
       "format": "woff2",
-      "size": 8472,
+      "size": 1768,
     },
     {
       "filename": "files/recursive-latin-slnt-normal.woff2",
       "format": "woff2",
-      "size": 8440,
+      "size": 2684,
     },
     {
       "filename": "files/recursive-latin-casl-normal.woff2",
       "format": "woff2",
-      "size": 8472,
+      "size": 2924,
     },
     {
       "filename": "files/recursive-latin-standard-normal.woff2",
       "format": "woff2",
-      "size": 8440,
+      "size": 2684,
     },
     {
       "filename": "files/recursive-latin-full-normal.woff2",
       "format": "woff2",
-      "size": 8440,
+      "size": 4708,
     },
   ],
 }
@@ -423,7 +423,7 @@ exports[`buildFont integration with real fixtures > infers static metadata and g
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal.woff2) format(woff2),
        url(./files/abel-latin-400-normal.woff) format('woff');
   unicode-range: U+20-22;
 }",
@@ -436,7 +436,7 @@ exports[`buildFont integration with real fixtures > infers static metadata and g
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal.woff2) format(woff2),
        url(./files/abel-latin-400-normal.woff) format('woff');
   unicode-range: U+20-22;
 }",
@@ -449,7 +449,7 @@ exports[`buildFont integration with real fixtures > infers static metadata and g
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal.woff2) format(woff2),
        url(./files/abel-latin-400-normal.woff) format('woff');
   unicode-range: U+20-22;
 }",
@@ -503,7 +503,7 @@ exports[`buildFont integration with real fixtures > preserves sliced static subs
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal-1.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal-1.woff2) format(woff2),
        url(./files/abel-latin-400-normal-1.woff) format('woff');
   unicode-range: U+42;
 }
@@ -514,7 +514,7 @@ exports[`buildFont integration with real fixtures > preserves sliced static subs
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal-2.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal-2.woff2) format(woff2),
        url(./files/abel-latin-400-normal-2.woff) format('woff');
   unicode-range: U+41;
 }",
@@ -527,7 +527,7 @@ exports[`buildFont integration with real fixtures > preserves sliced static subs
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal-1.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal-1.woff2) format(woff2),
        url(./files/abel-latin-400-normal-1.woff) format('woff');
   unicode-range: U+42;
 }
@@ -538,31 +538,7 @@ exports[`buildFont integration with real fixtures > preserves sliced static subs
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url(./files/abel-latin-400-normal-2.woff2) format('woff2'),
-       url(./files/abel-latin-400-normal-2.woff) format('woff');
-  unicode-range: U+41;
-}",
-      "filename": "latin.css",
-    },
-    {
-      "content": "/* abel-latin-400-normal-1 */
-@font-face {
-  font-family: 'Abel';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/abel-latin-400-normal-1.woff2) format('woff2'),
-       url(./files/abel-latin-400-normal-1.woff) format('woff');
-  unicode-range: U+42;
-}
-
-/* abel-latin-400-normal-2 */
-@font-face {
-  font-family: 'Abel';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(./files/abel-latin-400-normal-2.woff2) format('woff2'),
+  src: url(./files/abel-latin-400-normal-2.woff2) format(woff2),
        url(./files/abel-latin-400-normal-2.woff) format('woff');
   unicode-range: U+41;
 }",

--- a/packages/core/tests/css-planner.test.ts
+++ b/packages/core/tests/css-planner.test.ts
@@ -127,6 +127,25 @@ describe('css planner', () => {
 		expect(assetPlan.get('wght.css')).toEqual(faces);
 	});
 
+	it('uses slices for aggregate CSS and named faces for subset CSS', () => {
+		const named = staticFace({
+			subset: 'latin',
+			weight: 400,
+			filename: 'latin.woff2',
+		});
+		const sliced = staticFace({
+			subset: 'japanese',
+			weight: 400,
+			sliceIndex: 1,
+			filename: 'japanese-1.woff2',
+		});
+		const assetPlan = groupFacesByCSSFile([named, sliced]);
+
+		expect(assetPlan.get('latin.css')).toEqual([named]);
+		expect(assetPlan.get('400.css')).toEqual([sliced]);
+		expect(assetPlan.has('japanese.css')).toBe(false);
+	});
+
 	it('selects a normal static asset for index.css before falling back to italic', () => {
 		const faces = [
 			staticFace({

--- a/packages/core/tests/processor.test.ts
+++ b/packages/core/tests/processor.test.ts
@@ -129,19 +129,50 @@ describe('buildFont integration with real fixtures', () => {
 		expect(result.faces[0]?.weight).toBe('300 1000');
 	});
 
+	it('publishes standard and full variable bundles for the full repertoire', async () => {
+		const result = await buildWithFixture(loadVariableFontFixture(), {
+			type: 'variable',
+			id: 'recursive',
+			family: 'Recursive',
+			characters: 'all',
+			axisKeys: ['standard', 'full'],
+			formats: ['woff2'],
+		});
+
+		expect(result.fonts.map((font) => font.filename)).toEqual([
+			'files/recursive-full-standard-normal.woff2',
+			'files/recursive-full-full-normal.woff2',
+		]);
+		expect(result.faces.map((face) => face.axisKey)).toEqual([
+			'standard',
+			'full',
+		]);
+
+		const ctx = createFontContext();
+		try {
+			const [standard, full] = await Promise.all(
+				result.fonts.map((font) => inspectFont(ctx, font.content)),
+			);
+			expect(standard?.axes.map((axis) => axis.tag)).not.toContain('CASL');
+			expect(full?.axes.map((axis) => axis.tag)).toContain('CASL');
+		} finally {
+			ctx.destroy();
+		}
+	}, 10_000);
+
 	it('builds static weights and styles without retaining variable axes', async () => {
 		const result = await buildWithFixture(loadVariableFontFixture(), {
 			type: 'static',
 			id: 'recursive',
 			family: 'Recursive',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+			},
 			weights: [400, 700],
 			styles: ['normal', 'italic'],
 			formats: ['woff2'],
 			featureSettings: {},
-			subsetSources: {
-				latin: latinRangeSubset,
-			},
 		});
 		const ctx = createFontContext();
 
@@ -173,18 +204,50 @@ describe('buildFont integration with real fixtures', () => {
 		}
 	});
 
+	it('builds full static variants from a variable source', async () => {
+		const result = await buildWithFixture(loadVariableFontFixture(), {
+			type: 'static',
+			id: 'recursive',
+			family: 'Recursive',
+			characters: 'all',
+			weights: [400, 700],
+			styles: ['normal'],
+			formats: ['woff2'],
+		});
+		const ctx = createFontContext();
+
+		try {
+			const inspections = await Promise.all(
+				result.fonts.map((font) => inspectFont(ctx, font.content)),
+			);
+
+			expect(result.fonts.map((font) => font.filename)).toEqual([
+				'files/recursive-full-400-normal.woff2',
+				'files/recursive-full-700-normal.woff2',
+			]);
+			expect(inspections.map(({ weight, axes }) => ({ weight, axes }))).toEqual(
+				[
+					{ weight: 400, axes: [] },
+					{ weight: 700, axes: [] },
+				],
+			);
+		} finally {
+			ctx.destroy();
+		}
+	});
+
 	it('does not synthesize styles missing from the source faces', async () => {
 		const result = await buildWithFixture(loadStaticFontFixture(), {
 			type: 'static',
 			family: 'Abel',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+			},
 			weights: [400],
 			styles: ['normal', 'italic'],
 			formats: ['woff2'],
 			featureSettings: {},
-			subsetSources: {
-				latin: latinRangeSubset,
-			},
 		});
 
 		expect(result.fonts.map((font) => font.filename)).toEqual([
@@ -223,14 +286,14 @@ describe('buildFont integration with real fixtures', () => {
 		const result = await buildWithFixture(loadStaticFontFixture(), {
 			type: 'static',
 			family: 'Abel',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+			},
 			weights: [],
 			styles: [],
 			formats: ['woff2', 'woff'],
 			featureSettings: {},
-			subsetSources: {
-				latin: latinRangeSubset,
-			},
 		});
 
 		expect(result.faces).toHaveLength(1);
@@ -247,14 +310,14 @@ describe('buildFont integration with real fixtures', () => {
 		const result = await buildWithFixture(loadStaticFontFixture(), {
 			type: 'static',
 			family: 'Abel',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinSlicingSubset },
+			},
 			weights: [],
 			styles: [],
 			formats: ['woff2', 'woff'],
 			featureSettings: {},
-			subsetSources: {
-				latin: latinSlicingSubset,
-			},
 		});
 
 		expect(result.faces.map((face) => face.sliceIndex)).toEqual([1, 2]);
@@ -262,12 +325,46 @@ describe('buildFont integration with real fixtures', () => {
 		expect(serialisePackage(result)).toMatchSnapshot();
 	});
 
+	it('keeps named subset entrypoints separate from sliced aggregate CSS', async () => {
+		const result = await buildWithFixture(loadStaticFontFixture(), {
+			type: 'static',
+			family: 'Abel',
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+				slicing: {
+					subset: 'japanese',
+					source: latinSlicingSubset,
+				},
+			},
+			formats: ['woff2'],
+		});
+
+		expect(result.fonts.map((font) => font.filename)).toEqual([
+			'files/abel-latin-400-normal.woff2',
+			'files/abel-japanese-400-normal-1.woff2',
+			'files/abel-japanese-400-normal-2.woff2',
+		]);
+
+		const latin = result.css.find((asset) => asset.filename === 'latin.css');
+		const weight = result.css.find((asset) => asset.filename === '400.css');
+
+		expect(latin?.content).toContain('abel-latin-400-normal.woff2');
+		expect(latin?.content).not.toContain('abel-japanese');
+		expect(weight?.content).not.toContain('abel-latin');
+		expect(weight?.content).toContain('abel-japanese-400-normal-1.woff2');
+		expect(weight?.content).toContain('abel-japanese-400-normal-2.woff2');
+	});
+
 	it('builds variable slices for real standard-axis data', async () => {
 		const result = await buildWithFixture(loadVariableFontFixture(), {
 			type: 'variable',
 			id: 'recursive',
 			family: 'Recursive',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinSlicingSubset },
+			},
 			weights: [],
 			styles: ['normal'],
 			formats: ['woff2'],
@@ -275,9 +372,6 @@ describe('buildFont integration with real fixtures', () => {
 			variable: {
 				wght: { min: 300, max: 1000 },
 				slnt: { min: -15, max: 0 },
-			},
-			subsetSources: {
-				latin: latinSlicingSubset,
 			},
 		});
 
@@ -295,7 +389,10 @@ describe('buildFont integration with real fixtures', () => {
 			type: 'variable',
 			id: 'recursive',
 			family: 'Recursive',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+			},
 			weights: [],
 			styles: ['normal'],
 			formats: ['woff2'],
@@ -304,9 +401,6 @@ describe('buildFont integration with real fixtures', () => {
 				wght: { min: 300, max: 1000 },
 				slnt: { min: -15, max: 0 },
 				CASL: { min: 0, max: 1 },
-			},
-			subsetSources: {
-				latin: latinRangeSubset,
 			},
 		});
 
@@ -330,7 +424,10 @@ describe('buildFont integration with real fixtures', () => {
 			type: 'variable',
 			id: 'recursive',
 			family: 'Recursive',
-			subsets: ['latin'],
+			characters: {
+				subsets: ['latin'],
+				subsetSources: { latin: latinRangeSubset },
+			},
 			weights: [],
 			styles: ['normal'],
 			formats: ['woff2'],
@@ -340,9 +437,6 @@ describe('buildFont integration with real fixtures', () => {
 				MONO: { min: 0, max: 1 },
 				wght: { min: 300, max: 1000 },
 				slnt: { min: -15, max: 0 },
-			},
-			subsetSources: {
-				latin: latinRangeSubset,
 			},
 		});
 


### PR DESCRIPTION
Depends on #1224

## Overview

Extends Core builds to process full repertoires, named subsets, and optional numbered slicing from one character distribution. Aggregate CSS uses slices when present, named subset entrypoints remain available, variable `standard` and `full` bundles are instanced correctly, and generated WOFF2 CSS uses the current font format syntax.