### PR TITLE
feat(registry): expose preview source

### DIFF
--- a/api/shared/registry.ts
+++ b/api/shared/registry.ts
@@ -162,7 +162,25 @@ export const RegistryFamilyDetailSchema = FamilySummarySchema.extend({
 		})
 		.optional(),
 	sources: z.array(RegistrySourceSchema).min(1),
+	previewSource: Sha256Schema.describe(
+		'Representative distributed source for previews and capability inspection',
+	),
 	distribution: RegistryDistributionSchema,
+}).superRefine((family, context) => {
+	const sourceExists = family.sources.some(
+		(source) => source.sha256 === family.previewSource,
+	);
+	const isDistributed = [
+		...(family.distribution.static ?? []),
+		...(family.distribution.variable ?? []),
+	].some((variant) => variant.source === family.previewSource);
+	if (!sourceExists || !isDistributed) {
+		context.addIssue({
+			code: 'custom',
+			message: 'previewSource must reference a distributed source',
+			path: ['previewSource'],
+		});
+	}
 });
 
 export const RegistryFamilySymbolsSchema = z

--- a/api/shared/registry.ts
+++ b/api/shared/registry.ts
@@ -163,7 +163,7 @@ export const RegistryFamilyDetailSchema = FamilySummarySchema.extend({
 		.optional(),
 	sources: z.array(RegistrySourceSchema).min(1),
 	previewSource: Sha256Schema.describe(
-		'Representative distributed source for previews and capability inspection',
+		'Distributed source selected for default previews and source-scoped capability inspection',
 	),
 	distribution: RegistryDistributionSchema,
 }).superRefine((family, context) => {

--- a/api/tests/registry.test.ts
+++ b/api/tests/registry.test.ts
@@ -48,6 +48,7 @@ const VIEWS = [
 				url: 'https://openfontlicense.org',
 				text: 'Test license',
 			},
+			previewSource: SOURCE_SHA256,
 			symbols: {
 				catalogUrl: '/v1/registry/families/abel/symbols',
 				inputModes: ['codepoint', 'name-ligature'],

--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -187,18 +187,17 @@ describe('registry source archive', () => {
 		const ibmPlexMono = RegistryFamilyDetailSchema.parse(
 			views.get('families/ibm-plex-mono.json'),
 		);
+		expect(ibmPlexMono.previewSource).toBe(
+			ibmPlexMono.distribution.static?.find(
+				(variant) => variant.weight === 400 && variant.style === 'normal',
+			)?.source,
+		);
+		const ibmPlexMonoCapabilities = views.get(
+			`sources/${ibmPlexMono.previewSource}/capabilities.json`,
+		);
 		expect(
-			ibmPlexMono.sources.find(
-				(source) => source.sha256 === ibmPlexMono.previewSource,
-			),
-		).toMatchObject({
-			filename: 'IBMPlexMono-Regular.ttf',
-			weight: 400,
-			style: 'normal',
-		});
-		expect(
-			views.get(`sources/${ibmPlexMono.previewSource}/capabilities.json`),
-		).toMatchObject({ glyphCount: 1033, codepointCount: 930 });
+			RegistrySourceCapabilitiesSchema.parse(ibmPlexMonoCapabilities),
+		).toEqual(ibmPlexMonoCapabilities);
 		const familySource = (
 			family as {
 				sources: Array<{ sha256: string }>;
@@ -221,9 +220,15 @@ describe('registry source archive', () => {
 		expect(RegistrySourceCapabilitiesSchema.parse(capabilities)).toEqual(
 			capabilities,
 		);
-		const multiSourceFamily = views.get('families/adwaita-sans.json') as {
-			sources: Array<{ sha256: string }>;
-		};
+		const multiSourceFamily = RegistryFamilyDetailSchema.parse(
+			views.get('families/adwaita-sans.json'),
+		);
+		expect(multiSourceFamily.previewSource).toBe(
+			multiSourceFamily.distribution.variable?.find(
+				(variant) =>
+					variant.axisKey === 'standard' && variant.style === 'normal',
+			)?.source,
+		);
 		const multiSourceCapabilities = multiSourceFamily.sources.map((source) =>
 			views.get(`sources/${source.sha256}/capabilities.json`),
 		) as Array<{ unicodeRange: string }>;

--- a/registry/scripts/archive.test.ts
+++ b/registry/scripts/archive.test.ts
@@ -44,6 +44,7 @@ describe('registry source archive', () => {
 			'families/dejavu-math.json',
 			'families/dseg7-classic.json',
 			'families/ek-mukta.json',
+			'families/ibm-plex-mono.json',
 			'families/jsmath-cmr10.json',
 			'families/material-icons.json',
 			'families/material-icons/symbols.json',
@@ -81,7 +82,8 @@ describe('registry source archive', () => {
 						views.set(path, value);
 						if (
 							path === 'families/abel.json' ||
-							path === 'families/adwaita-sans.json'
+							path === 'families/adwaita-sans.json' ||
+							path === 'families/ibm-plex-mono.json'
 						) {
 							for (const source of value.sources) {
 								wantedViews.add(`sources/${source.sha256}/capabilities.json`);
@@ -166,6 +168,7 @@ describe('registry source archive', () => {
 					subsets: [{ id: 'latin', definition: 'latin' }],
 				},
 			},
+			previewSource: expect.stringMatching(/^[0-9a-f]{64}$/),
 			sources: [
 				expect.objectContaining({
 					format: 'ttf',
@@ -181,6 +184,21 @@ describe('registry source archive', () => {
 			],
 		});
 		expect(RegistryFamilyDetailSchema.parse(family)).toEqual(family);
+		const ibmPlexMono = RegistryFamilyDetailSchema.parse(
+			views.get('families/ibm-plex-mono.json'),
+		);
+		expect(
+			ibmPlexMono.sources.find(
+				(source) => source.sha256 === ibmPlexMono.previewSource,
+			),
+		).toMatchObject({
+			filename: 'IBMPlexMono-Regular.ttf',
+			weight: 400,
+			style: 'normal',
+		});
+		expect(
+			views.get(`sources/${ibmPlexMono.previewSource}/capabilities.json`),
+		).toMatchObject({ glyphCount: 1033, codepointCount: 930 });
 		const familySource = (
 			family as {
 				sources: Array<{ sha256: string }>;

--- a/registry/scripts/archive.ts
+++ b/registry/scripts/archive.ts
@@ -87,6 +87,36 @@ const sourceCapabilities = (source: FamilySource) =>
 		colorTables: source.inspection.colorTables,
 	});
 
+const selectPreviewSource = (
+	distribution: ReturnType<typeof resolveDistributionSources>,
+): string => {
+	// Prefer the normal variable source that represents the package's standard
+	// axes. It gives previews the broadest useful style range from one source.
+	const variable =
+		distribution.variable?.find(
+			(variant) => variant.axisKey === 'standard' && variant.style === 'normal',
+		) ??
+		distribution.variable?.find((variant) => variant.style === 'normal') ??
+		distribution.variable?.find((variant) => variant.axisKey === 'standard') ??
+		distribution.variable?.[0];
+	if (variable) return variable.source;
+
+	const staticSource = distribution.static
+		?.toSorted((left, right) => {
+			const leftStyle = left.style === 'normal' ? 0 : 1;
+			const rightStyle = right.style === 'normal' ? 0 : 1;
+			return (
+				leftStyle - rightStyle ||
+				Math.abs(left.weight - 400) - Math.abs(right.weight - 400) ||
+				right.weight - left.weight
+			);
+		})
+		.at(0);
+	if (staticSource) return staticSource.source;
+
+	throw new Error('Registry distribution has no preview source');
+};
+
 const createArchivePlan = async (root: string, registryRevision: string) => {
 	await validateRegistry(root);
 
@@ -156,6 +186,7 @@ const createArchivePlan = async (root: string, registryRevision: string) => {
 					? ({ type: 'all' } as const)
 					: ({ type: 'subsets', ...distribution.characters } as const),
 		};
+		const previewSource = selectPreviewSource(publicDistribution);
 		const axes = [
 			...new Set(
 				family.sources.flatMap(({ inspection }) =>
@@ -245,6 +276,7 @@ const createArchivePlan = async (root: string, registryRevision: string) => {
 							}
 						: undefined,
 					sources,
+					previewSource,
 					distribution: publicDistribution,
 				}),
 			),

--- a/website/app/generated/api/types.gen.ts
+++ b/website/app/generated/api/types.gen.ts
@@ -889,7 +889,7 @@ export type GetRegistryFamilyResponses = {
             }>;
         }>;
         /**
-         * Representative distributed source for previews and capability inspection
+         * Distributed source selected for default previews and source-scoped capability inspection
          */
         previewSource: string;
         distribution: {

--- a/website/app/generated/api/types.gen.ts
+++ b/website/app/generated/api/types.gen.ts
@@ -888,6 +888,10 @@ export type GetRegistryFamilyResponses = {
                 default: number;
             }>;
         }>;
+        /**
+         * Representative distributed source for previews and capability inspection
+         */
+        previewSource: string;
         distribution: {
             static?: Array<{
                 weight: number;


### PR DESCRIPTION
## Overview

Adds a deterministic `previewSource` to each public Registry family so clients can load one valid distributed source without duplicating selection policy. Capabilities remain explicitly source-scoped rather than implying family-wide coverage.