### PR TITLE
feat(registry): publish material symbol categories

### DIFF
--- a/api/shared/registry.ts
+++ b/api/shared/registry.ts
@@ -188,6 +188,7 @@ export const RegistryFamilySymbolsSchema = z
 		z.strictObject({
 			name: z.string().min(1).regex(/^\S+$/),
 			codepoint: UnicodeScalarSchema,
+			categories: z.array(IdSchema).min(1).optional(),
 		}),
 	)
 	.min(1);

--- a/api/tests/registry.test.ts
+++ b/api/tests/registry.test.ts
@@ -82,7 +82,7 @@ const VIEWS = [
 		path: 'families/abel/symbols.json',
 		route: '/v1/registry/families/abel/symbols',
 		body: RegistryFamilySymbolsSchema.parse([
-			{ name: 'home', codepoint: 0xe88a },
+			{ name: 'home', codepoint: 0xe88a, categories: ['action', 'symbols'] },
 		]),
 	},
 	{

--- a/registry/scripts/google-icons.ts
+++ b/registry/scripts/google-icons.ts
@@ -19,6 +19,7 @@ const LICENSE = {
 	url: 'https://www.apache.org/licenses/LICENSE-2.0',
 } as const;
 const TAGS = ['special-use/icons'] as const;
+const CATEGORIES_PATH = 'update/current_versions.json';
 
 type FamilyDefinition = {
 	id: string;
@@ -81,10 +82,40 @@ const FAMILIES: readonly FamilyDefinition[] = [
 const codepointsPath = (fontPath: string): string =>
 	`${fontPath.slice(0, -extname(fontPath).length)}.codepoints`;
 
+const readIconCategories = (snapshot: GitSnapshot) => {
+	const contents = snapshot.read(CATEGORIES_PATH);
+	const value: unknown = JSON.parse(contents.toString('utf8'));
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error(`${CATEGORIES_PATH} is not an object`);
+	}
+
+	const categories = new Map<string, string[]>();
+	for (const key of Object.keys(value)) {
+		const [category, name, ...rest] = key.split('::');
+		if (!category || !name || rest.length > 0) {
+			throw new Error(`${CATEGORIES_PATH} has an invalid key: ${key}`);
+		}
+		const current = categories.get(name) ?? [];
+		current.push(category);
+		categories.set(name, current);
+	}
+
+	const changed = snapshot.lastChanged(CATEGORIES_PATH);
+	return {
+		categories,
+		source: {
+			revision: changed.revision,
+			path: CATEGORIES_PATH,
+			sha256: sha256(contents),
+		},
+	};
+};
+
 const readIcons = (
 	snapshot: GitSnapshot,
 	path: string,
 ): { manifest: FamilyIcons; modified: string } => {
+	const categoryCatalog = readIconCategories(snapshot);
 	const contents = snapshot.read(path);
 	const icons = contents
 		.toString('utf8')
@@ -98,6 +129,7 @@ const readIcons = (
 			return {
 				name: match[1],
 				codepoint: Number.parseInt(match[2], 16),
+				categories: categoryCatalog.categories.get(match[1]),
 			};
 		})
 		.toSorted(
@@ -110,6 +142,7 @@ const readIcons = (
 		manifest: familyIconsSchema.parse({
 			inputModes: ['codepoint', 'name-ligature'],
 			icons,
+			categoriesSource: categoryCatalog.source,
 			source: {
 				revision: changed.revision,
 				path,

--- a/registry/scripts/registry.test.ts
+++ b/registry/scripts/registry.test.ts
@@ -348,6 +348,16 @@ const createGoogleIconsRepository = async (): Promise<{
 			'home 41\nsettings 42\n',
 		);
 	}
+	await writeFixture(
+		repository,
+		'update/current_versions.json',
+		canonicalJson({
+			'action::flourescent': 1,
+			'action::home': 1,
+			'action::settings': 1,
+			'symbols::home': 1,
+		}),
+	);
 	await writeFixture(repository, 'LICENSE', 'Apache License\n');
 	return {
 		repository,
@@ -797,9 +807,10 @@ describe('registry ingestion', () => {
 		).toMatchObject({
 			inputModes: ['codepoint', 'name-ligature'],
 			icons: [
-				{ name: 'flourescent', codepoint: 65 },
-				{ name: 'flourescent', codepoint: 66 },
+				{ name: 'flourescent', codepoint: 65, categories: ['action'] },
+				{ name: 'flourescent', codepoint: 66, categories: ['action'] },
 			],
+			categoriesSource: { path: 'update/current_versions.json' },
 			source: {
 				path: 'font/MaterialIcons-Regular.codepoints',
 			},

--- a/registry/scripts/schema.ts
+++ b/registry/scripts/schema.ts
@@ -227,9 +227,17 @@ export const familyIconsSchema = z.strictObject({
 			z.strictObject({
 				name: z.string().min(1).regex(/^\S+$/),
 				codepoint: unicodeScalarSchema,
+				categories: z.array(idSchema).min(1).optional(),
 			}),
 		)
 		.min(1),
+	categoriesSource: z
+		.strictObject({
+			revision: revisionSchema,
+			path: sourcePathSchema,
+			sha256: sha256Schema,
+		})
+		.optional(),
 	source: z.strictObject({
 		revision: revisionSchema,
 		path: sourcePathSchema,

--- a/website/app/generated/api/types.gen.ts
+++ b/website/app/generated/api/types.gen.ts
@@ -970,6 +970,7 @@ export type GetRegistryFamilySymbolsResponses = {
     200: Array<{
         name: string;
         codepoint: number;
+        categories?: Array<string>;
     }>;
 };
 


### PR DESCRIPTION
## Overview

Adds revision-pinned Material icon category metadata to the existing symbol catalog during Registry generation. The optional `categories` field keeps existing snapshots valid and lets clients group Material Icons and Material Symbols without a live Google metadata dependency.